### PR TITLE
Suggest page titles for new URL tiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,8 +295,8 @@ check_untyped_defs = False
    - Keep file names stable: `DesktopTileLauncher-<version>.exe`.
 
 5) **Network & telemetry discipline.**  
-   - No background telemetry. The only network request in the app is the optional favicon fetch for a user‑entered site; keep it that way (best‑effort, silent on failure).  
-   - Do **not** add auto‑update, beaconing, or process‑injection logic.
+   - No background telemetry. Aside from user‑initiated browser launches, application‑initiated network requests are limited to the optional favicon fetch and best‑effort destination-page title lookup; keep both lookup paths silent on failure.
+   - Do **not** add auto‑update, beaconing, credentialed requests, background crawling, telemetry, or process‑injection logic.
 
 6) **Process launching is explicit and narrow.**  
    - Use `subprocess` with `shell=False`; commands must come from narrow, internal allow‑lists (browser binaries/flags).  
@@ -355,7 +355,7 @@ check_untyped_defs = False
 
 > **Cross‑checks:**  
 > • Persistence path is user‑scope (`APPDATA` on Windows); keep it.  
-> • Optional favicon fetch and read‑only Chrome detection are acceptable and already present; do not broaden them.
+> • Optional favicon fetch, narrow destination-page title lookup, and read‑only Chrome detection are acceptable and already present; do not broaden them.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Review/Approval for release signing: 108thecitizen
 External pull requests are reviewed before merge; only tagged builds from `main` are submitted for release signing.
 
 **Privacy**  
