### PR TITLE
Ensure Add Tile uses system browser by default and validates fields

### DIFF
--- a/tests/test_add_tile.py
+++ b/tests/test_add_tile.py
@@ -1,0 +1,54 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PySide6.QtWidgets")
+
+import tile_launcher
+
+
+@pytest.fixture
+def temp_main(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    icon_dir = tmp_path / "icons"
+    icon_dir.mkdir()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    monkeypatch.setattr(tile_launcher, "ICON_DIR", icon_dir)
+    cfg = tile_launcher.LauncherConfig(
+        title="t", columns=5, tiles=[], tabs=["Main", "Extra"]
+    )
+    main = tile_launcher.Main.__new__(tile_launcher.Main)
+    main.cfg = cfg
+    main.rebuild = lambda: None
+    main.tabs_widget = SimpleNamespace(setCurrentIndex=lambda idx: None)
+    return main, cfg, cfg_path
+
+
+def test_add_tile_defaults_to_system_browser(temp_main, monkeypatch):
+    main, cfg, cfg_path = temp_main
+    monkeypatch.setattr(tile_launcher, "fetch_favicon", lambda url: None)
+    main.add_tile_record("Test", "http://example.com", "Extra", None)
+    assert cfg.tiles[0].browser is None
+    data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert data["tiles"][0]["browser"] is None
+    assert data["tiles"][0]["tab"] == "Extra"
+
+
+@pytest.mark.parametrize("field", ["name", "url", "tab"])
+def test_add_tile_validation(temp_main, field, monkeypatch):
+    main, cfg, cfg_path = temp_main
+    monkeypatch.setattr(tile_launcher, "fetch_favicon", lambda url: None)
+    kwargs = {"name": "n", "url": "http://x", "tab": "Main", "browser": None}
+    kwargs[field] = ""
+    with pytest.raises(ValueError):
+        main.add_tile_record(**kwargs)
+
+
+def test_url_normalization(temp_main, monkeypatch):
+    main, cfg, cfg_path = temp_main
+    monkeypatch.setattr(tile_launcher, "fetch_favicon", lambda url: None)
+    main.add_tile_record("Test", "example.com", "Main", None)
+    assert cfg.tiles[0].url == "https://example.com"
+    data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert data["tiles"][0]["url"] == "https://example.com"

--- a/version_info.txt
+++ b/version_info.txt
@@ -1,16 +1,16 @@
 # version_info.txt
 VSVersionInfo(
-  ffi=FixedFileInfo(filevers=(0,1,0,0), prodvers=(0,1,0,0),
+  ffi=FixedFileInfo(filevers=(0,1,1,0), prodvers=(0,1,1,0),
                     mask=0x3f, flags=0x0, OS=0x40004, fileType=0x1, subtype=0x0, date=(0,0)),
   kids=[
     StringFileInfo([
       StringTable('040904B0', [
         StringStruct('FileDescription', 'DesktopTileLauncher'),
-        StringStruct('FileVersion', '0.1.0'),
+        StringStruct('FileVersion', '0.1.1'),
         StringStruct('InternalName', 'DesktopTileLauncher'),
         StringStruct('OriginalFilename', 'DesktopTileLauncher.exe'),
         StringStruct('ProductName', 'DesktopTileLauncher'),
-        StringStruct('ProductVersion', '0.1.0'),
+        StringStruct('ProductVersion', '0.1.1'),
         StringStruct('CompanyName', '108thecitizen'),
       ])
     ]),


### PR DESCRIPTION
## Summary
- Add dialog for creating tiles with URL normalization and default-to-system browser
- Persist tiles atomically and validate required fields before adding
- Cover Add Tile behavior with new tests and bump version to 0.1.1

## Testing
- `ruff check tile_launcher.py tests/test_add_tile.py`
- `mypy tile_launcher.py tests/test_add_tile.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bc924030832fb2fabd8f91efde24