### PR TITLE
Ensure deterministic browser window launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ system's default browser, Python's `webbrowser.open` is used with `new=2` for a
 tab or `new=1` for a window. Safari and other unknown browsers fall back to
 this behavior and may not differentiate between tabs and windows.
 
+On Windows when the chosen browser is Chrome (either explicitly or because it's
+the system default), the launcher invokes Chrome's command-line interface to
+ensure "New browser window" always opens a separate top-level window.
+
 Existing configurations that lack this setting are automatically migrated and
 default to opening URLs in a new tab.
 

--- a/tests/unit/test_launching.py
+++ b/tests/unit/test_launching.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import sys
+import subprocess
+import webbrowser
+
+import pytest
+
+pytest.importorskip("PySide6.QtWidgets")
+
+from tile_launcher import Main, Tile
+
+
+@pytest.mark.unit
+def test_windows_default_chrome_new_window(monkeypatch) -> None:
+    tile = Tile(name="t", url="http://example.com", open_target="window")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr("tile_launcher.is_windows_default_browser_chrome", lambda: True)
+
+    called: dict[str, tuple[str, str, str, None | str]] = {}
+
+    def fake_launch(
+        url: str, profile_dir: str, open_target: str, chrome_path: str | None = None
+    ) -> bool:
+        called["args"] = (url, profile_dir, open_target, chrome_path)
+        return True
+
+    monkeypatch.setattr("tile_launcher.launch_chrome_with_profile", fake_launch)
+
+    def fail_popen(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("Popen called")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+
+    def fail_open(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("webbrowser.open called")
+
+    monkeypatch.setattr(webbrowser, "open", fail_open)
+
+    Main.open_tile(object(), tile)
+
+    assert called["args"] == ("http://example.com", "Default", "window", None)  # nosec B101
+
+
+@pytest.mark.unit
+def test_explicit_chrome_cli_fallback(monkeypatch) -> None:
+    tile = Tile(name="t", url="http://e", browser="chrome", open_target="window")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    launch_calls = {"count": 0}
+
+    def fake_launch(
+        url: str, profile_dir: str, open_target: str, chrome_path: str | None = None
+    ) -> bool:
+        launch_calls["count"] += 1
+        return False
+
+    monkeypatch.setattr("tile_launcher.launch_chrome_with_profile", fake_launch)
+
+    popen_args: dict[str, list[str]] = {}
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> object:
+        popen_args["cmd"] = cmd
+        return object()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    def fail_open(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("webbrowser.open called")
+
+    monkeypatch.setattr(webbrowser, "open", fail_open)
+
+    Main.open_tile(object(), tile)
+
+    assert launch_calls["count"] == 1  # nosec B101
+    assert "--new-window" in popen_args["cmd"]  # nosec B101
+
+
+@pytest.mark.unit
+def test_firefox_tab_cli(monkeypatch) -> None:
+    tile = Tile(name="t", url="http://e", browser="firefox", open_target="tab")
+
+    def fail_launch(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("launch_chrome_with_profile called")
+
+    monkeypatch.setattr("tile_launcher.launch_chrome_with_profile", fail_launch)
+
+    popen_args: dict[str, list[str]] = {}
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> object:
+        popen_args["cmd"] = cmd
+        return object()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    def fail_open(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("webbrowser.open called")
+
+    monkeypatch.setattr(webbrowser, "open", fail_open)
+
+    Main.open_tile(object(), tile)
+
+    assert "--new-tab" in popen_args["cmd"]  # nosec B101
+
+
+@pytest.mark.unit
+def test_default_browser_new_flag(monkeypatch) -> None:
+    tile_win = Tile(name="t1", url="http://e", open_target="window")
+    tile_tab = Tile(name="t2", url="http://e")  # defaults to tab
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "tile_launcher.is_windows_default_browser_chrome", lambda: False
+    )
+
+    def fail_launch(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("launch_chrome_with_profile called")
+
+    monkeypatch.setattr("tile_launcher.launch_chrome_with_profile", fail_launch)
+
+    def fail_popen(
+        *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - should not run
+        raise AssertionError("Popen called")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+
+    calls: list[int] = []
+
+    def fake_open(url: str, new: int = 0) -> bool:
+        calls.append(new)
+        return True
+
+    monkeypatch.setattr(webbrowser, "open", fake_open)
+
+    Main.open_tile(object(), tile_win)
+    Main.open_tile(object(), tile_tab)
+
+    assert calls == [1, 2]  # nosec B101


### PR DESCRIPTION
## Summary
- guarantee Tile.open_target behavior by forcing Chrome CLI on Windows and logging chosen launch path
- add detailed breadcrumbs for browser CLI and webbrowser fallbacks
- document Chrome new-window handling on Windows

## Testing
- `ruff format --check .`
- `ruff check .`
- `ruff check tests`
- `mypy .`
- `pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"`


------
https://chatgpt.com/codex/tasks/task_e_68bc44a3f108832fa5f1a1fd7eff1711