### PR TITLE
feat(tabs): allow hiding/showing tabs with persisted visibility

### DIFF
--- a/tests/unit/test_hidden_tabs.py
+++ b/tests/unit/test_hidden_tabs.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("PySide6.QtWidgets")
+
+from tile_launcher import LauncherConfig
+
+
+@pytest.mark.unit
+def test_hidden_tabs_load_and_save(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "title": "Launcher",
+                "columns": 5,
+                "tiles": [{"name": "t1", "url": "http://e", "tab": "Extra"}],
+                "tabs": ["Main"],
+                "hidden_tabs": ["Extra", "Unknown", 123, "Main"],
+            }
+        )
+    )
+    monkeypatch.setattr("tile_launcher.CFG_PATH", cfg_path)
+    cfg = LauncherConfig.load()
+    assert cfg.tabs == ["Main", "Extra"]
+    assert cfg.hidden_tabs == ["Extra"]
+    cfg.save()
+    data = json.loads(cfg_path.read_text())
+    assert data["hidden_tabs"] == ["Extra"]


### PR DESCRIPTION
## Summary
- add `hidden_tabs` to config to persist per-tab visibility
- render only visible tabs and add menu actions to hide/show
- provide dialog for managing tab visibility and ensure at least one visible tab

## Testing
- `ruff format --check .`
- `ruff check .`
- `ruff check tests`
- `mypy .`
- `make test_unit` *(fails: No module named pytest)*
- `pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"`


------
https://chatgpt.com/codex/tasks/task_e_68bdcf614dbc832f9576885859e89c7b