### PR TITLE
fix: redact launch URLs from diagnostics

### DIFF
--- a/debug_scaffold.py
+++ b/debug_scaffold.py
@@ -10,12 +10,14 @@ tests can import the module even when PySide6/Qt is not available.
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Iterable
 import faulthandler
 import json
 import logging
 from logging.handlers import RotatingFileHandler
 import os
 import platform
+import re
 import signal
 import subprocess  # nosec B404: used to launch local apps; inputs validated & shell=False
 
@@ -146,15 +148,16 @@ def sanitize_log_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:
 
     sanitized: dict[str, Any] = {}
     for key, value in extra.items():
+        clean_value = sanitize_diagnostic_value(value)
         if key in _RESERVED_LOG_KEYS:
             if key == "name":
-                sanitized["tile_name"] = value
+                sanitized["tile_name"] = clean_value
             elif key == "message":
-                sanitized["event_message"] = value
+                sanitized["event_message"] = clean_value
             else:
-                sanitized[f"extra_{key}"] = value
+                sanitized[f"extra_{key}"] = clean_value
         else:
-            sanitized[key] = value
+            sanitized[key] = clean_value
     return sanitized
 
 
@@ -165,7 +168,7 @@ def record_breadcrumb(event: str, **fields: Any) -> None:
         "ts": datetime.now(timezone.utc).isoformat(),
         "event": event,
     }
-    entry.update(fields)
+    entry.update(sanitize_diagnostic_mapping(fields))
     _breadcrumbs.append(entry)
     logging.getLogger("breadcrumb").debug("", extra=sanitize_log_extra(entry))
 
@@ -177,10 +180,16 @@ def get_breadcrumbs() -> list[dict[str, Any]]:
 
 
 SENSITIVE_KEYS = {"token", "code", "session", "auth", "key", "password"}
+_URL_IN_TEXT_RE = re.compile(
+    "(?P<url>(?:[a-z][a-z0-9+.-]*://|www\\.)[^\\s\"'<>]+)",
+    re.IGNORECASE,
+)
+_FRAGMENT_REDACTION = "REDACTED"
+_QUERY_REDACTION = "REDACTED"
 
 
 def sanitize_url(url: str) -> str:
-    """Strip credentials and sensitive query parameters from *url*."""
+    """Strip credentials and redact query values/fragments from *url*."""
 
     try:
         parsed = urllib.parse.urlsplit(url)
@@ -188,11 +197,63 @@ def sanitize_url(url: str) -> str:
         return url
     netloc = parsed.netloc.split("@")[-1]
     query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
-    redacted = [(k, "REDACTED" if k.lower() in SENSITIVE_KEYS else v) for k, v in query]
+    redacted = [(k, _QUERY_REDACTION) for k, _v in query]
     new_query = urllib.parse.urlencode(redacted)
+    fragment = _FRAGMENT_REDACTION if parsed.fragment else ""
     return urllib.parse.urlunsplit(
-        (parsed.scheme, netloc, parsed.path, new_query, parsed.fragment)
+        (parsed.scheme, netloc, parsed.path, new_query, fragment)
     )
