### PR TITLE
Align window top when many tiles

### DIFF
--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -298,6 +298,9 @@ class Main(QMainWindow):
         height = min(height, screen.height())
         self.resize(width, height)
 
+        if len(self.cfg.tiles) > 20:
+            self.move(self.x(), screen.top())
+
     def update_lock_ui(self):
         self.lock_action.setText("?? Locked" if self.locked else "?? Editing")
 


### PR DESCRIPTION
## Summary
- Position launcher window at top of screen when more than 20 tiles exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48360274c832fa1419c64118e6766