### PR TITLE
Add tile open target option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,10 @@ Definition of Done for any change touching Python code:
 ruff format --check .
 ruff check .
 mypy .
+pytest
 
 
-All three commands must exit with code 0.
+All four commands must exit with code 0.
 
 Agent Operating Procedure
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ dropdown. The list is populated from Chrome's local profile cache and includes
 entries like `Default`, `Profile 1`, or names from signed-in Google accounts.
 Choosing a profile pins the tile to that persona; select **None** to use
 Chrome's last-used profile.
+
+Each tile also provides an **Open in** option:
+
+* **New tab in existing window** *(default)*
+* **New browser window**
+
+For Chromium browsers (Chrome/Edge), a new window adds the `--new-window`
+switch. Firefox uses `--new-tab` or `--new-window`. If the tile targets the
+system's default browser, Python's `webbrowser.open` is used with `new=2` for a
+tab or `new=1` for a window. Safari and other unknown browsers fall back to
+this behavior and may not differentiate between tabs and windows.
+
+Existing configurations that lack this setting are automatically migrated and
+default to opening URLs in a new tab.

--- a/browser_chrome_win.py
+++ b/browser_chrome_win.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 import typing as t
+from typing import Literal
 
 if sys.platform == "win32":  # pragma: no cover - executed only on Windows
     import winreg
@@ -125,12 +126,16 @@ def list_chrome_profiles() -> list[tuple[str, str]]:
 
 
 def launch_chrome_with_profile(
-    url: str, profile_dir_id: str, chrome_path: str | None = None
+    url: str,
+    profile_dir_id: str,
+    open_target: Literal["tab", "window"] = "tab",
+    chrome_path: str | None = None,
 ) -> bool:
     """Launch Chrome with *profile_dir_id* and open *url*.
 
-    Returns True if Chrome was started successfully, otherwise False. Failure is
-    silent; callers should fall back to other open mechanisms.
+    ``open_target`` controls whether the URL opens in a new tab or window.
+    Returns True if Chrome was started successfully, otherwise False.
+    Failure is silent; callers should fall back to other open mechanisms.
     """
     if sys.platform != "win32":
         return False
@@ -138,9 +143,11 @@ def launch_chrome_with_profile(
     if not chrome:
         return False
     try:
-        subprocess.Popen(
-            [chrome, f"--profile-directory={profile_dir_id}", url], close_fds=True
-        )
+        cmd = [chrome, f"--profile-directory={profile_dir_id}"]
+        if open_target == "window":
+            cmd.append("--new-window")
+        cmd.append(url)
+        subprocess.Popen(cmd, close_fds=True)
         return True
     except OSError:
         return False

--- a/tests/test_launch_plan.py
+++ b/tests/test_launch_plan.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtWidgets")
+
+from tile_launcher import LauncherConfig, Tile, build_launch_plan
+
+
+def test_launch_plan_chrome_profile_tab():
+    tile = Tile(
+        name="t",
+        url="http://e",
+        browser="chrome",
+        chrome_profile="Profile 1",
+        open_target="tab",
+    )
+    plan = build_launch_plan(tile)
+    assert plan.command is not None
+    assert any(arg.startswith("--profile-directory=") for arg in plan.command)
+    assert "--new-window" not in plan.command
+
+
+def test_launch_plan_chrome_profile_window():
+    tile = Tile(
+        name="t",
+        url="http://e",
+        browser="chrome",
+        chrome_profile="Profile 1",
+        open_target="window",
+    )
+    plan = build_launch_plan(tile)
+    assert plan.command is not None
+    assert any(arg.startswith("--profile-directory=") for arg in plan.command)
+    assert "--new-window" in plan.command
+
+
+def test_launch_plan_firefox_tab():
+    tile = Tile(name="t", url="http://e", browser="firefox", open_target="tab")
+    plan = build_launch_plan(tile)
+    assert plan.command is not None
+    assert plan.command[1] == "--new-tab"
+
+
+def test_launch_plan_firefox_window():
+    tile = Tile(name="t", url="http://e", browser="firefox", open_target="window")
+    plan = build_launch_plan(tile)
+    assert plan.command is not None
+    assert plan.command[1] == "--new-window"
+
+
+def test_launch_plan_default_browser_tab_window():
+    tile_tab = Tile(name="t", url="http://e")
+    plan_tab = build_launch_plan(tile_tab)
+    assert plan_tab.controller == "default"
+    assert plan_tab.new == 2
+
+    tile_win = Tile(name="t", url="http://e", open_target="window")
+    plan_win = build_launch_plan(tile_win)
+    assert plan_win.controller == "default"
+    assert plan_win.new == 1
+
+
+def test_config_migration_adds_open_target(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "title": "Launcher",
+                "columns": 5,
+                "tiles": [{"name": "t", "url": "http://e", "tab": "Main"}],
+                "tabs": ["Main"],
+            }
+        )
+    )
+    monkeypatch.setattr("tile_launcher.CFG_PATH", cfg_path)
+    cfg = LauncherConfig.load()
+    assert cfg.tiles[0].open_target == "tab"
+    cfg.save()
+    data = json.loads(cfg_path.read_text())
+    assert data["tiles"][0]["open_target"] == "tab"

--- a/tile_editor_dialog.py
+++ b/tile_editor_dialog.py
@@ -109,6 +109,15 @@ class TileEditorDialog(QDialog):
                 self.browser_combo.setCurrentIndex(idx)
         form.addRow("Browser:", self.browser_combo)
 
+        self.open_target_combo = QComboBox()
+        self.open_target_combo.addItem("New tab in existing window", "tab")
+        self.open_target_combo.addItem("New browser window", "window")
+        if tile:
+            idx = self.open_target_combo.findData(getattr(tile, "open_target", "tab"))
+            if idx >= 0:
+                self.open_target_combo.setCurrentIndex(idx)
+        form.addRow("Open in:", self.open_target_combo)
+
         self.chromeProfileLabel = QLabel("Chrome profile")
         self.chromeProfileCombo = QComboBox()
         self.chromeProfileCombo.addItem("None (use Chrome default)", "")
@@ -224,6 +233,9 @@ class TileEditorDialog(QDialog):
         chrome_prof_data = self.chromeProfileCombo.currentData()
         chrome_profile = str(chrome_prof_data) if chrome_prof_data else None
 
+        open_target_data = self.open_target_combo.currentData()
+        open_target = str(open_target_data) if open_target_data else "tab"
+
         self.data = {
             "name": name,
             "url": url,
@@ -231,5 +243,6 @@ class TileEditorDialog(QDialog):
             "icon": icon,
             "browser": browser,
             "chrome_profile": chrome_profile,
+            "open_target": open_target,
         }
         super().accept()


### PR DESCRIPTION
## Summary
- allow tiles to choose whether URLs open in a new tab or new window
- pass open target through editor, config, and launcher with browser-specific flags
- add tests for launch planning and config migration
- remove dialog screenshot causing binary-file PR issue

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47f98c8fc832f9617e5d35f185514