+
+
+def _looks_like_standalone_url(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped or any(ch.isspace() for ch in stripped):
+        return False
+
+    parsed = urllib.parse.urlsplit(stripped)
+    if parsed.scheme and len(parsed.scheme) > 1:
+        return bool(parsed.netloc or parsed.query or parsed.fragment)
+    if parsed.netloc:
+        return True
+
+    first_segment = parsed.path.split("/", 1)[0]
+    return "." in first_segment and any(
+        marker in stripped for marker in ("?", "#", "@")
+    )
+
+
+def _sanitize_text(value: str) -> str:
+    if _looks_like_standalone_url(value):
+        return sanitize_url(value)
+    return _URL_IN_TEXT_RE.sub(lambda match: sanitize_url(match.group("url")), value)
+
+
+def sanitize_launch_command(command: Iterable[str] | None) -> list[str] | None:
+    """Return a copy of *command* with URL-bearing arguments redacted."""
+
+    if command is None:
+        return None
+    return [_sanitize_text(part) for part in command]
+
+
+def sanitize_diagnostic_value(value: Any) -> Any:
+    """Redact URL-like strings inside diagnostic values."""
+
+    if isinstance(value, str):
+        return _sanitize_text(value)
+    if isinstance(value, dict):
+        return {key: sanitize_diagnostic_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [sanitize_diagnostic_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_diagnostic_value(item) for item in value)
+    return value
+
+
+def sanitize_diagnostic_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Redact URL-like strings inside a diagnostic mapping."""
+
+    return {key: sanitize_diagnostic_value(value) for key, value in mapping.items()}
 
 
 def _log_dir(app_name: str) -> Path:
@@ -261,7 +322,7 @@ def collect_runtime_context(app: QApplication | None) -> dict[str, Any]:
 
     ctx["last_launch_command"] = last_launch_command
     ctx["breadcrumbs"] = get_breadcrumbs()[-20:]
-    return ctx
+    return sanitize_diagnostic_mapping(ctx)
 
 
 def create_crash_bundle(log_dir: Path, context: dict[str, Any]) -> Path:
@@ -270,7 +331,8 @@ def create_crash_bundle(log_dir: Path, context: dict[str, Any]) -> Path:
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     bundle = log_dir / f"crash-{ts}.zip"
     crash_json = log_dir / "crash.json"
-    crash_json.write_text(json.dumps(context, indent=2), encoding="utf-8")
+    safe_context = sanitize_diagnostic_mapping(context)
+    crash_json.write_text(json.dumps(safe_context, indent=2), encoding="utf-8")
     with zipfile.ZipFile(bundle, "w", zipfile.ZIP_DEFLATED) as zf:
         for path in log_dir.glob("debug.log*"):
             zf.write(path, path.name)

--- a/tests/test_debug_scaffold_unit.py
+++ b/tests/test_debug_scaffold_unit.py
@@ -1,15 +1,15 @@
 import pytest
-from debug_scaffold import sanitize_url, SENSITIVE_KEYS
+from debug_scaffold import SENSITIVE_KEYS, sanitize_url
 
 pytestmark = pytest.mark.unit
 
 
 def test_sanitize_url_redacts_sensitive_params():
-    url = "https://example.com/path?token=abc123&code=xyz&ok=1"
+    url = "https://example.test/path?token=sample-token&code=sample-code&ok=1"
     out = sanitize_url(url)
     assert "token=REDACTED" in out
     assert "code=REDACTED" in out
-    assert "ok=1" in out
+    assert "ok=REDACTED" in out
 
 
 def test_sensitive_keys_catalog_is_nonempty():

--- a/tests/unit/test_crash_bundle.py
+++ b/tests/unit/test_crash_bundle.py
@@ -13,7 +13,12 @@ from debug_scaffold import create_crash_bundle
 def test_create_crash_bundle(tmp_path) -> None:  # type: ignore[no-untyped-def]
     log_dir = tmp_path
     (log_dir / "debug.log").write_text("log")
-    context = {"foo": "bar"}
+    raw_url = "https://user:pass@example.test/path?token=sample-token#frag-value"
+    context = {
+        "foo": "bar",
+        "last_launch_command": f"firefox --new-tab {raw_url}",
+        "breadcrumbs": [{"event": "launch_plan", "command": ["firefox", raw_url]}],
+    }
     bundle = create_crash_bundle(log_dir, context)
     assert bundle.exists()  # nosec B101
 
@@ -25,3 +30,9 @@ def test_create_crash_bundle(tmp_path) -> None:  # type: ignore[no-untyped-def]
 
         crash_data = json.loads(zf.read("crash.json").decode("utf-8"))
         assert crash_data["foo"] == "bar"  # nosec B101
+        crash_text = json.dumps(crash_data)
+        assert raw_url not in crash_text  # nosec B101
+        assert "sample-token" not in crash_text  # nosec B101
+        assert "user:pass@" not in crash_text  # nosec B101
+        assert "frag-value" not in crash_text  # nosec B101
+        assert "REDACTED" in crash_text  # nosec B101

--- a/tests/unit/test_sanitize_url.py
+++ b/tests/unit/test_sanitize_url.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import pytest
 
-from debug_scaffold import sanitize_url
+from debug_scaffold import (
+    sanitize_diagnostic_value,
+    sanitize_launch_command,
+    sanitize_url,
+)
 
 
 @pytest.mark.unit
@@ -11,18 +15,53 @@ from debug_scaffold import sanitize_url
     "raw,expected",
     [
         (
-            "http://user:pass@example.com/path?token=abc&ok=1",
-            "http://example.com/path?token=REDACTED&ok=1",
+            "http://user:pass@example.test/path?token=sample-token&ok=1",
+            "http://example.test/path?token=REDACTED&ok=REDACTED",
         ),
         (
-            "https://example.com/?Code=123&next=page",
-            "https://example.com/?Code=REDACTED&next=page",
+            "https://example.test/?Code=sample-code&next=page",
+            "https://example.test/?Code=REDACTED&next=REDACTED",
         ),
         (
-            "https://example.com/path",
-            "https://example.com/path",
+            "https://user:pass@example.test/path?search=term#frag-value",
+            "https://example.test/path?search=REDACTED#REDACTED",
+        ),
+        (
+            "https://example.test/path",
+            "https://example.test/path",
         ),
     ],
 )
 def test_sanitize_url(raw: str, expected: str) -> None:
     assert sanitize_url(raw) == expected  # nosec B101
+
+
+@pytest.mark.unit
+def test_sanitize_launch_command_redacts_url_argument() -> None:
+    raw_url = "https://user:pass@example.test/path?state=sample-state#frag-value"
+    command = ["firefox", "--new-tab", raw_url]
+
+    sanitized = sanitize_launch_command(command)
+
+    assert sanitized == [  # nosec B101
+        "firefox",
+        "--new-tab",
+        "https://example.test/path?state=REDACTED#REDACTED",
+    ]
+
+
+@pytest.mark.unit
+def test_sanitize_diagnostic_value_redacts_embedded_url() -> None:
+    raw = {
+        "last_launch_command": (
+            "firefox --new-tab "
+            "https://user:pass@example.test/path?token=sample-token#frag-value"
+        )
+    }
+
+    sanitized = sanitize_diagnostic_value(raw)
+
+    assert "sample-token" not in str(sanitized)  # nosec B101
+    assert "user:pass@" not in str(sanitized)  # nosec B101
+    assert "frag-value" not in str(sanitized)  # nosec B101
+    assert "REDACTED" in str(sanitized)  # nosec B101

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -70,7 +70,12 @@ from PySide6.QtWidgets import (
 )
 
 import debug_scaffold
-from debug_scaffold import record_breadcrumb, sanitize_log_extra, sanitize_url
+from debug_scaffold import (
+    record_breadcrumb,
+    sanitize_launch_command,
+    sanitize_log_extra,
+    sanitize_url,
+)
 from tile_editor_dialog import TileEditorDialog
 from browser_chrome_win import (
     is_windows_default_browser_chrome,
@@ -1140,6 +1145,7 @@ class Main(QMainWindow):
         logger = logging.getLogger(__name__)
         plan = build_launch_plan(tile)
         url = sanitize_url(tile.url)
+        sanitized_command = sanitize_launch_command(plan.command)
         record_breadcrumb(
             "launch_attempt",
             name=tile.name,
@@ -1151,7 +1157,7 @@ class Main(QMainWindow):
             "launch_plan",
             browser=plan.browser_name or "default",
             open_target=plan.open_target,
-            command=plan.command,
+            command=sanitized_command,
             controller=plan.controller,
             new=plan.new,
         )
@@ -1161,7 +1167,7 @@ class Main(QMainWindow):
                 {
                     "event": "browser_launch_attempt",
                     "browser": plan.browser_name or "default",
-                    "flags": plan.command[1:-1] if plan.command else [],
+                    "flags": sanitized_command[1:-1] if sanitized_command else [],
                     "profile": plan.profile,
                     "open_target": plan.open_target,
                     "url": url,
@@ -1268,14 +1274,16 @@ class Main(QMainWindow):
         # --- Explicit controller CLI path (firefox/chrome/edge, etc.) ---
         if plan.command:
             try:
-                debug_scaffold.last_launch_command = " ".join(plan.command)
+                debug_scaffold.last_launch_command = (
+                    " ".join(sanitized_command) if sanitized_command else None
+                )
                 subprocess.Popen(plan.command, close_fds=True)  # nosec B603
                 record_breadcrumb(
                     "launch_path",
                     path="browser_cli",
                     browser=plan.browser_name or "default",
                     open_target=plan.open_target,
-                    cmd=plan.command,
+                    cmd=sanitized_command,
                 )
                 record_breadcrumb("launch_result", ok=True, url=url)
                 logger.info(
@@ -1291,7 +1299,7 @@ class Main(QMainWindow):
                     path="browser_cli",
                     browser=plan.browser_name or "default",
                     open_target=plan.open_target,
-                    cmd=plan.command,
+                    cmd=sanitized_command,
                     error=str(exc),
                 )
                 logger.error(


### PR DESCRIPTION
## Summary

- Redacts launch URL data before it reaches diagnostic context
- Prevents raw tile URLs from being stored in breadcrumbs, logs, crash context, and crash bundles
- Adds unit coverage for sensitive URL redaction

## Evidence

- `make format-check` passed
- `make lint` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed with 26 tests

Closes #63