### PR TITLE
Expand browser detection for tile launcher

### DIFF
--- a/tests/test_available_browsers.py
+++ b/tests/test_available_browsers.py
@@ -1,0 +1,25 @@
+import os
+import webbrowser
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtWidgets")
+
+from tile_launcher import available_browsers  # noqa: E402
+
+
+def test_checks_common_browsers(monkeypatch):
+    checked: list[str] = []
+
+    def fake_get(name: str):
+        checked.append(name)
+        raise webbrowser.Error
+
+    monkeypatch.setattr(webbrowser, "get", fake_get)
+    monkeypatch.setattr(webbrowser, "_tryorder", [])
+
+    available_browsers()
+
+    for expected in {"brave", "firefox", "safari"}:
+        assert expected in checked


### PR DESCRIPTION
## Summary
- broaden browser discovery to include common browsers like Brave, Firefox, and Safari
- auto-register Brave when installed and probe common browser paths
- add tests verifying detection of major browsers

## Testing
- `ruff format .`
- `mypy --ignore-missing-imports .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac90654808832f9b03d46a950378e0