-DesktopTileLauncher does not collect telemetry. Network access is limited to user-initiated actions: opening a tile URL in your browser, and adding or editing a URL tile may fetch a site icon through Google's favicon service. That favicon lookup may make a third-party network request and may send the tile's domain/host to the favicon service. See [Debugging & Crash Reports](#debugging--crash-reports) for local log locations.
+DesktopTileLauncher does not collect telemetry. Network access is limited to user-initiated actions: opening a tile URL in your browser, adding or editing a URL tile may fetch a site icon through Google's favicon service, and completing URL entry while adding a new tile may make a best-effort request to that destination page to suggest the static page title. The title lookup contacts the destination directly, requests only the top-level document, follows normal redirects, uses the response only when it is HTML/XHTML, executes no JavaScript, loads no subresources, sends no browser cookies or saved credentials, and fails silently. Full URLs, query strings, retrieved titles, and page content are not written to diagnostics. The favicon lookup may make a third-party network request and may send the tile's domain/host to the favicon service. See [Debugging & Crash Reports](#debugging--crash-reports) for local log locations.
 
 **Uninstall**  
 Delete the application folder. Optionally remove per‑user logs/config in the directories listed in the README.
@@ -164,10 +164,15 @@ directory:
   `~/.local/state/DesktopTileLauncher/`
 
 Aside from user-initiated URL opens and optional favicon lookups described
-above, the application does not send logs or crash data over the network. When
-something goes wrong, use the *Create Crash Bundle* button on the crash dialog
-to zip the log files and a `crash.json` snapshot of runtime context. Attach this
-bundle when filing a GitHub issue.
+above, adding a URL tile may contact the destination page directly to suggest a
+static page title. That lookup requests only the top-level document, follows
+normal redirects, uses the response only when it is HTML/XHTML, executes no
+JavaScript, loads no subresources, sends no browser cookies or saved
+credentials, fails silently, and does not write full URLs, query strings,
+retrieved titles, or page content to diagnostics. The application does not send
+logs or crash data over the network. When something goes wrong, use the *Create
+Crash Bundle* button on the crash dialog to zip the log files and a `crash.json`
+snapshot of runtime context. Attach this bundle when filing a GitHub issue.
 
 ## Running unit tests offline (Codex / air‑gapped)
 

--- a/page_title_lookup.py
+++ b/page_title_lookup.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import codecs
+import http.client
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+import urllib.response
+from collections.abc import Mapping
+from dataclasses import dataclass
+from email.message import Message
+from enum import Enum
+from html.parser import HTMLParser
+from typing import IO, Protocol, cast
+
+MAX_REDIRECTS = 5
+MAX_RESPONSE_BYTES = 256 * 1024
+MAX_TITLE_LENGTH = 512
+TITLE_LOOKUP_TIMEOUT_SECONDS = 3.0
+_READ_CHUNK_BYTES = 16 * 1024
+_USER_AGENT = (
+    "DesktopTileLauncher (+https://github.com/108thecitizen/DesktopTileLauncher)"
+)
+
+_SAFE_REQUEST_HEADERS = {
+    "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.1",
+    "Accept-Encoding": "identity",
+    "User-Agent": _USER_AGENT,
+}
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_HTML_CONTENT_TYPES = {"text/html", "application/xhtml+xml"}
+_MALFORMED_URL_ERRORS = (ValueError, UnicodeError)
+_NETWORK_ERRORS = (
+    OSError,
+    TimeoutError,
+    http.client.HTTPException,
+    urllib.error.URLError,
+    ValueError,
+    UnicodeError,
+    socket.timeout,
+)
+
+
+class PageTitleResponse(Protocol):
+    headers: Mapping[str, str]
+
+    def getcode(self) -> int: ...
+
+    def read(self, amt: int = -1) -> bytes: ...
+
+    def close(self) -> None: ...
+
+
+class PageTitleOpener(Protocol):
+    def open(
+        self, request: urllib.request.Request, timeout: float
+    ) -> PageTitleResponse: ...
+
+
+class NameOwnership(Enum):
+    UNTOUCHED = "untouched"
+    AUTO = "auto"
+    USER = "user"
+
+
+@dataclass(frozen=True)
+class UrlChangeDecision:
+    generation: int
+    clear_name: bool
+
+
+@dataclass(frozen=True)
+class LookupRequest:
+    generation: int
+    url: str
+
+
+@dataclass(frozen=True)
+class TitleApplyDecision:
+    title: str | None
+
+
+@dataclass
+class TitleSuggestionController:
+    is_add_dialog: bool
+    active: bool = True
+    generation: int = 0
+    ownership: NameOwnership = NameOwnership.UNTOUCHED
+    automatic_suggestion: str | None = None
+
+    def deactivate(self) -> None:
+        self.active = False
+        self.invalidate()
+
+    def invalidate(self) -> int:
+        self.generation += 1
+        return self.generation
+
+    def name_edited(self) -> None:
+        self.ownership = NameOwnership.USER
+
+    def url_changed(self, current_name: str) -> UrlChangeDecision:
+        generation = self.invalidate()
+        clear_name = False
+        if self.ownership is NameOwnership.AUTO:
+            if current_name == self.automatic_suggestion:
+                clear_name = True
+            if clear_name or not current_name:
+                self.ownership = NameOwnership.UNTOUCHED
+                self.automatic_suggestion = None
+        return UrlChangeDecision(generation=generation, clear_name=clear_name)
+
+    def begin_lookup(self, raw_url: str) -> LookupRequest | None:
+        if (
+            not self.active
+            or not self.is_add_dialog
+            or self.ownership is NameOwnership.USER
+        ):
+            return None
+        normalized_url = normalize_title_lookup_url(raw_url)
+        if normalized_url is None:
+            return None
+        generation = self.invalidate()
+        return LookupRequest(generation=generation, url=normalized_url)
+
+    def apply_result(
+        self, generation: int, title: str | None, current_name: str
+    ) -> TitleApplyDecision:
+        if (
+            not self.active
+            or not self.is_add_dialog
+            or generation != self.generation
+            or self.ownership is NameOwnership.USER
+        ):
+            return TitleApplyDecision(title=None)
+        if title is None:
+            return TitleApplyDecision(title=None)
+        normalized_title = normalize_title(title)
+        if normalized_title is None:
+            return TitleApplyDecision(title=None)
+
+        may_replace = not current_name or current_name == self.automatic_suggestion
+        if not may_replace:
+            return TitleApplyDecision(title=None)
+
+        self.ownership = NameOwnership.AUTO
+        self.automatic_suggestion = normalized_title
+        return TitleApplyDecision(title=normalized_title)
+
+
+class _TitleParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._in_title = False
+        self._done = False
+        self._parts: list[str] = []
+
+    @property
+    def title(self) -> str | None:
+        if not self._done:
+            return None
+        return normalize_title("".join(self._parts))
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if not self._done and tag.lower() == "title":
+            self._in_title = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._in_title and tag.lower() == "title":
+            self._in_title = False
+            self._done = True
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title and not self._done:
+            self._parts.append(data)
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def http_error_301(
+        self,
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: http.client.HTTPMessage,
+    ) -> urllib.response.addinfourl:
+        return self._return_redirect_response(req, fp, code, headers)
+
+    http_error_302 = http_error_301
+    http_error_303 = http_error_301
+    http_error_307 = http_error_301
+    http_error_308 = http_error_301
+
+    @staticmethod
+    def _return_redirect_response(
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        headers: http.client.HTTPMessage,
+    ) -> urllib.response.addinfourl:
+        return urllib.response.addinfourl(fp, headers, req.full_url, code)
+
+
+def normalize_title_lookup_url(raw_url: str) -> str | None:
+    try:
+        text = (raw_url or "").strip()
+        if not text:
+            return None
+        parsed = urllib.parse.urlparse(text)
+        if not parsed.scheme:
+            parsed = urllib.parse.urlparse(f"https://{text}")
+        return _validated_url_from_parts(parsed)
+    except _MALFORMED_URL_ERRORS:
+        return None
+
+
+def extract_title(html_bytes: bytes, content_type: str | None = None) -> str | None:
+    charset = _declared_charset(content_type) or "utf-8"
+    try:
+        text = html_bytes.decode(charset, errors="replace")
+    except LookupError:
+        text = html_bytes.decode("utf-8", errors="replace")
+
+    parser = _TitleParser()
+    try:
+        parser.feed(text)
+        parser.close()
+    except Exception:
+        return None
+    return parser.title
+
+
+def normalize_title(title: str) -> str | None:
+    normalized = " ".join(title.split())
+    if not normalized or len(normalized) > MAX_TITLE_LENGTH:
+        return None
+    return normalized
+
+
+def fetch_page_title(
+    url: str,
+    *,
+    opener: PageTitleOpener | None = None,
+    timeout: float = TITLE_LOOKUP_TIMEOUT_SECONDS,
+) -> str | None:
+    current_url = normalize_title_lookup_url(url)
+    if current_url is None:
+        return None
+
+    active_opener = opener or _build_private_opener()
+    redirect_count = 0
+    while True:
+        try:
+            request = urllib.request.Request(
+                current_url, headers=_SAFE_REQUEST_HEADERS, method="GET"
+            )
+        except _MALFORMED_URL_ERRORS:
+            return None
+        try:
+            response = active_opener.open(request, timeout=timeout)
+        except urllib.error.HTTPError as exc:
+            exc.close()
+            return None
+        except _NETWORK_ERRORS:
+            return None
+
+        try:
+            status = _response_status(response)
+            if status in _REDIRECT_STATUSES:
+                if redirect_count >= MAX_REDIRECTS:
+                    return None
+                location = _header(response, "Location")
+                next_url = _validated_redirect_url(current_url, location)
+                if next_url is None:
+                    return None
+                redirect_count += 1
+                current_url = next_url
+                continue
+            if status < 200 or status >= 300:
+                return None
+            return _extract_response_title(response)
+        except _NETWORK_ERRORS:
+            return None
+        finally:
+            response.close()
+
+
+def _build_private_opener() -> PageTitleOpener:
+    return cast(
+        PageTitleOpener,
+        urllib.request.build_opener(
+            urllib.request.ProxyHandler({}),
+            _NoRedirectHandler(),
+        ),
+    )
+
+
+def _validated_redirect_url(base_url: str, location: str | None) -> str | None:
+    if not location:
+        return None
+    try:
+        joined = urllib.parse.urljoin(base_url, location)
+    except _MALFORMED_URL_ERRORS:
+        return None
+    return normalize_title_lookup_url(joined)
+
+
+def _validated_url_from_parts(parsed: urllib.parse.ParseResult) -> str | None:
+    try:
+        scheme = parsed.scheme.lower()
+        if scheme not in {"http", "https"}:
+            return None
+        hostname = parsed.hostname
+        parsed.port
+        if not hostname:
+            return None
+        if parsed.username is not None or parsed.password is not None:
+            return None
+        clean = parsed._replace(scheme=scheme, fragment="")
+        return urllib.parse.urlunparse(clean)
+    except _MALFORMED_URL_ERRORS:
+        return None
+
+
+def _response_status(response: PageTitleResponse) -> int:
+    raw_status = getattr(response, "status", None)
+    if raw_status is None:
+        raw_status = getattr(response, "code", None)
+    if raw_status is None:
+        raw_status = response.getcode()
+    return int(raw_status)
+
+
+def _extract_response_title(response: PageTitleResponse) -> str | None:
+    if _is_attachment(response) or _has_unsupported_encoding(response):
+        return None
+    raw_content_type = _header(response, "Content-Type")
+    content_type = (
+        raw_content_type if raw_content_type and raw_content_type.strip() else None
+    )
+    if content_type and not _is_html_content_type(content_type):
+        return None
+
+    body = bytearray()
+    should_parse = content_type is not None
+    while len(body) < MAX_RESPONSE_BYTES:
+        remaining = MAX_RESPONSE_BYTES - len(body)
+        chunk = response.read(min(_READ_CHUNK_BYTES, remaining))
+        if not chunk:
+            return None
+        body.extend(chunk)
+        if content_type is None and not should_parse:
+            if not _looks_html_like(bytes(body)):
+                return None
+            should_parse = True
+        if should_parse:
+            title = extract_title(bytes(body), content_type)
+            if title is not None:
+                return title
+    return None
+
+
+def _may_parse_as_html(content_type: str | None, body: bytes) -> bool:
+    if content_type:
+        return _is_html_content_type(content_type)
+    return _looks_html_like(body)
+
+
+def _is_html_content_type(content_type: str) -> bool:
+    message = _content_type_message(content_type)
+    return message.get_content_type().lower() in _HTML_CONTENT_TYPES
+
+
+def _looks_html_like(body: bytes) -> bool:
+    prefix = body[:512].lstrip().lower()
+    if prefix.startswith(codecs.BOM_UTF8):
+        prefix = prefix[len(codecs.BOM_UTF8) :].lstrip()
+    if prefix.startswith(b"<?xml"):
+        declaration_end = prefix.find(b"?>")
+        if declaration_end < 0:
+            return False
+        prefix = prefix[declaration_end + 2 :].lstrip()
+    return prefix.startswith((b"<!doctype html", b"<html", b"<head", b"<title"))
+
+
+def _is_attachment(response: PageTitleResponse) -> bool:
+    disposition = _header(response, "Content-Disposition")
+    if not disposition:
+        return False
+    return disposition.split(";", 1)[0].strip().lower() == "attachment"
+
+
+def _has_unsupported_encoding(response: PageTitleResponse) -> bool:
+    encoding = _header(response, "Content-Encoding")
+    if not encoding:
+        return False
+    return encoding.strip().lower() != "identity"
+
+
+def _declared_charset(content_type: str | None) -> str | None:
+    if not content_type:
+        return None
+    charset = _content_type_message(content_type).get_content_charset()
+    if not charset:
+        return None
+    try:
+        codecs.lookup(charset)
+    except LookupError:
+        return None
+    return charset
+
+
+def _content_type_message(content_type: str) -> Message:
+    message = Message()
+    message["content-type"] = content_type
+    return message
+
+
+def _header(response: PageTitleResponse, name: str) -> str | None:
+    headers = getattr(response, "headers", {})
+    value = headers.get(name)
+    if value is not None:
+        return str(value)
+    return headers.get(name.lower())

--- a/tests/unit/test_page_title_lookup.py
+++ b/tests/unit/test_page_title_lookup.py
@@ -1,0 +1,505 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import http.client
+import socket
+import urllib.error
+import urllib.request
+from collections.abc import Iterator, Mapping, Sequence
+from typing import cast
+
+import pytest
+
+from page_title_lookup import (
+    MAX_REDIRECTS,
+    MAX_RESPONSE_BYTES,
+    MAX_TITLE_LENGTH,
+    NameOwnership,
+    PageTitleResponse,
+    TitleSuggestionController,
+    extract_title,
+    fetch_page_title,
+    normalize_title,
+    normalize_title_lookup_url,
+)
+
+
+pytestmark = pytest.mark.unit
+_EXPECTED_USER_AGENT = (
+    "DesktopTileLauncher (+https://github.com/108thecitizen/DesktopTileLauncher)"
+)
+
+
+class _Headers(dict[str, str]):
+    def __init__(self, values: Mapping[str, str] | None = None) -> None:
+        super().__init__()
+        for key, value in (values or {}).items():
+            self[key] = value
+
+    def __setitem__(self, key: str, value: str) -> None:
+        super().__setitem__(key.lower(), value)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return super().get(key.lower(), default)
+
+
+class _Response:
+    def __init__(
+        self,
+        body: bytes = b"<html><head><title>Example</title></head></html>",
+        *,
+        status: int = 200,
+        headers: Mapping[str, str] | None = None,
+        read_error: BaseException | None = None,
+    ) -> None:
+        self.status = status
+        self.headers = _Headers({"Content-Type": "text/html; charset=utf-8"})
+        for key, value in (headers or {}).items():
+            self.headers[key] = value
+        self._body = body
+        self._cursor = 0
+        self._read_error = read_error
+        self.closed = False
+        self.read_sizes: list[int] = []
+        self.bytes_read = 0
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self, amt: int = -1) -> bytes:
+        self.read_sizes.append(amt)
+        if self._read_error is not None:
+            raise self._read_error
+        if amt < 0:
+            chunk = self._body[self._cursor :]
+        else:
+            chunk = self._body[self._cursor : self._cursor + amt]
+        self._cursor += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ClosableBody:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _NoHeadersResponse:
+    def getcode(self) -> int:
+        return 200
+
+    def read(self, amt: int = -1) -> bytes:
+        return b"bad"
+
+    def close(self) -> None:
+        return None
+
+
+class _Opener:
+    def __init__(self, actions: Sequence[object]) -> None:
+        self._actions: Iterator[object] = iter(actions)
+        self.requests: list[urllib.request.Request] = []
+        self.timeouts: list[float] = []
+        self.last_action: object | None = None
+
+    def open(
+        self, request: urllib.request.Request, timeout: float
+    ) -> PageTitleResponse:
+        self.requests.append(request)
+        self.timeouts.append(timeout)
+        action = next(self._actions)
+        self.last_action = action
+        if isinstance(action, BaseException):
+            raise action
+        return cast(PageTitleResponse, action)
+
+
+def _html(title: str) -> bytes:
+    return f"<html><head><title>{title}</title></head></html>".encode()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("http://example.test/path?x=1#frag", "http://example.test/path?x=1"),
+        ("https://example.test/", "https://example.test/"),
+        ("example.test/path?x=1#frag", "https://example.test/path?x=1"),
+    ],
+)
+def test_http_https_and_bare_host_url_acceptance(raw: str, expected: str) -> None:
+    assert normalize_title_lookup_url(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ftp://example.test/",
+        "mailto:user@example.test",
+        "https:///missing-host",
+        "https://user@example.test/",
+        "https://user:pass@example.test/",
+        "https://[bad/",
+        "http://[]/",
+        "[bad",
+    ],
+)
+def test_url_rejection(raw: str) -> None:
+    assert normalize_title_lookup_url(raw) is None
+
+
+def test_fetch_silently_rejects_malformed_urls_before_opening() -> None:
+    opener = _Opener([_Response(_html("Should Not Open"))])
+
+    assert fetch_page_title("https://[bad/", opener=opener) is None
+    assert opener.requests == []
+
+
+def test_fetch_uses_fragment_stripped_url() -> None:
+    opener = _Opener([_Response(_html("Fragment"))])
+
+    assert fetch_page_title("example.test/path?x=1#secret", opener=opener) == "Fragment"
+    assert opener.requests[0].full_url == "https://example.test/path?x=1"
+
+
+def test_redirect_acceptance_and_five_redirects() -> None:
+    responses = [
+        _Response(status=302, headers={"Location": f"/step-{index}"})
+        for index in range(MAX_REDIRECTS)
+    ]
+    responses.append(_Response(_html("Final")))
+    opener = _Opener(responses)
+
+    assert (
+        fetch_page_title("https://example.test/start", opener=opener, timeout=1.25)
+        == "Final"
+    )
+    assert opener.requests[-1].full_url == "https://example.test/step-4"
+    assert opener.timeouts == [1.25] * (MAX_REDIRECTS + 1)
+    assert all(response.closed for response in responses)
+
+
+def test_redirect_limit_rejects_sixth_redirect() -> None:
+    responses = [
+        _Response(status=302, headers={"Location": f"/step-{index}"})
+        for index in range(MAX_REDIRECTS + 1)
+    ]
+    opener = _Opener(responses)
+
+    assert fetch_page_title("https://example.test/start", opener=opener) is None
+    assert len(opener.requests) == MAX_REDIRECTS + 1
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["ftp://example.test/file", "https://user:pass@example.test/"],
+)
+def test_redirect_rejection_for_unsupported_scheme_or_credentials(
+    location: str,
+) -> None:
+    opener = _Opener([_Response(status=302, headers={"Location": location})])
+
+    assert fetch_page_title("https://example.test/start", opener=opener) is None
+    assert isinstance(opener.last_action, _Response)
+    assert opener.last_action.closed
+
+
+def test_simple_title_extraction() -> None:
+    assert extract_title(_html("Example Title")) == "Example Title"
+
+
+def test_entity_decoding_happens_exactly_once() -> None:
+    assert extract_title(_html("AT&amp;amp;T")) == "AT&amp;T"
+
+
+def test_unicode_preservation_and_whitespace_normalization() -> None:
+    body = "<html><title>\n Café\t東京  Test \r\n</title></html>".encode()
+
+    assert extract_title(body) == "Café 東京 Test"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"<html><head></head></html>",
+        b"<html><head><title>   </title></head></html>",
+        b"<html><head><title></head></html>",
+    ],
+)
+def test_missing_and_malformed_titles(body: bytes) -> None:
+    assert extract_title(body) is None
+
+
+@pytest.mark.parametrize(
+    ("headers", "body", "expected"),
+    [
+        ({"Content-Type": "text/html; charset=utf-8"}, _html("HTML"), "HTML"),
+        ({"Content-Type": "application/xhtml+xml"}, _html("XHTML"), "XHTML"),
+        ({"Content-Type": ""}, _html("Missing"), "Missing"),
+        (
+            {"Content-Type": ""},
+            b"<?xml version='1.0'?><html><head><title>XML HTML</title></head></html>",
+            "XML HTML",
+        ),
+        ({"Content-Type": "application/json"}, b'{"title": "No"}', None),
+        ({"Content-Type": ""}, b"plain text", None),
+        (
+            {"Content-Type": ""},
+            b"<?xml version='1.0'?><rss><title>Feed</title></rss>",
+            None,
+        ),
+        (
+            {"Content-Type": ""},
+            b"<?xml version='1.0'?><svg><title>Icon</title></svg>",
+            None,
+        ),
+    ],
+)
+def test_content_type_handling(
+    headers: Mapping[str, str], body: bytes, expected: str | None
+) -> None:
+    opener = _Opener([_Response(body, headers=headers)])
+
+    assert fetch_page_title("https://example.test/", opener=opener) == expected
+
+
+def test_attachment_response_is_rejected() -> None:
+    opener = _Opener(
+        [_Response(_html("Download"), headers={"Content-Disposition": "attachment"})]
+    )
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+
+
+def test_unsupported_content_encoding_is_rejected() -> None:
+    opener = _Opener([_Response(_html("Zip"), headers={"Content-Encoding": "gzip"})])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+
+
+def test_declared_oversized_response_succeeds_with_title_in_bounded_prefix() -> None:
+    response = _Response(
+        _html("Large Declared") + (b"x" * MAX_RESPONSE_BYTES),
+        headers={"Content-Length": str(MAX_RESPONSE_BYTES + 1)},
+    )
+    opener = _Opener([response])
+
+    assert fetch_page_title("https://example.test/", opener=opener) == "Large Declared"
+    assert 0 < response.bytes_read < len(response._body)
+    assert response.closed
+
+
+def test_actual_oversized_response_succeeds_with_title_in_bounded_prefix() -> None:
+    response = _Response(_html("Early Title") + (b"x" * MAX_RESPONSE_BYTES))
+    opener = _Opener([response])
+
+    assert fetch_page_title("https://example.test/", opener=opener) == "Early Title"
+    assert response.bytes_read < len(response._body)
+    assert response.closed
+
+
+def test_large_response_with_no_title_inside_cap_returns_none() -> None:
+    response = _Response((b"x" * MAX_RESPONSE_BYTES) + _html("Too Late"))
+    opener = _Opener([response])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+    assert response.bytes_read == MAX_RESPONSE_BYTES
+    assert response.closed
+
+
+def test_title_closing_tag_beyond_cap_returns_none() -> None:
+    body = b"<html><head><title>" + (b"x" * MAX_RESPONSE_BYTES) + b"</title>"
+    response = _Response(body)
+    opener = _Opener([response])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+    assert response.bytes_read == MAX_RESPONSE_BYTES
+    assert response.closed
+
+
+def test_unclosed_or_chunk_truncated_title_returns_none() -> None:
+    response = _Response(b"<html><head><title>Partial")
+    opener = _Opener([response])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+    assert response.bytes_read == len(response._body)
+    assert response.closed
+
+
+def test_declared_non_html_content_type_rejected_without_reading() -> None:
+    response = _Response(
+        _html("Ignored"),
+        headers={"Content-Type": "application/json"},
+    )
+    opener = _Opener([response])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+    assert response.read_sizes == []
+    assert response.closed
+
+
+def test_empty_and_overlong_titles_are_rejected() -> None:
+    assert normalize_title("") is None
+    assert normalize_title("x" * (MAX_TITLE_LENGTH + 1)) is None
+
+
+def test_charset_handling_uses_valid_declared_charset() -> None:
+    body = "<html><title>Caf\xe9</title></html>".encode("iso-8859-1")
+
+    assert extract_title(body, "text/html; charset=iso-8859-1") == "Café"
+
+
+def test_invalid_charset_falls_back_to_utf8_replacement() -> None:
+    body = b"<html><title>\xff</title></html>"
+
+    assert extract_title(body, "text/html; charset=not-a-codec") == "�"
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        TimeoutError("timeout"),
+        urllib.error.HTTPError("https://example.test/", 500, "error", {}, None),
+        urllib.error.URLError("http error"),
+        http.client.BadStatusLine("bad"),
+        socket.timeout("socket timeout"),
+        OSError("network"),
+    ],
+)
+def test_network_failures_return_none(failure: BaseException) -> None:
+    opener = _Opener([failure])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+
+
+def test_raised_http_error_closes_response_body() -> None:
+    body = _ClosableBody()
+    error = urllib.error.HTTPError("https://example.test/", 500, "error", {}, body)
+    opener = _Opener([error])
+
+    assert fetch_page_title("https://example.test/", opener=opener) is None
+    assert body.closed
+
+
+def test_http_error_status_and_malformed_response_return_none() -> None:
+    assert (
+        fetch_page_title(
+            "https://example.test/",
+            opener=_Opener([_Response(status=404)]),
+        )
+        is None
+    )
+    assert (
+        fetch_page_title(
+            "https://example.test/",
+            opener=_Opener([_NoHeadersResponse()]),
+        )
+        is None
+    )
+
+
+def test_response_closes_on_success_and_failure() -> None:
+    success = _Response(_html("Closed"))
+    failure = _Response(_html("Closed"), read_error=OSError("read"))
+
+    assert fetch_page_title("https://example.test/", opener=_Opener([success]))
+    assert success.closed
+    assert fetch_page_title("https://example.test/", opener=_Opener([failure])) is None
+    assert failure.closed
+
+
+def test_forbidden_headers_are_not_sent() -> None:
+    opener = _Opener(
+        [
+            _Response(status=302, headers={"Location": "/next"}),
+            _Response(_html("Headers")),
+        ]
+    )
+
+    assert fetch_page_title("https://example.test/", opener=opener) == "Headers"
+    for request in opener.requests:
+        sent = {key.lower(): value for key, value in request.header_items()}
+        assert sent["user-agent"] == _EXPECTED_USER_AGENT
+        assert sent["accept-encoding"] == "identity"
+        assert "cookie" not in sent
+        assert "authorization" not in sent
+        assert "proxy-authorization" not in sent
+        assert "referer" not in sent
+        assert "origin" not in sent
+
+
+def test_state_transitions_for_untouched_auto_and_user() -> None:
+    state = TitleSuggestionController(is_add_dialog=True)
+
+    request = state.begin_lookup("example.test")
+    assert request is not None
+    decision = state.apply_result(request.generation, "Example", "")
+    assert decision.title == "Example"
+    assert state.ownership is NameOwnership.AUTO
+
+    state.name_edited()
+    assert state.ownership is NameOwnership.USER
+    request = state.begin_lookup("https://example.test/other")
+    assert request is None
+
+
+def test_every_url_change_invalidates_earlier_generation() -> None:
+    state = TitleSuggestionController(is_add_dialog=True)
+    request = state.begin_lookup("example.test")
+    assert request is not None
+
+    change = state.url_changed("")
+
+    assert change.generation != request.generation
+    assert state.apply_result(request.generation, "Stale", "").title is None
+
+
+def test_user_ownership_prevents_application() -> None:
+    state = TitleSuggestionController(is_add_dialog=True)
+    request = state.begin_lookup("example.test")
+    assert request is not None
+
+    state.name_edited()
+
+    assert state.apply_result(request.generation, "Title", "Mine").title is None
+
+
+def test_auto_replacement_after_url_change() -> None:
+    state = TitleSuggestionController(is_add_dialog=True)
+    first = state.begin_lookup("example.test")
+    assert first is not None
+    assert state.apply_result(first.generation, "First", "").title == "First"
+
+    change = state.url_changed("First")
+    assert change.clear_name
+    second = state.begin_lookup("example.test/next")
+    assert second is not None
+
+    assert state.apply_result(second.generation, "Second", "").title == "Second"
+
+
+def test_deactivation_prevents_late_application() -> None:
+    state = TitleSuggestionController(is_add_dialog=True)
+    request = state.begin_lookup("example.test")
+    assert request is not None
+
+    state.deactivate()
+
+    assert state.apply_result(request.generation, "Late", "").title is None
+
+
+def test_add_disabled_state_never_begins_lookup() -> None:
+    state = TitleSuggestionController(is_add_dialog=False)
+
+    assert state.begin_lookup("https://example.test/") is None

