### PR TITLE
Expand tile grid for larger layouts

### DIFF
--- a/tests/test_auto_columns.py
+++ b/tests/test_auto_columns.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtWidgets")
+from PySide6.QtWidgets import QApplication  # noqa: E402  # pragma: no cover
+
+from tile_launcher import LauncherConfig, Main, Tile  # noqa: E402
+
+
+def test_expands_to_seven_columns(tmp_path, monkeypatch):
+    monkeypatch.setattr("tile_launcher.CFG_PATH", tmp_path / "config.json")
+    tiles = [Tile(name=f"t{i}", url="https://example.com") for i in range(37)]
+    cfg = LauncherConfig(title="title", columns=5, tiles=tiles)
+    cfg.save()
+
+    app = QApplication([])
+    main = Main()
+    assert main.cfg.columns == 7
+    app.quit()

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -253,11 +253,14 @@ class Main(QMainWindow):
         super().__init__()
         self.cfg = LauncherConfig.load()
 
-        # If the user has more than 25 tiles saved, automatically expand to
-        # show six tiles across.  This adjusts both the column count and the
-        # window width so that the grid fits without the user having to resize
-        # manually.
-        if len(self.cfg.tiles) > 25 and self.cfg.columns < 6:
+        # Automatically expand to show more columns based on the number of
+        # tiles. More than 25 tiles expands to six columns and more than 36
+        # tiles expands to seven columns. This adjusts both the column count
+        # and the window width so that the grid fits without the user having to
+        # resize manually.
+        if len(self.cfg.tiles) > 36 and self.cfg.columns < 7:
+            self.cfg.columns = 7
+        elif len(self.cfg.tiles) > 25 and self.cfg.columns < 6:
             self.cfg.columns = 6
 
         self.setWindowTitle(self.cfg.title)


### PR DESCRIPTION
## Summary
- Auto-expand to 7 columns when more than 36 tiles are saved
- Add regression test for auto-expansion logic

## Testing
- `ruff check .`
- `mypy tile_launcher.py tests --ignore-missing-imports`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a73755e1a0832f8500afe2b4b23c68