### PR TITLE
feat(debug): global exception dialog + unified Qt/Python rotating log

### DIFF
--- a/debug_scaffold.py
+++ b/debug_scaffold.py
@@ -1,0 +1,83 @@
+"""Debug scaffold for DesktopTileLauncher.
+
+Provides unified logging for Qt and Python exceptions with a rotating file
+handler and a modal error dialog for uncaught exceptions.
+"""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+import sys
+import traceback
+from pathlib import Path
+from types import TracebackType
+
+from PySide6.QtCore import QtMsgType, qInstallMessageHandler, QMessageLogContext
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+MAX_BYTES = 500 * 1024
+BACKUPS = 5
+
+
+def _log_dir(app_name: str) -> Path:
+    if sys.platform.startswith("win"):
+        base = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Logs"
+    else:
+        base = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    path = base / app_name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def install_debug_scaffold(
+    app: QApplication, app_name: str = "DesktopTileLauncher"
+) -> None:
+    """Install global exception and Qt log handlers."""
+    app.setApplicationName(app_name)
+    log_path = _log_dir(app_name) / "debug.log"
+
+    handler = RotatingFileHandler(
+        log_path, maxBytes=MAX_BYTES, backupCount=BACKUPS, encoding="utf-8"
+    )
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.addHandler(handler)
+
+    def handle_exception(
+        exc_type: type[BaseException],
+        exc: BaseException,
+        tb: TracebackType | None,
+    ) -> None:
+        trace = "".join(traceback.format_exception(exc_type, exc, tb))
+        root_logger.error("Uncaught exception:\n%s", trace)
+        msg = QMessageBox()
+        msg.setIcon(QMessageBox.Icon.Critical)
+        msg.setWindowTitle(app_name)
+        msg.setText(str(exc))
+        msg.setDetailedText(trace)
+        msg.exec()
+
+    sys.excepthook = handle_exception
+
+    def qt_message_handler(
+        mode: QtMsgType, context: QMessageLogContext, message: str
+    ) -> None:
+        level_map = {
+            QtMsgType.QtDebugMsg: logging.DEBUG,
+            QtMsgType.QtInfoMsg: logging.INFO,
+            QtMsgType.QtWarningMsg: logging.WARNING,
+            QtMsgType.QtCriticalMsg: logging.ERROR,
+            QtMsgType.QtFatalMsg: logging.CRITICAL,
+        }
+        root_logger.log(level_map.get(mode, logging.INFO), message)
+        if mode == QtMsgType.QtFatalMsg:
+            raise SystemExit(message)
+
+    qInstallMessageHandler(qt_message_handler)

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Callable, Optional
 import shutil
 
-from PySide6.QtCore import QMimeData, QPoint, QSize, Qt, QTimer
+from PySide6.QtCore import QMimeData, QPoint, QSize, Qt, QTimer, qWarning
 from PySide6.QtGui import (
     QAction,
     QColor,
@@ -43,6 +43,8 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QWidget,
 )
+
+from debug_scaffold import install_debug_scaffold
 
 APP_NAME = "TileLauncher"
 
@@ -419,6 +421,10 @@ class Main(QMainWindow):
         tab_menu.addAction("Rename Tab", self.rename_tab)
         tab_menu.addAction("Delete Tab", self.delete_tab)
 
+        debug_menu = self.menuBar().addMenu("Debug")
+        debug_menu.addAction("Raise Exception", self._debug_raise)
+        debug_menu.addAction("Qt Warning", lambda: qWarning("test"))
+
         self.tabs_widget = QTabWidget()
         self.tabs_widget.currentChanged.connect(
             lambda _=0: QTimer.singleShot(0, self.resize_to_fit_tiles)
@@ -725,9 +731,13 @@ class Main(QMainWindow):
         self.cfg.save()
         self.rebuild()
 
+    def _debug_raise(self) -> None:
+        raise RuntimeError("Test exception")
+
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+    install_debug_scaffold(app, app_name="DesktopTileLauncher")
     mw = Main()
     mw.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- add debug scaffold with rotating file logger and Qt/Python exception hooks
- wire scaffold into launcher with debug menu for test exceptions and Qt warnings

## Testing
- `ruff format debug_scaffold.py tile_launcher.py`
- `ruff check debug_scaffold.py tile_launcher.py`
- `mypy debug_scaffold.py tile_launcher.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1959d16c0832f9f596127239330f0