--- a/tests/unit/test_tile_editor_title_suggestion.py
+++ b/tests/unit/test_tile_editor_title_suggestion.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtCore")
+pytest.importorskip("PySide6.QtWidgets")
+
+from PySide6.QtCore import QRunnable  # noqa: E402
+from PySide6.QtWidgets import QApplication, QDialogButtonBox  # noqa: E402
+
+import tile_editor_dialog  # noqa: E402
+from tile_editor_dialog import TileEditorDialog  # noqa: E402
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeThreadPool:
+    def __init__(self) -> None:
+        self.runnables: list[QRunnable] = []
+
+    def start(self, runnable: QRunnable) -> None:
+        self.runnables.append(runnable)
+
+    def run_next(self) -> None:
+        runnable = self.runnables.pop(0)
+        runnable.run()
+
+
+class _FakeQThreadPool:
+    pool: _FakeThreadPool
+
+    @staticmethod
+    def globalInstance() -> _FakeThreadPool:
+        return _FakeQThreadPool.pool
+
+
+class _Fetcher:
+    def __init__(self, results: list[str | None | Exception]) -> None:
+        self._results = results
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> str | None:
+        self.calls.append(url)
+        result = self._results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+@pytest.fixture
+def app() -> QApplication:
+    try:
+        application = QApplication.instance()
+        if application is None:
+            application = QApplication([])
+    except Exception:  # pragma: no cover - Qt may be missing platform plugins
+        pytest.skip("Qt platform plugin not available")
+    return cast(QApplication, application)
+
+
+@pytest.fixture
+def fake_pool(monkeypatch: pytest.MonkeyPatch) -> _FakeThreadPool:
+    pool = _FakeThreadPool()
+    _FakeQThreadPool.pool = pool
+    monkeypatch.setattr(tile_editor_dialog, "QThreadPool", _FakeQThreadPool)
+    return pool
+
+
+def _dialog(
+    tmp_path: Path,
+    fetcher: Callable[[str], str | None],
+    *,
+    tile: Any | None = None,
+) -> TileEditorDialog:
+    return TileEditorDialog(
+        tabs=["Main"],
+        browsers=[],
+        icon_dir=tmp_path,
+        fetch_favicon=lambda _url: None,
+        fetch_title=fetcher,
+        tile=tile,
+    )
+
+
+def _flush(app: QApplication) -> None:
+    app.processEvents()
+
+
+def _finish_lookup(app: QApplication, fake_pool: _FakeThreadPool) -> None:
+    fake_pool.run_next()
+    _flush(app)
+
+
+def _type_name(dialog: TileEditorDialog, text: str) -> None:
+    dialog.name_edit.setText(text)
+    dialog.name_edit.textEdited.emit(text)
+
+
+def _ok_enabled(dialog: TileEditorDialog) -> bool:
+    button = dialog.button_box.button(QDialogButtonBox.StandardButton.Ok)
+    assert button is not None
+    return button.isEnabled()
+
+
+def test_add_dialog_starts_lookup_on_editing_finished_not_keystrokes(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    fetcher = _Fetcher(["Example"])
+    dialog = _dialog(tmp_path, fetcher)
+
+    dialog.url_edit.setText("exa")
+    dialog.url_edit.setText("example.test")
+    _flush(app)
+
+    assert fake_pool.runnables == []
+    assert fetcher.calls == []
+
+    dialog.url_edit.editingFinished.emit()
+
+    assert len(fake_pool.runnables) == 1
+    _finish_lookup(app, fake_pool)
+    assert fetcher.calls == ["https://example.test"]
+
+
+def test_blank_untouched_name_receives_result(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["Example Title"]))
+
+    dialog.url_edit.setText("example.test")
+    dialog.url_edit.editingFinished.emit()
+    fake_pool.run_next()
+    assert dialog.name_edit.text() == ""
+    _flush(app)
+
+    assert dialog.name_edit.text() == "Example Title"
+    assert _ok_enabled(dialog)
+
+
+def test_typed_name_is_not_overwritten(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["Example Title"]))
+
+    _type_name(dialog, "Mine")
+    dialog.url_edit.setText("example.test")
+    dialog.url_edit.editingFinished.emit()
+    _flush(app)
+
+    assert fake_pool.runnables == []
+    assert dialog.name_edit.text() == "Mine"
+
+
+def test_user_editing_while_lookup_pending_wins(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["Remote Title"]))
+
+    dialog.url_edit.setText("example.test")
+    dialog.url_edit.editingFinished.emit()
+    _type_name(dialog, "Local Title")
+    _finish_lookup(app, fake_pool)
+
+    assert dialog.name_edit.text() == "Local Title"
+
+
+def test_url_changes_invalidate_stale_results(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["First", "Second"]))
+
+    dialog.url_edit.setText("example.test/one")
+    dialog.url_edit.editingFinished.emit()
+    dialog.url_edit.setText("example.test/two")
+    dialog.url_edit.editingFinished.emit()
+
+    _finish_lookup(app, fake_pool)
+    assert dialog.name_edit.text() == ""
+
+    _finish_lookup(app, fake_pool)
+    assert dialog.name_edit.text() == "Second"
+
+
+def test_automatic_suggestion_is_cleared_and_replaced_for_changed_url(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["First", "Second"]))
+
+    dialog.url_edit.setText("example.test/one")
+    dialog.url_edit.editingFinished.emit()
+    _finish_lookup(app, fake_pool)
+    assert dialog.name_edit.text() == "First"
+
+    dialog.url_edit.setText("example.test/two")
+    assert dialog.name_edit.text() == ""
+    dialog.url_edit.editingFinished.emit()
+    _finish_lookup(app, fake_pool)
+
+    assert dialog.name_edit.text() == "Second"
+
+
+def test_edit_dialog_never_starts_lookup(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    fetcher = _Fetcher(["Ignored"])
+    tile = SimpleNamespace(
+        name="Existing",
+        url="https://example.test/",
+        tab="Main",
+        icon=None,
+        browser=None,
+        chrome_profile=None,
+        open_target="tab",
+    )
+    dialog = _dialog(tmp_path, fetcher, tile=tile)
+
+    dialog.url_edit.setText("example.test/changed")
+    dialog.url_edit.editingFinished.emit()
+    _flush(app)
+
+    assert fake_pool.runnables == []
+    assert fetcher.calls == []
+    assert dialog.name_edit.text() == "Existing"
+
+
+def test_malformed_url_never_escapes_from_editing_finished(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["Ignored"]))
+
+    dialog.url_edit.setText("https://[bad/")
+    dialog.url_edit.editingFinished.emit()
+    _flush(app)
+
+    assert fake_pool.runnables == []
+    assert dialog.name_edit.text() == ""
+
+
+@pytest.mark.parametrize("action", ["reject", "accept", "close"])
+def test_dialog_completion_prevents_late_result(
+    app: QApplication,
+    fake_pool: _FakeThreadPool,
+    tmp_path: Path,
+    action: str,
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["Late"]))
+
+    dialog.show()
+    _flush(app)
+    dialog.url_edit.setText("example.test")
+    dialog.url_edit.editingFinished.emit()
+    if action == "reject":
+        dialog.reject()
+    elif action == "accept":
+        dialog.accept()
+    else:
+        dialog.close()
+    _flush(app)
+
+    assert not dialog.isVisible()
+    _finish_lookup(app, fake_pool)
+
+    assert dialog.name_edit.text() == ""
+
+
+def test_failure_produces_no_modal_dialog_and_leaves_name_unchanged(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher([OSError("network")]))
+
+    dialog.url_edit.setText("example.test")
+    dialog.url_edit.editingFinished.emit()
+    _finish_lookup(app, fake_pool)
+
+    assert dialog.name_edit.text() == ""
+    assert QApplication.activeModalWidget() is None
+
+
+def test_existing_ok_button_behavior_remains_correct(
+    app: QApplication, fake_pool: _FakeThreadPool, tmp_path: Path
+) -> None:
+    dialog = _dialog(tmp_path, _Fetcher(["Remote"]))
+
+    assert not _ok_enabled(dialog)
+
+    dialog.url_edit.setText("example.test")
+    assert not _ok_enabled(dialog)
+
+    _type_name(dialog, "Manual")
+    assert _ok_enabled(dialog)
+
+    dialog.name_edit.clear()
+    assert not _ok_enabled(dialog)
+
+    dialog = _dialog(tmp_path, _Fetcher(["Remote"]))
+    dialog.url_edit.setText("example.test")
+    dialog.url_edit.editingFinished.emit()
+    _finish_lookup(app, fake_pool)
+
+    assert _ok_enabled(dialog)

