### PR TITLE
Ensure new tiles appear on chosen tab

### DIFF
--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -523,16 +523,20 @@ class Main(QMainWindow):
         icon = str(icon_path) if icon_path else None
 
         bg = "#F5F6FA"
+        current_tab = self.current_tab()
         tab, ok = QInputDialog.getItem(
             self,
             "Assign Tab",
             "Tab:",
             self.cfg.tabs,
-            0,
+            self.cfg.tabs.index(current_tab) if current_tab in self.cfg.tabs else 0,
             False,
         )
-        if not ok or not tab:
-            tab = "Main"
+        if not ok or not tab.strip():
+            tab = current_tab
+        else:
+            tab = tab.strip()
+
         browsers = ["Default"] + available_browsers()
         browser_choice, ok = QInputDialog.getItem(
             self,


### PR DESCRIPTION
## Summary
- Default new tile tab assignment to the current tab when no selection is made, preventing tiles from disappearing into the Main tab.
- Request browser selection and tab assignment consistently when adding tiles.

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af029d60b0832f85860d1fba01967d