### PR TITLE
Fix logging extras to avoid crash on tile launch

### DIFF
--- a/tests/unit/test_sanitize_log_extra.py
+++ b/tests/unit/test_sanitize_log_extra.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from debug_scaffold import sanitize_log_extra
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (
+            {"name": "tile", "message": "msg", "levelname": "INFO", "other": 1},
+            {
+                "tile_name": "tile",
+                "event_message": "msg",
+                "extra_levelname": "INFO",
+                "other": 1,
+            },
+        ),
+        ({"foo": "bar"}, {"foo": "bar"}),
+    ],
+)
+def test_sanitize_log_extra(
+    extra: dict[str, object], expected: dict[str, object]
+) -> None:
+    assert sanitize_log_extra(extra) == expected  # nosec B101
+
+
+@pytest.mark.unit
+def test_sanitize_log_extra_none() -> None:
+    assert sanitize_log_extra(None) is None  # nosec B101

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -51,7 +51,7 @@ from PySide6.QtWidgets import (
 )
 
 import debug_scaffold
-from debug_scaffold import record_breadcrumb, sanitize_url
+from debug_scaffold import record_breadcrumb, sanitize_log_extra, sanitize_url
 from tile_editor_dialog import TileEditorDialog
 from browser_chrome_win import (
     is_windows_default_browser_chrome,
@@ -627,15 +627,17 @@ class Main(QMainWindow):
         )
         logger.info(
             "browser_launch_attempt",
-            extra={
-                "event": "browser_launch_attempt",
-                "browser": plan.browser_name or "default",
-                "flags": plan.command[1:-1] if plan.command else [],
-                "profile": plan.profile,
-                "url": url,
-                "platform": sys.platform,
-                "pid": os.getpid(),
-            },
+            extra=sanitize_log_extra(
+                {
+                    "event": "browser_launch_attempt",
+                    "browser": plan.browser_name or "default",
+                    "flags": plan.command[1:-1] if plan.command else [],
+                    "profile": plan.profile,
+                    "url": url,
+                    "platform": sys.platform,
+                    "pid": os.getpid(),
+                }
+            ),
         )
         profile = tile.chrome_profile
         if profile and _tile_uses_chrome(tile):
@@ -643,7 +645,9 @@ class Main(QMainWindow):
                 record_breadcrumb("launch_result", ok=True, url=url)
                 logger.info(
                     "browser_launch_result",
-                    extra={"event": "browser_launch_result", "ok": True},
+                    extra=sanitize_log_extra(
+                        {"event": "browser_launch_result", "ok": True}
+                    ),
                 )
                 return
             qWarning(
@@ -657,17 +661,21 @@ class Main(QMainWindow):
                 record_breadcrumb("launch_result", ok=True, url=url)
                 logger.info(
                     "browser_launch_result",
-                    extra={"event": "browser_launch_result", "ok": True},
+                    extra=sanitize_log_extra(
+                        {"event": "browser_launch_result", "ok": True}
+                    ),
                 )
                 return
             except OSError as exc:
                 logger.error(
                     "browser_launch_result",
-                    extra={
-                        "event": "browser_launch_result",
-                        "ok": False,
-                        "error": str(exc),
-                    },
+                    extra=sanitize_log_extra(
+                        {
+                            "event": "browser_launch_result",
+                            "ok": False,
+                            "error": str(exc),
+                        }
+                    ),
                 )
                 qWarning("Failed to launch command; falling back.")
         try:
@@ -678,17 +686,21 @@ class Main(QMainWindow):
             record_breadcrumb("launch_result", ok=True, url=url)
             logger.info(
                 "browser_launch_result",
-                extra={"event": "browser_launch_result", "ok": True},
+                extra=sanitize_log_extra(
+                    {"event": "browser_launch_result", "ok": True}
+                ),
             )
         except webbrowser.Error as exc:
             record_breadcrumb("launch_result", ok=False, url=url)
             logger.error(
                 "browser_launch_result",
-                extra={
-                    "event": "browser_launch_result",
-                    "ok": False,
-                    "error": str(exc),
-                },
+                extra=sanitize_log_extra(
+                    {
+                        "event": "browser_launch_result",
+                        "ok": False,
+                        "error": str(exc),
+                    }
+                ),
             )
             webbrowser.open(tile.url, new=plan.new or 0)
 


### PR DESCRIPTION
## Summary
- sanitize logging `extra` dictionaries so reserved LogRecord fields like `name` can't collide
- use the sanitizer for breadcrumbs and browser launch logging
- add unit tests for the sanitizer

## Testing
- `ruff format --check .`
- `ruff check .`
- `ruff check tests`
- `mypy .`
- `pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"`


------
https://chatgpt.com/codex/tasks/task_e_68bb9b01cdb8832fa6aa9c30ff7531d4