--- a/tests/unit/test_tile_name_diagnostics.py
+++ b/tests/unit/test_tile_name_diagnostics.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import sys
+import webbrowser
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6.QtWidgets")
+
+import tile_launcher  # noqa: E402
+from tile_launcher import Main, Tile  # noqa: E402
+
+
+pytestmark = pytest.mark.unit
+
+_SENSITIVE_TITLE = "Sensitive Retrieved Title"
+
+
+@dataclass
+class _Config:
+    tabs: list[str] = field(default_factory=lambda: ["Main"])
+    tiles: list[Tile] = field(default_factory=list)
+    save_count: int = 0
+
+    def save(self) -> None:
+        self.save_count += 1
+
+
+class _TabCombo:
+    def findText(self, _text: str, _flags: object) -> int:
+        return 0
+
+    def setCurrentIndex(self, _index: int) -> None:
+        return None
+
+
+class _Dialog:
+    tab_combo = _TabCombo()
+    data: dict[str, str | None] = {
+        "name": _SENSITIVE_TITLE,
+        "url": "https://example.test/",
+        "tab": "Main",
+        "icon": None,
+        "browser": None,
+        "chrome_profile": None,
+        "open_target": "tab",
+    }
+
+    def __init__(self, **_kwargs: object) -> None:
+        return None
+
+    def exec(self) -> object:
+        return tile_launcher.QDialog.DialogCode.Accepted
+
+
+class _MainHarness:
+    def __init__(self) -> None:
+        self.cfg = _Config()
+        self.rebuilt = False
+        self.selected_tab: str | None = None
+
+    def current_tab(self) -> str:
+        return "Main"
+
+    def rebuild(self) -> None:
+        self.rebuilt = True
+
+    def _set_current_tab_by_name(self, tab: str) -> None:
+        self.selected_tab = tab
+
+
+def _capture_breadcrumbs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, dict[str, object]]]:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def fake_record(event: str, **fields: object) -> None:
+        captured.append((event, fields))
+
+    monkeypatch.setattr(tile_launcher, "record_breadcrumb", fake_record)
+    return captured
+
+
+def _assert_sensitive_title_absent(
+    captured: list[tuple[str, dict[str, object]]],
+) -> None:
+    assert _SENSITIVE_TITLE not in repr(captured)
+
+
+def test_open_tile_does_not_pass_tile_name_to_breadcrumbs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture_breadcrumbs(monkeypatch)
+    tile = Tile(name=_SENSITIVE_TITLE, url="https://example.test/")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(webbrowser, "open", lambda _url, new=0: True)
+
+    Main.open_tile(object(), tile)
+
+    assert captured
+    launch_attempt = [fields for event, fields in captured if event == "launch_attempt"]
+    assert launch_attempt
+    assert "name" not in launch_attempt[0]
+    _assert_sensitive_title_absent(captured)
+
+
+def test_add_tile_does_not_pass_accepted_tile_name_to_breadcrumbs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured = _capture_breadcrumbs(monkeypatch)
+    harness = _MainHarness()
+
+    monkeypatch.setattr(tile_launcher, "TileEditorDialog", _Dialog)
+    monkeypatch.setattr(tile_launcher, "available_browsers", lambda: [])
+    monkeypatch.setattr(tile_launcher, "ICON_DIR", tmp_path)
+
+    Main.add_tile(harness, default_tab="Main")
+
+    assert harness.cfg.save_count == 1
+    assert harness.rebuilt
+    assert harness.selected_tab == "Main"
+    assert harness.cfg.tiles[0].name == _SENSITIVE_TITLE
+    tile_add = [fields for event, fields in captured if event == "tile_add"]
+    assert tile_add
+    assert "name" not in tile_add[0]
+    _assert_sensitive_title_absent(captured)

