### PR TITLE
test: isolate unit tests from user profile paths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 # pytest.ini
 [pytest]
-addopts = -q
+addopts = -q --basetemp=.pytest_cache/test-runtime/pytest-tmp
 markers =
     unit: fast, hermetic tests that run on any OS and do not require GUI/Qt
     integration: exercises multiple components, may touch filesystem/network

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ try:
     _xdg.chmod(0o700)
 except Exception:
     pass
-os.environ.setdefault("XDG_RUNTIME_DIR", str(_xdg))
+os.environ["XDG_RUNTIME_DIR"] = str(_xdg)
 
 # ---------- Preserve your original sys.path tweak ----------
 ROOT = str(ROOT_PATH)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,12 +12,46 @@ Pytest bootstrap for headless/CI runs.
   * Optional marker 'requires_opengl' you can use to skip GL-only tests when libGL isn't available
 """
 
+import ctypes
 import os
+import pathlib
 import sys
 import tempfile
-import pathlib
-import ctypes
+
 import pytest  # noqa: F401  # imported for pytest hooks below
+
+# ---------- Test-only path sandbox ----------
+# Keep application config, logs, caches, and temp files out of the real user profile.
+ROOT_PATH = pathlib.Path(__file__).resolve().parents[1]
+TEST_RUNTIME_ROOT = ROOT_PATH / ".pytest_cache" / "test-runtime"
+TEST_TEMP_ROOT = TEST_RUNTIME_ROOT / "temp"
+
+for path in (
+    TEST_RUNTIME_ROOT,
+    TEST_TEMP_ROOT,
+    TEST_RUNTIME_ROOT / "appdata",
+    TEST_RUNTIME_ROOT / "localappdata",
+    TEST_RUNTIME_ROOT / "xdg-config",
+    TEST_RUNTIME_ROOT / "xdg-state",
+    TEST_RUNTIME_ROOT / "xdg-cache",
+):
+    path.mkdir(parents=True, exist_ok=True)
+
+_TEST_ENV_PATHS = {
+    "APPDATA": TEST_RUNTIME_ROOT / "appdata",
+    "LOCALAPPDATA": TEST_RUNTIME_ROOT / "localappdata",
+    "TEMP": TEST_TEMP_ROOT,
+    "TMP": TEST_TEMP_ROOT,
+    "TMPDIR": TEST_TEMP_ROOT,
+    "XDG_CONFIG_HOME": TEST_RUNTIME_ROOT / "xdg-config",
+    "XDG_STATE_HOME": TEST_RUNTIME_ROOT / "xdg-state",
+    "XDG_CACHE_HOME": TEST_RUNTIME_ROOT / "xdg-cache",
+}
+for name, path in _TEST_ENV_PATHS.items():
+    os.environ[name] = str(path)
+
+# tempfile caches its chosen temp dir, so force it to observe the test env above.
+tempfile.tempdir = None
 
 # ---------- Headless-safe Qt defaults ----------
 # Keep your original setting and add a software GL fallback.
@@ -29,7 +63,7 @@ try:
     uid = os.getuid()  # not present on Windows; handled below
 except AttributeError:
     uid = 0
-_xdg = pathlib.Path(tempfile.gettempdir()) / f"xdg-runtime-{uid}"
+_xdg = TEST_TEMP_ROOT / f"xdg-runtime-{uid}"
 try:
     _xdg.mkdir(parents=True, exist_ok=True)
     # Some filesystems (e.g., Windows mounts) may not support chmod; ignore if it fails.
@@ -39,7 +73,7 @@ except Exception:
 os.environ.setdefault("XDG_RUNTIME_DIR", str(_xdg))
 
 # ---------- Preserve your original sys.path tweak ----------
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+ROOT = str(ROOT_PATH)
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 

--- a/tests/unit/test_test_path_isolation.py
+++ b/tests/unit/test_test_path_isolation.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+
+def _resolved_env_path(name: str) -> pathlib.Path:
+    return pathlib.Path(os.environ[name]).resolve()
+
+
+@pytest.mark.unit
+def test_unit_tests_use_repo_local_runtime_paths(tmp_path: pathlib.Path) -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    runtime_root = (repo_root / ".pytest_cache" / "test-runtime").resolve()
+
+    assert tmp_path.resolve().is_relative_to(runtime_root)  # nosec B101
+    assert pathlib.Path(tempfile.gettempdir()).resolve().is_relative_to(runtime_root)  # nosec B101
+
+    for name in (
+        "APPDATA",
+        "LOCALAPPDATA",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "XDG_CONFIG_HOME",
+        "XDG_STATE_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_RUNTIME_DIR",
+    ):
+        assert _resolved_env_path(name).is_relative_to(runtime_root)  # nosec B101


### PR DESCRIPTION
## Summary

- Redirects unit-test config/temp/cache paths away from real user-profile locations
- Prevents unit tests from writing to real `%APPDATA%`, `%LOCALAPPDATA%`, or user Temp directories
- Adds unit coverage proving test paths resolve under the repo-local test runtime

## Evidence

- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed

Closes #71