### PR TITLE
feat(ui): add auto-fit policy and persistent window geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- Make window user-resizable and persist geometry.
+- Introduce auto-fit policy (`always`/`on_startup`/`off`) with migration from legacy `auto_fit`.
+- Add "Auto-fit Mode" menu and one-shot "Fit to Display Now" command.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ ensure "New browser window" always opens a separate top-level window.
 Existing configurations that lack this setting are automatically migrated and
 default to opening URLs in a new tab.
 
+### Auto-fit window
+
+The **View → Auto-fit Mode** submenu controls how the launcher resizes itself:
+
+- **Always** – recompute and resize on every move or display change.
+- **On startup** – fit once at launch (default), then allow manual resizing.
+- **Off** – never auto-resize; the window remembers its size and position.
+
+Choose **View → Fit to Display Now** for a one-off fit regardless of the
+current mode.
+
 ## Debugging & Crash Reports
 
 DesktopTileLauncher writes JSON logs to a rotating `debug.log` in a per-user

--- a/tests/unit/test_fit_policy.py
+++ b/tests/unit/test_fit_policy.py
@@ -1,0 +1,19 @@
+from tile_launcher import FitPolicy, FitTrigger, should_fit
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "policy,did,trigger,expected",
+    [
+        ("always", False, "move", True),
+        ("on_startup", False, "show", True),
+        ("on_startup", True, "resize", False),
+        ("off", False, "move", False),
+        ("off", True, "manual", True),
+    ],
+)
+def test_should_fit(
+    policy: FitPolicy, did: bool, trigger: FitTrigger, expected: bool
+) -> None:
+    assert should_fit(policy, did, trigger) is expected  # nosec B101


### PR DESCRIPTION
## Summary
- allow user-resizable window with persistent geometry
- add auto-fit policy modes and on-demand fit
- record fit policy changes and add unit tests

## Testing
- `ruff format --check .`
- `ruff check .`
- `ruff check tests`
- `mypy .`
- `make test_unit`


------
https://chatgpt.com/codex/tasks/task_e_68c6e958fc30832f89e0ed209f8f6926