--- a/tile_editor_dialog.py
+++ b/tile_editor_dialog.py
@@ -9,7 +9,7 @@ import urllib.parse
 from pathlib import Path
 from typing import Callable, TYPE_CHECKING
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, Signal, Slot
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
     QComboBox,
@@ -34,6 +34,13 @@ from browser_chrome_win import (
     is_windows_default_browser_chrome,
     list_chrome_profiles,
 )
+from page_title_lookup import (
+    LookupRequest,
+    TitleSuggestionController,
+    fetch_page_title,
+)
+
+TitleFetcher = Callable[[str], str | None]
 
 
 def _normalize_url(raw: str) -> str:
@@ -42,6 +49,32 @@ def _normalize_url(raw: str) -> str:
         return ""
     parsed = urllib.parse.urlparse(s)
     return s if parsed.scheme else f"https://{s}"
+
+
+class _TitleLookupSignals(QObject):
+    finished = Signal(int, object)
+
+
+class _TitleLookupRunnable(QRunnable):
+    def __init__(
+        self,
+        request: LookupRequest,
+        fetch_title: TitleFetcher,
+        signals: _TitleLookupSignals,
+    ) -> None:
+        super().__init__()
+        self.generation = request.generation
+        self._url = request.url
+        self._fetch_title = fetch_title
+        self.signals = signals
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            title = self._fetch_title(self._url)
+        except Exception:
+            title = None
+        self.signals.finished.emit(self.generation, title)
 
 
 class TileEditorDialog(QDialog):
