### PR TITLE
fix: make tab visibility dialog scrollable

### DIFF
--- a/tests/unit/test_tab_visibility_dialog.py
+++ b/tests/unit/test_tab_visibility_dialog.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtWidgets")
+
+from PySide6.QtWidgets import (  # noqa: E402
+    QApplication,
+    QCheckBox,
+    QDialogButtonBox,
+    QScrollArea,
+)
+
+from tile_launcher import TabVisibilityDialog  # noqa: E402
+
+
+@pytest.mark.unit
+def test_tab_visibility_dialog_scrolls_many_tabs() -> None:
+    try:
+        _ = QApplication.instance() or QApplication([])
+    except Exception:  # pragma: no cover - Qt may be missing platform plugins
+        pytest.skip("Qt platform plugin not available")
+
+    tabs = [f"Tab {index:02d}" for index in range(55)]
+    dialog = TabVisibilityDialog(tabs, hidden=["Tab 03"])
+
+    scroll = dialog.findChild(QScrollArea)
+    assert scroll is not None
+    assert scroll.widgetResizable()
+
+    checkboxes = scroll.widget().findChildren(QCheckBox)
+    assert [checkbox.text() for checkbox in checkboxes] == tabs
+    assert dialog.result_hidden() == ["Tab 03"]
+
+    button_box = dialog.findChild(QDialogButtonBox)
+    assert button_box is not None
+    assert button_box not in scroll.findChildren(QDialogButtonBox)

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -576,6 +576,10 @@ def letter_icon(text: str, size: int = 92, bg: str = "#F5F6FA") -> QIcon:
 
 
 class TabVisibilityDialog(QDialog):
+    _AVAILABLE_AREA_MARGIN = 48
+    _FALLBACK_MAX_INITIAL_HEIGHT = 640
+    _MIN_INITIAL_HEIGHT = 260
+
     def __init__(
         self,
         tabs: list[str],
@@ -584,22 +588,62 @@ class TabVisibilityDialog(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Manage Tab Visibility")
+        self.setSizeGripEnabled(True)
         layout = QVBoxLayout(self)
         self._boxes: list[tuple[str, QCheckBox]] = []
+
+        scroll = QScrollArea(self)
+        scroll.setWidgetResizable(True)
+        list_widget = QWidget(scroll)
+        list_layout = QVBoxLayout(list_widget)
         for tab in tabs:
             cb = QCheckBox(tab)
             cb.setChecked(tab not in hidden)
-            layout.addWidget(cb)
+            list_layout.addWidget(cb)
             self._boxes.append((tab, cb))
+        scroll.setWidget(list_widget)
+        layout.addWidget(scroll, 1)
+
         buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
+        save_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
+        if save_button is not None:
+            save_button.setText("Save")
+            save_button.setDefault(True)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
+        self._cap_initial_size_to_available_area()
 
     def result_hidden(self) -> list[str]:
         return [tab for tab, cb in self._boxes if not cb.isChecked()]
+
+    def _cap_initial_size_to_available_area(self) -> None:
+        screen = None
+        parent = self.parentWidget()
+        if parent is not None:
+            parent_window = parent.window().windowHandle()
+            if parent_window is not None:
+                screen = parent_window.screen()
+        if screen is None:
+            own_window = self.windowHandle()
+            if own_window is not None:
+                screen = own_window.screen()
+        if screen is None:
+            screen = QApplication.primaryScreen()
+
+        max_height = self._FALLBACK_MAX_INITIAL_HEIGHT
+        if screen is not None:
+            available = screen.availableGeometry()
+            max_height = max(
+                self._MIN_INITIAL_HEIGHT,
+                available.height() - self._AVAILABLE_AREA_MARGIN,
+            )
+
+        hint = self.sizeHint()
+        self.resize(hint.width(), min(hint.height(), max_height))
 
 
 class TileButton(QToolButton):


### PR DESCRIPTION
## Summary

- Keep Manage Tab Visibility Save/Cancel controls reachable by moving the tab checkbox list into a scrollable region.
- Cap the dialog’s initial height using available screen/work-area geometry and keep the dialog resizable.
- Add a focused Qt/offscreen unit test for many-tab dialog structure and preserved hidden-tab result behavior.
- No tab persistence, packaging, release workflow, or unrelated app behavior changes.

## Evidence

- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed
- Manual Windows GUI check: Manage Tab Visibility with many tabs kept Save/Cancel visible, the checkbox list scrollable, resizing functional, Save persisted changes, and Cancel/Esc did not save changes

Closes #79