### PR TITLE
ci: update release action for Node 24 runtime

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -152,7 +152,7 @@ jobs:
 
       # Single, consolidated release step: create/update the release and upload all assets
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.value }}
           name: ${{ steps.tag.outputs.value }}


### PR DESCRIPTION
## Summary

- Updates the release workflow from `softprops/action-gh-release@v2` to `softprops/action-gh-release@v3`
- Moves the release action to the Node 24-compatible action line
- Preserves the existing release workflow behavior

## Evidence

- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed

Closes #77