@@ -54,6 +87,7 @@ class TileEditorDialog(QDialog):
         browsers: list[str],
         icon_dir: Path,
         fetch_favicon: Callable[[str], Path | None],
+        fetch_title: TitleFetcher = fetch_page_title,
         tile: "Tile | None" = None,
         parent: QWidget | None = None,
     ) -> None:
@@ -61,7 +95,10 @@ class TileEditorDialog(QDialog):
         self.setWindowTitle("Tile")
         self.icon_dir = icon_dir
         self.fetch_favicon = fetch_favicon
+        self.fetch_title = fetch_title
         self._icon_path: str | None = getattr(tile, "icon", None) if tile else None
+        self._title_suggestion = TitleSuggestionController(is_add_dialog=tile is None)
+        self._title_lookup_signals: dict[int, _TitleLookupSignals] = {}
         self.data: dict[str, str | None] | None = None
 
         layout = QVBoxLayout(self)
@@ -145,7 +182,10 @@ class TileEditorDialog(QDialog):
         self._update_ok()
 
         self.name_edit.textChanged.connect(self._update_ok)  # type: ignore[arg-type]
+        self.name_edit.textEdited.connect(self._on_name_edited)  # type: ignore[arg-type]
         self.url_edit.textChanged.connect(self._update_ok)  # type: ignore[arg-type]
