### PR TITLE
Detect major browsers for tile launch

### DIFF
--- a/tests/test_available_browsers.py
+++ b/tests/test_available_browsers.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import webbrowser
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtWidgets")
+
+from tile_launcher import available_browsers
+
+
+def test_available_browsers_detects_common_executables(monkeypatch):
+    """Brave and Firefox should be detected when their executables are present."""
+
+    monkeypatch.setattr(webbrowser, "_tryorder", [])
+
+    def fake_which(cmd: str) -> str | None:  # pragma: no cover - simple
+        mapping = {
+            "brave": "/usr/bin/brave",
+            "brave-browser": "/usr/bin/brave",
+            "firefox": "/usr/bin/firefox",
+        }
+        return mapping.get(cmd)
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+
+    browsers = available_browsers()
+    assert "brave" in browsers
+    assert "firefox" in browsers
+
+
+def test_available_browsers_detects_safari(monkeypatch):
+    """Safari should be detected on macOS when installed."""
+
+    monkeypatch.setattr(webbrowser, "_tryorder", [])
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    def fake_exists(self: Path) -> bool:  # pragma: no cover - simple
+        return str(self) == "/Applications/Safari.app/Contents/MacOS/Safari"
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+    browsers = available_browsers()
+    assert "safari" in browsers


### PR DESCRIPTION
## Summary
- broaden browser detection to include Brave, Firefox, Chrome, Edge, and Safari by checking common install locations
- cover browser discovery logic with unit tests

## Testing
- `ruff format --check tile_launcher.py tests/test_available_browsers.py`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e2a6e80832f8e47014274c2d615