### PR TITLE
chore: align tile_launcher SPDX license identifier

### DIFF
--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -2,7 +2,7 @@
 # Minimal desktop launcher: tile grid that opens URLs in the default browser.
 # Windows/Mac/Linux.  Requires: Python 3.10+  pip install PySide6
 # encoding changed
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Updates `tile_launcher.py` SPDX identifier from MIT to Apache-2.0
- Aligns the main application file with the repository license
- Makes no functional code changes

## Evidence

- `make format-check` passed
- `make lint` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed

Closes #67
