### PR TITLE
[desktop] Multi-window support (tray "New Window") + per-tab lazy refresh + persisted window state

### DIFF
--- a/DesktopTileLauncher.py
+++ b/DesktopTileLauncher.py
@@ -1,1 +1,22 @@
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from debug_scaffold import install_debug_scaffold
+from tile_launcher import APP_STATE, WindowManager
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    QApplication.setQuitOnLastWindowClosed(False)
+    install_debug_scaffold(app, app_name="DesktopTileLauncher")
+    manager = WindowManager(app, APP_STATE)
+    manager.open_initial_windows()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ this behavior and may not differentiate between tabs and windows.
 
 Existing configurations that lack this setting are automatically migrated and
 default to opening URLs in a new tab.
+
+## Multiple windows
+
+DesktopTileLauncher supports multiple peer windows. Create another window from
+**Window → New Window** or from the system tray icon's **New Window** action.
+The tray icon remains after all windows close so new ones can be spawned; use
+**Quit** in the tray to exit the app.
+
+Open windows persist across restarts. Each window's ID, geometry, maximized
+state, and last selected tab are stored in `config.json` under a `windows`
+array. On startup, one window per entry is restored (if none exist, a single
+window opens with the first tab).
+
+Windows receive model updates lazily: changes made on a background tab are not
+rendered in other windows until that tab is selected, avoiding unnecessary
+rebuilds.

--- a/tests/test_multi_window.py
+++ b/tests/test_multi_window.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+import tile_launcher
+from tile_launcher import Tile, WindowManager
+
+
+@pytest.mark.qt_no_exception_capture
+def test_spawn_and_persist(tmp_path, monkeypatch, qtbot):
+    cfg_path = tmp_path / "config.json"
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    state = tile_launcher.AppState()
+    state.cfg.tabs.append("Work")
+    state.cfg.save()
+
+    manager = WindowManager(qtbot._qapp, state)
+    manager.open_initial_windows()
+    win = next(iter(manager.windows.values()))
+    qtbot.addWidget(win)
+    win.tabs_widget.setCurrentIndex(state.cfg.tabs.index("Work"))
+    manager.save_all_windows_state()
+
+    manager.new_window(win.current_tab())
+    assert len(manager.windows) == 2
+    second = [w for w in manager.windows.values() if w is not win][0]
+    qtbot.addWidget(second)
+    second.close()
+    qtbot.waitUntil(lambda: len(manager.windows) == 1)
+    manager.save_all_windows_state()
+
+    state2 = tile_launcher.AppState()
+    manager2 = WindowManager(qtbot._qapp, state2)
+    manager2.open_initial_windows()
+    assert len(manager2.windows) == 1
+    restored = next(iter(manager2.windows.values()))
+    assert restored.current_tab() == "Work"
+
+
+@pytest.mark.qt_no_exception_capture
+def test_tray_new_window(monkeypatch, qtbot, tmp_path):
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", tmp_path / "config.json")
+    monkeypatch.setattr(
+        tile_launcher.QSystemTrayIcon, "isSystemTrayAvailable", classmethod(lambda cls: True)
+    )
+    state = tile_launcher.AppState()
+    manager = WindowManager(qtbot._qapp, state)
+    manager.open_initial_windows()
+    assert len(manager.windows) == 1
+    assert manager._tray_new_action is not None
+    manager._tray_new_action.trigger()
+    assert len(manager.windows) == 2
+
+
+@pytest.mark.qt_no_exception_capture
+def test_lazy_refresh(monkeypatch, qtbot, tmp_path):
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", tmp_path / "config.json")
+    state = tile_launcher.AppState()
+    state.cfg.tiles = []
+    state.cfg.tabs = ["Main", "Work"]
+    state.cfg.save()
+
+    manager = WindowManager(qtbot._qapp, state)
+    manager.open_initial_windows()
+    win_a = next(iter(manager.windows.values()))
+    qtbot.addWidget(win_a)
+    win_b = manager.new_window("Work")
+    qtbot.addWidget(win_b)
+
+    assert win_a.current_tab() == "Main"
+    assert win_b.current_tab() == "Work"
+    before_a = win_a._grids["Main"].count()
+    before_b = win_b._grids["Main"].count()
+
+    state.cfg.tiles.append(Tile(name="T", url="https://example.com", tab="Main"))
+    state.cfg.save()
+    state.model_changed.emit("Main", "tile_added", {})
+    qtbot.wait(50)
+
+    assert win_a._grids["Main"].count() == before_a + 1
+    assert win_b._grids["Main"].count() == before_b
+
+    win_b.tabs_widget.setCurrentIndex(0)
+    qtbot.wait(50)
+    assert win_b._grids["Main"].count() == before_b + 1
+


### PR DESCRIPTION
## Summary
- add AppState and WindowManager to manage peer windows and a system tray menu
- persist window geometry, maximized state and selected tab in config.json
- refresh inactive tabs lazily when model updates

## Testing
- `bandit -r .` *(fails: command not found)*
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest -q -k "multi_window or tray or lazy_refresh"` *(fails: ImportError: libGL.so.1 missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b5ae71c2b8832f81f3665dfd6cde38