### PR TITLE
fix(build): use portable Makefile recipe tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # Makefile — DesktopTileLauncher
 
 SHELL := bash
-.RECIPEPREFIX := >
 
 .PHONY: default
 default: test_unit
@@ -23,104 +22,104 @@ PIP := $(PY) -m pip
 ONLINE := $(shell $(PY) tools/netprobe.py >/dev/null 2>&1 && echo 1 || echo 0)
 
 help: ## List available targets
-> @grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "%-14s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "%-14s %s\n", $$1, $$2}'
 
 .PHONY: venv
 venv: ## Create virtualenv if missing
-> @if [ ! -e "$(VENV)" ]; then python -m venv "$(VENV)"; fi
-> @$(PY) -m ensurepip --upgrade >/dev/null 2>&1 || true
+	@if [ ! -e "$(VENV)" ]; then python -m venv "$(VENV)"; fi
+	@$(PY) -m ensurepip --upgrade >/dev/null 2>&1 || true
 
 .PHONY: install-dev
 install-dev: venv ## Bootstrap dev environment without failing when offline
-> @set -euo pipefail; \
-> echo "[install-dev] Using interpreter: $(PY)"; \
-> $(PY) tools/bootstrap.py
+	@set -euo pipefail; \
+	echo "[install-dev] Using interpreter: $(PY)"; \
+	$(PY) tools/bootstrap.py
 
 lint: install-dev ## Run ruff checks
-> $(PY) -m ruff check .
+	$(PY) -m ruff check .
 
 format: install-dev ## Format with ruff
-> $(PY) -m ruff format .
+	$(PY) -m ruff format .
 
 format-check: install-dev ## Verify formatting with ruff
-> $(PY) -m ruff format --check .
+	$(PY) -m ruff format --check .
 
 typecheck: install-dev ## Run mypy
-> $(PY) -m mypy .
+	$(PY) -m mypy .
 
 .PHONY: ensure-test-deps
 ensure-test-deps: venv
-> @set -euo pipefail; \
-> if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
->   echo "[ensure-test-deps] pytest already present"; \
->   exit 0; \
-> fi; \
-> if [ "$(ONLINE)" = "1" ]; then \
->   echo "[ensure-test-deps] online: upgrading pip and installing test deps"; \
->   $(PIP) install --disable-pip-version-check -q -U pip; \
->   if [ -f tests/requirements.txt ]; then \
->     $(PIP) install --disable-pip-version-check -q --only-binary=:all: --prefer-binary -r tests/requirements.txt; \
->   else \
->     $(PIP) install --disable-pip-version-check -q --only-binary=:all: --prefer-binary pytest; \
->   fi; \
-> else \
->   echo "[ensure-test-deps] offline/proxy detected: skipping dependency installation"; \
-> fi
+	@set -euo pipefail; \
+	if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
+	  echo "[ensure-test-deps] pytest already present"; \
+	  exit 0; \
+	fi; \
+	if [ "$(ONLINE)" = "1" ]; then \
+	  echo "[ensure-test-deps] online: upgrading pip and installing test deps"; \
+	  $(PIP) install --disable-pip-version-check -q -U pip; \
+	  if [ -f tests/requirements.txt ]; then \
+	    $(PIP) install --disable-pip-version-check -q --only-binary=:all: --prefer-binary -r tests/requirements.txt; \
+	  else \
+	    $(PIP) install --disable-pip-version-check -q --only-binary=:all: --prefer-binary pytest; \
+	  fi; \
+	else \
+	  echo "[ensure-test-deps] offline/proxy detected: skipping dependency installation"; \
+	fi
 
 test: install-dev ## Run the full test suite (default)
