### PR TITLE
fix(make): bootstrap pytest and add headless unit tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,18 @@
+# pytest.ini
 [pytest]
+addopts = -q
 markers =
-    unit: unit tests
+    unit: fast, hermetic tests that run on any OS and do not require GUI/Qt
+    integration: exercises multiple components, may touch filesystem/network
+    e2e: end-to-end flows
+    slow: long-running tests
+    network: requires network
+    gui: requires a GUI/Qt environment
+    qt: requires PySide6/Qt
+    gl: uses OpenGL/GL context
+    x11: requires X11
+    wayland: requires Wayland
+    docker: requires docker
+    gpu: requires GPU
+    perf: performance tests
+    flaky: tests known to be flaky

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Testing
+pytest>=8.2,<9
+pytest-mock>=3.14,<4
+
+# Linting / Typing (present or planned in Makefile)
+ruff>=0.5,<1
+mypy>=1.10,<2

--- a/tests/test_browser_chrome_win_unit.py
+++ b/tests/test_browser_chrome_win_unit.py
@@ -1,0 +1,15 @@
+import pytest
+from browser_chrome_win import is_chrome_path
+
+pytestmark = pytest.mark.unit
+
+
+def test_is_chrome_path_matches_windows_executable_name():
+    assert is_chrome_path("C:/Program Files/Google/Chrome/Application/chrome.exe")
+    assert is_chrome_path("chrome.exe")
+
+
+def test_is_chrome_path_is_false_for_non_matching_names():
+    assert not is_chrome_path("")
+    assert not is_chrome_path("/usr/bin/google-chrome")
+    assert not is_chrome_path("msedge.exe")

--- a/tests/test_debug_scaffold_unit.py
+++ b/tests/test_debug_scaffold_unit.py
@@ -1,0 +1,16 @@
+import pytest
+from debug_scaffold import sanitize_url, SENSITIVE_KEYS
+
+pytestmark = pytest.mark.unit
+
+
+def test_sanitize_url_redacts_sensitive_params():
+    url = "https://example.com/path?token=abc123&code=xyz&ok=1"
+    out = sanitize_url(url)
+    assert "token=REDACTED" in out
+    assert "code=REDACTED" in out
+    assert "ok=1" in out
+
+
+def test_sensitive_keys_catalog_is_nonempty():
+    assert SENSITIVE_KEYS


### PR DESCRIPTION
## Summary
- ensure dev dependencies like pytest are installed before tests
- document test markers and add headless unit tests
- run tests via install-dev target for reliable bootstrap

## Testing
- `make install-dev` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `make test_unit` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `make test` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `pytest -q -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' -k 'not multi_window and not tray and not lazy_refresh'`


------
https://chatgpt.com/codex/tasks/task_e_68be3a7c5504832f8e3ba1e5a1f7ee7b