+        self.url_edit.textChanged.connect(self._on_url_changed)  # type: ignore[arg-type]
+        self.url_edit.editingFinished.connect(self._on_url_editing_finished)
         self.browser_combo.currentIndexChanged.connect(
             self._refresh_chrome_profile_visibility
         )
@@ -190,6 +230,37 @@ class TileEditorDialog(QDialog):
             self._icon_path = str(result)
             self._update_icon_preview()
 
+    def _on_name_edited(self, _text: str) -> None:
+        self._title_suggestion.name_edited()
+
+    def _on_url_changed(self, _text: str) -> None:
+        decision = self._title_suggestion.url_changed(self.name_edit.text())
+        if decision.clear_name:
+            self.name_edit.clear()
+
+    def _on_url_editing_finished(self) -> None:
+        request = self._title_suggestion.begin_lookup(self.url_edit.text())
+        if request is None:
+            return
+        signals = _TitleLookupSignals()
+        signals.finished.connect(
+            self._on_title_lookup_finished,
+            Qt.ConnectionType.QueuedConnection,
+        )
+        self._title_lookup_signals[request.generation] = signals
+        runnable = _TitleLookupRunnable(request, self.fetch_title, signals)
+        QThreadPool.globalInstance().start(runnable)
+
+    @Slot(int, object)
+    def _on_title_lookup_finished(self, generation: int, title: object) -> None:
+        self._title_lookup_signals.pop(generation, None)
+        result = title if isinstance(title, str) else None
+        decision = self._title_suggestion.apply_result(
+            generation, result, self.name_edit.text()
+        )
+        if decision.title is not None:
+            self.name_edit.setText(decision.title)
+
     def _is_effective_browser_chrome(self) -> bool:
         """Return True if the dialog's browser selection resolves to Chrome."""
         sel = self.browser_combo.currentText()