-> @set -euo pipefail; \
-> if $(PY) - <<'PY' >/dev/null 2>&1; then
->   import urllib.request, ssl, sys; \
->   try: \
->       urllib.request.urlopen("https://pypi.org/simple", timeout=3, context=ssl.create_default_context()); sys.exit(0); \
->   except Exception: \
->       sys.exit(1); \
-> PY \
-> then \
->   echo "[test] Online: running full pytest suite"; \
->   $(PY) -m pytest -q; \
-> else \
->   echo "[test] Offline detected: skipping full test suite"; \
-> fi
+	@set -euo pipefail; \
+	if $(PY) - <<'PY' >/dev/null 2>&1; then
+	  import urllib.request, ssl, sys; \
+	  try: \
+	      urllib.request.urlopen("https://pypi.org/simple", timeout=3, context=ssl.create_default_context()); sys.exit(0); \
+	  except Exception: \
+	      sys.exit(1); \
+	PY \
+	then \
+	  echo "[test] Online: running full pytest suite"; \
+	  $(PY) -m pytest -q; \
+	else \
+	  echo "[test] Offline detected: skipping full test suite"; \
+	fi
 
 # Exact unit-only filter you used successfully:
 test_unit: install-dev ensure-test-deps ## Run unit tests only (exclude slow/integration/e2e/etc.)
-> @set -euo pipefail; \
-> if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
->   echo "[test_unit] running pytest (unit filter)"; \
->   $(PY) -m pytest -q \
->     -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' \
->     -k 'not multi_window and not tray and not lazy_refresh'; \
-> else \
->   if [ "$(ONLINE)" = "0" ]; then \
->     echo "[test_unit] offline/proxy and pytest unavailable → skipping unit tests (exit 0)"; \
->     exit 0; \
->   fi; \
->   echo "[test_unit] pytest missing but network available → aborting"; \
->   exit 1; \
-> fi
+	@set -euo pipefail; \
+	if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
+	  echo "[test_unit] running pytest (unit filter)"; \
+	  $(PY) -m pytest -q \
+	    -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' \
+	    -k 'not multi_window and not tray and not lazy_refresh'; \
+	else \
+	  if [ "$(ONLINE)" = "0" ]; then \
+	    echo "[test_unit] offline/proxy and pytest unavailable → skipping unit tests (exit 0)"; \
+	    exit 0; \
+	  fi; \
+	  echo "[test_unit] pytest missing but network available → aborting"; \
+	  exit 1; \
+	fi
 
 .PHONY: smoke
 smoke: install-dev ## Import core modules to ensure environment is sane
-> @set -euo pipefail; \
-> $(PY) tools/smoke.py
+	@set -euo pipefail; \
+	$(PY) tools/smoke.py
 
 clean: ## Remove caches and build artifacts
-> rm -rf $(VENV) build dist .pytest_cache .ruff_cache .mypy_cache **/__pycache__
+	rm -rf $(VENV) build dist .pytest_cache .ruff_cache .mypy_cache **/__pycache__
 
 .PHONY: reassemble_wheels test_unit_offline
 
 reassemble_wheels:
->	@set -euo pipefail; \
->	for aa in vendor/wheelhouse-linux/*.whl.part-aa; do \
->	  [ -e "$$aa" ] || continue; \
->	  base="$${aa%.part-*}"; \
->	  echo "Reassembling $${base##*/}"; \
->	  cat "$$base".part-* > "$$base"; \
->	done
+	@set -euo pipefail; \
+	for aa in vendor/wheelhouse-linux/*.whl.part-aa; do \
+	  [ -e "$$aa" ] || continue; \
+	  base="$${aa%.part-*}"; \
+	  echo "Reassembling $${base##*/}"; \
+	  cat "$$base".part-* > "$$base"; \
+	done
 
 # One-liner that mirrors the Codex task: reassemble + force offline install + run tests
 test_unit_offline: reassemble_wheels
->	@PIP_NO_INDEX=1 PIP_FIND_LINKS="vendor/wheelhouse-linux" $(MAKE) ONLINE=1 test_unit
+	@PIP_NO_INDEX=1 PIP_FIND_LINKS="vendor/wheelhouse-linux" $(MAKE) ONLINE=1 test_unit
 
 


### PR DESCRIPTION
## Summary

- Removes `.RECIPEPREFIX := >`
- Converts Makefile recipe lines to standard tab-prefixed recipes
- Fixes Makefile parsing under GNU Make 3.81 on Git Bash / MINGW

## Evidence

- `make help` passed
- `make format-check` passed
- `make lint` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed with 23 tests

## Notes

Build portability fix only. No target behavior was intentionally changed.