### PR TITLE
docs: prepare release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## Unreleased
-- Make window user-resizable and persist geometry.
-- Introduce auto-fit policy (`always`/`on_startup`/`off`) with migration from legacy `auto_fit`.
-- Add "Auto-fit Mode" menu and one-shot "Fit to Display Now" command.
+## v0.3.5 - Unreleased
+
+### Security/Privacy
+- Redact launch URLs from diagnostics so local logs do not expose the sites opened from tiles.
+- Document the optional favicon request made for user-entered sites during icon discovery.
+
+### CI/Test
+- Isolate unit tests from user profile paths for more hermetic local and CI runs.
+- Explicitly lint the `tests/` tree with Ruff in CI and local quality gates.
+
+### Dependencies
+- Allow current and next-major pytest releases by supporting pytest 8.2 through 9.x.
+- Update GitHub Actions dependencies for checkout, setup-python, upload-artifact, and CodeQL.
+
+### Docs
+- Align the source SPDX license identifier with the project license.
+
+### Build/Tooling
+- Use portable Makefile recipe tabs for more consistent builds across environments.
+
+### App Behavior
+- Make the launcher window user-resizable and persist its geometry.
+- Introduce auto-fit policy modes (`always`, `on_startup`, `off`) with migration from the legacy
+  `auto_fit` setting.
+- Add an "Auto-fit Mode" menu and a one-shot "Fit to Display Now" command.


### PR DESCRIPTION
## Summary

- Adds release-note coverage for recent maintenance, privacy, CI, test, and dependency updates
- Prepares `CHANGELOG.md` for the next patch release
- Makes no application behavior changes

## Evidence

- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed

Closes #73