@@ -204,6 +275,10 @@ class TileEditorDialog(QDialog):
         is_chrome = self._is_effective_browser_chrome()
         self.chromeProfileLabel.setVisible(is_chrome)
         self.chromeProfileCombo.setVisible(is_chrome)
+
+    def done(self, result: int) -> None:  # noqa: D401
+        self._title_suggestion.deactivate()
+        super().done(result)
 
     def accept(self) -> None:  # noqa: D401
         name = self.name_edit.text().strip()

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -1192,7 +1192,6 @@ class Main(QMainWindow):
         sanitized_command = sanitize_launch_command(plan.command)
         record_breadcrumb(
             "launch_attempt",
-            name=tile.name,
             url=url,
             browser=plan.browser_name or "default",
             open_target=plan.open_target,
@@ -1499,7 +1498,6 @@ class Main(QMainWindow):
             self._set_current_tab_by_name(cast(str, data["tab"]))
             record_breadcrumb(
                 "tile_add",
-                name=cast(str, data["name"]),
                 url=sanitize_url(cast(str, data["url"])),
                 tab=cast(str, data["tab"]),
             )


### PR DESCRIPTION
## Summary

- Suggest the destination page's static HTML title when adding a new URL tile.
- Preserve manual names, ignore stale lookup results, and allow untouched automatic suggestions to be replaced when the URL changes.
- Perform bounded asynchronous HTTP/HTTPS lookup without blocking the Qt UI thread.
- Keep Edit Tile, favicon retrieval, URL launching, dependencies, and packaging behavior unchanged.
- Remove tile names from relevant diagnostic breadcrumbs and document the new network/privacy behavior.

## Network and privacy

- Accepts only HTTP/HTTPS URLs without embedded credentials.
- Uses verified TLS, bounded timeouts, five redirects, and a 256 KiB read limit.
- Requests only the top-level HTML/XHTML document and loads no subresources.
- Sends no cookies, authentication headers, browser profiles, or saved credentials.
- Executes no JavaScript and fails silently.
- Does not log full URLs, query strings, retrieved titles, or page content.

## Testing

All required local gates passed:

- `make format-check`
- `make lint`
- `make lint_tests`
- `.venv/Scripts/python.exe -m ruff check tests`
- `make typecheck`
- `make test_unit` — passed at 100%
- `git diff --check`

Unit tests are hermetic and use fake network responses and an injected thread pool; they do not contact real websites.

Manual Windows GUI checks passed:

- Automatic title suggestion
- Replacement after changing the URL
- Protection of names edited before or during lookup
- Edit Tile remains unchanged
- Silent network failure
- Closing the dialog prevents late UI updates

Manual compatibility checks:

- Populated: Python.org, Wikipedia, Online Python
- Gracefully left blank: CNN, Visual Studio Marketplace, Facebook

The blank cases produced no modal errors and remain consistent with bounded, static-HTML-only best-effort behavior.

Closes #89
