### PR TITLE
feat: add chrome profile selection on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@
 
 
 License: MIT
+
+## Usage
+
+On Windows, selecting Google Chrome for a tile (or leaving the browser as
+Default when Chrome is the system default) reveals a **Chrome profile**
+dropdown. The list is populated from Chrome's local profile cache and includes
+entries like `Default`, `Profile 1`, or names from signed-in Google accounts.
+Choosing a profile pins the tile to that persona; select **None** to use
+Chrome's last-used profile.

--- a/browser_chrome_win.py
+++ b/browser_chrome_win.py
@@ -1,0 +1,146 @@
+"""Windows-specific helpers for interacting with Google Chrome profiles.
+
+These helpers detect the Windows default browser, locate Chrome installations,
+list available Chrome user profiles, and launch Chrome with a specific profile.
+All functions fail safely on non-Windows platforms and never raise
+platform-specific errors to callers.
+"""
+
+# mypy: disable-error-code=unreachable
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import typing as t
+
+if sys.platform == "win32":  # pragma: no cover - executed only on Windows
+    import winreg
+else:  # pragma: no cover - not executed on Windows
+    winreg = t.cast(t.Any, None)
+
+
+def is_windows_default_browser_chrome() -> bool:
+    """Return True if the Windows default browser is Google Chrome."""
+    if sys.platform != "win32":
+        return False
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice",
+        ) as key:
+            progid, _ = winreg.QueryValueEx(key, "ProgId")
+            return isinstance(progid, str) and progid.startswith("ChromeHTML")
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+
+def _reg_query_app_paths() -> t.Optional[str]:
+    """Return chrome.exe path from Windows App Paths registry, if available."""
+    for hive in (
+        getattr(winreg, "HKEY_CURRENT_USER", None),
+        getattr(winreg, "HKEY_LOCAL_MACHINE", None),
+    ):
+        if hive is None:
+            continue
+        try:
+            with winreg.OpenKey(
+                hive, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe"
+            ) as key:
+                val, _ = winreg.QueryValueEx(key, None)
+                if isinstance(val, str) and os.path.isfile(val):
+                    return val
+        except OSError:
+            continue
+    return None
+
+
+def find_chrome_exe() -> t.Optional[str]:
+    """Locate chrome.exe on Windows, returning the executable path if found."""
+    if sys.platform != "win32":
+        return None
+    reg_path = _reg_query_app_paths()
+    if reg_path:
+        return reg_path
+    candidates: list[str] = []
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        candidates.append(
+            os.path.join(local, "Google", "Chrome", "Application", "chrome.exe")
+        )
+    candidates.extend(
+        [
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+            r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+        ]
+    )
+    for path in candidates:
+        if path and os.path.isfile(path):
+            return path
+    return None
+
+
+def is_chrome_path(path: str | None) -> bool:
+    """Return True if *path* refers to a chrome.exe executable."""
+    if not path:
+        return False
+    return os.path.basename(path).lower() == "chrome.exe"
+
+
+def list_chrome_profiles() -> list[tuple[str, str]]:
+    """Return a list of available Chrome profiles as (dir_id, display_name)."""
+    if sys.platform != "win32":
+        return []
+    local = os.environ.get("LOCALAPPDATA")
+    if not local:
+        return []
+    user_data = os.path.join(local, "Google", "Chrome", "User Data")
+    local_state = os.path.join(user_data, "Local State")
+    results: list[tuple[str, str]] = []
+    info_cache: dict[str, dict[str, t.Any]] = {}
+    try:
+        with open(local_state, "r", encoding="utf-8") as f:
+            state = json.load(f)
+            info_cache = state.get("profile", {}).get("info_cache", {}) or {}
+    except (OSError, json.JSONDecodeError):
+        info_cache = {}
+    for dir_id, meta in info_cache.items():
+        display = meta.get("gaia_name") or meta.get("name") or dir_id
+        results.append((dir_id, f"{display} ({dir_id})"))
+    default_dir = os.path.join(user_data, "Default")
+    if os.path.isdir(default_dir) and not any(d == "Default" for d, _ in results):
+        results.insert(0, ("Default", "Default (Default)"))
+    seen: set[str] = set()
+    deduped: list[tuple[str, str]] = []
+    for dir_id, label in results:
+        if dir_id not in seen:
+            seen.add(dir_id)
+            deduped.append((dir_id, label))
+    deduped.sort(key=lambda x: (x[0] != "Default", x[1].lower()))
+    return deduped
+
+
+def launch_chrome_with_profile(
+    url: str, profile_dir_id: str, chrome_path: str | None = None
+) -> bool:
+    """Launch Chrome with *profile_dir_id* and open *url*.
+
+    Returns True if Chrome was started successfully, otherwise False. Failure is
+    silent; callers should fall back to other open mechanisms.
+    """
+    if sys.platform != "win32":
+        return False
+    chrome = chrome_path or find_chrome_exe()
+    if not chrome:
+        return False
+    try:
+        subprocess.Popen(
+            [chrome, f"--profile-directory={profile_dir_id}", url], close_fds=True
+        )
+        return True
+    except OSError:
+        return False

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -46,6 +46,11 @@ from PySide6.QtWidgets import (
 
 from debug_scaffold import install_debug_scaffold
 from tile_editor_dialog import TileEditorDialog
+from browser_chrome_win import (
+    is_windows_default_browser_chrome,
+    is_chrome_path,
+    launch_chrome_with_profile,
+)
 
 APP_NAME = "TileLauncher"
 
@@ -185,6 +190,7 @@ class Tile:
     icon: Optional[str] = None  # path to png/ico
     bg: str = "#F5F6FA"  # background color (CSS)
     browser: Optional[str] = None  # webbrowser name
+    chrome_profile: Optional[str] = None  # e.g. "Default", "Profile 1"
 
 
 @dataclass
@@ -225,10 +231,16 @@ class LauncherConfig:
         return cfg
 
     def save(self):
+        tiles = []
+        for t in self.tiles:
+            d = asdict(t)
+            if d.get("chrome_profile") is None:
+                d.pop("chrome_profile", None)
+            tiles.append(d)
         data = {
             "title": self.title,
             "columns": self.columns,
-            "tiles": [asdict(t) for t in self.tiles],
+            "tiles": tiles,
             "tabs": self.tabs,
         }
         CFG_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -384,6 +396,17 @@ class TileButton(QToolButton):
             event.acceptProposedAction()
 
 
+def _tile_uses_chrome(tile: Tile) -> bool:
+    """Return True if the given tile will launch using Google Chrome."""
+    if sys.platform != "win32":
+        return False
+    chosen = getattr(tile, "browser", None)
+    if chosen:
+        as_str = str(chosen)
+        return is_chrome_path(as_str) or "chrome" in as_str.lower()
+    return is_windows_default_browser_chrome()
+
+
 class Main(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
@@ -531,6 +554,13 @@ class Main(QMainWindow):
 
     # -------- actions --------
     def open_tile(self, tile: Tile) -> None:
+        profile = tile.chrome_profile
+        if profile and _tile_uses_chrome(tile):
+            if launch_chrome_with_profile(tile.url, profile):
+                return
+            qWarning(
+                f"Chrome not found or failed to launch with profile '{profile}'; falling back."
+            )
         try:
             if tile.browser:
                 webbrowser.get(tile.browser).open(tile.url)
@@ -569,6 +599,7 @@ class Main(QMainWindow):
                     bg="#F5F6FA",
                     tab=cast(str, data["tab"]),
                     browser=data["browser"],
+                    chrome_profile=data["chrome_profile"],
                 )
             )
             self.cfg.save()
@@ -593,6 +624,7 @@ class Main(QMainWindow):
             tile.icon = data["icon"]
             tile.tab = cast(str, data["tab"])
             tile.browser = data["browser"]
+            tile.chrome_profile = data["chrome_profile"]
             self.cfg.save()
             self.rebuild()
             self.tabs_widget.setCurrentIndex(self.cfg.tabs.index(tile.tab))


### PR DESCRIPTION
## Summary
- allow tiles to specify a Chrome profile on Windows
- add Windows-specific helpers for detecting Chrome and available profiles
- expose Chrome profile dropdown in tile editor and honor it when launching

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42bf4f0fc832f9b83f57b2dc3f9c1