### PR TITLE
Allow tabs to be reordered by drag and drop

### DIFF
--- a/tab_order.py
+++ b/tab_order.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+TabIdFactory = Callable[[], str]
+
+
+@dataclass(frozen=True, slots=True)
+class TabOrderState:
+    """Normalized tab titles, stable identifiers, and canonical full order."""
+
+    tabs: list[str]
+    tab_ids: dict[str, str]
+    tab_order: list[str]
+
+
+def new_tab_id() -> str:
+    """Return a new stable identifier suitable for persisted tab state."""
+
+    return str(uuid4())
+
+
+def _canonical_tab_id(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return str(UUID(value))
+    except ValueError:
+        return None
+
+
+def _new_unique_tab_id(blocked_ids: set[str], id_factory: TabIdFactory) -> str:
+    while True:
+        candidate = _canonical_tab_id(id_factory())
+        if candidate is not None and candidate not in blocked_ids:
+            return candidate
+
+
+def _reserved_saved_ids(raw_tab_ids: object, raw_tab_order: object) -> set[str]:
+    reserved: set[str] = set()
+    if isinstance(raw_tab_ids, dict):
+        for value in raw_tab_ids.values():
+            candidate = _canonical_tab_id(value)
+            if candidate is not None:
+                reserved.add(candidate)
+    if isinstance(raw_tab_order, list):
+        for value in raw_tab_order:
+            candidate = _canonical_tab_id(value)
+            if candidate is not None:
+                reserved.add(candidate)
+    return reserved
+
+
+def normalize_tab_order(
+    tabs: Sequence[str],
+    raw_tab_ids: object,
+    raw_tab_order: object,
+    id_factory: TabIdFactory = new_tab_id,
+) -> TabOrderState:
+    """Normalize persisted tab identity and ordering data without losing tabs.
+
+    Existing valid identifiers are retained. Missing, malformed, or duplicate
+    identifiers are replaced, and unknown order entries are discarded. Any known
+    identifiers omitted from the saved order are appended in the input tab order.
+    """
+
+    clean_tabs: list[str] = []
+    seen_titles: set[str] = set()
+    for title in tabs:
+        if isinstance(title, str) and title not in seen_titles:
+            clean_tabs.append(title)
+            seen_titles.add(title)
+
+    saved_ids = raw_tab_ids if isinstance(raw_tab_ids, dict) else {}
+    reserved_ids = _reserved_saved_ids(raw_tab_ids, raw_tab_order)
+    used_ids: set[str] = set()
+    tab_ids: dict[str, str] = {}
+    for title in clean_tabs:
+        candidate = _canonical_tab_id(saved_ids.get(title))
+        if candidate is None or candidate in used_ids:
+            candidate = _new_unique_tab_id(reserved_ids | used_ids, id_factory)
+        tab_ids[title] = candidate
+        used_ids.add(candidate)
+
+    title_by_id = {tab_id: title for title, tab_id in tab_ids.items()}
+    tab_order: list[str] = []
+    seen_order_ids: set[str] = set()
+    if isinstance(raw_tab_order, list):
+        for raw_id in raw_tab_order:
+            tab_id = _canonical_tab_id(raw_id)
+            if (
+                tab_id is not None
+                and tab_id in title_by_id
+                and tab_id not in seen_order_ids
+            ):
+                tab_order.append(tab_id)
+                seen_order_ids.add(tab_id)
+
+    for title in clean_tabs:
+        tab_id = tab_ids[title]
+        if tab_id not in seen_order_ids:
+            tab_order.append(tab_id)
+            seen_order_ids.add(tab_id)
+
+    ordered_tabs = [title_by_id[tab_id] for tab_id in tab_order]
+    ordered_tab_ids = {title: tab_ids[title] for title in ordered_tabs}
+    return TabOrderState(ordered_tabs, ordered_tab_ids, tab_order)
+
+
+def rename_tab(state: TabOrderState, old_title: str, new_title: str) -> TabOrderState:
+    """Rename a tab without changing its stable identifier or position."""
+
+    if old_title not in state.tab_ids or new_title in state.tab_ids:
+        return state
+
+    tabs = [new_title if title == old_title else title for title in state.tabs]
+    tab_ids = {
+        new_title if title == old_title else title: tab_id
+        for title, tab_id in state.tab_ids.items()
+    }
+    return TabOrderState(tabs, tab_ids, list(state.tab_order))
+
+
+def add_tab(
+    state: TabOrderState,
+    title: str,
+    id_factory: TabIdFactory = new_tab_id,
+) -> TabOrderState:
+    """Append a newly identified tab to the canonical full order."""
+
+    if title in state.tab_ids:
+        return state
+
+    used_ids = set(state.tab_ids.values()) | set(state.tab_order)
+    tab_id = _new_unique_tab_id(used_ids, id_factory)
+    return TabOrderState(
+        [*state.tabs, title],
+        {**state.tab_ids, title: tab_id},
+        [*state.tab_order, tab_id],
+    )
+
+
+def delete_tab(state: TabOrderState, title: str) -> TabOrderState:
+    """Remove a tab and every occurrence of its identifier from the order."""
+
+    tab_id = state.tab_ids.get(title)
+    if tab_id is None:
+        return state
+
+    return TabOrderState(
+        [existing for existing in state.tabs if existing != title],
+        {
+            existing: existing_id
+            for existing, existing_id in state.tab_ids.items()
+            if existing != title
+        },
+        [existing_id for existing_id in state.tab_order if existing_id != tab_id],
+    )
+
+
+def _is_canonical_unique_id_sequence(values: Sequence[object]) -> bool:
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str) or _canonical_tab_id(value) != value:
+            return False
+        if value in seen:
+            return False
+        seen.add(value)
+    return True
+
+
+def move_visible_tab(
+    full_order: Sequence[str],
+    hidden_ids: Sequence[object],
+    from_index: int,
+    to_index: int,
+    visible_ids_after: Sequence[object],
+) -> list[str]:
+    """Apply a validated visible-tab move to the canonical full order.
+
+    ``visible_ids_after`` is the QTabBar data read after ``tabMoved`` fires. It
+    must exactly match the move described by the signal. Invalid or inconsistent
+    inputs return an unchanged copy of ``full_order``.
+    """
+
+    unchanged = list(full_order)
+    full_values: list[object] = list(full_order)
+    if not _is_canonical_unique_id_sequence(full_values):
+        return unchanged
+    if not _is_canonical_unique_id_sequence(hidden_ids):
+        return unchanged
+
+    full_ids = set(full_order)
+    hidden = set(hidden_ids)
+    if not hidden.issubset(full_ids):
+        return unchanged
+
+    visible_before = [tab_id for tab_id in full_order if tab_id not in hidden]
+    if (
+        type(from_index) is not int
+        or type(to_index) is not int
+        or from_index == to_index
+        or not 0 <= from_index < len(visible_before)
+        or not 0 <= to_index < len(visible_before)
+    ):
+        return unchanged
+
+    if not _is_canonical_unique_id_sequence(visible_ids_after):
+        return unchanged
+    actual_after = list(visible_ids_after)
+    expected_after = list(visible_before)
+    moved_id = expected_after.pop(from_index)
+    expected_after.insert(to_index, moved_id)
+    if actual_after != expected_after:
+        return unchanged
+
+    remaining_order = [tab_id for tab_id in full_order if tab_id != moved_id]
+    destination_id = visible_before[to_index]
+    insertion_index = remaining_order.index(destination_id)
+    if from_index < to_index:
+        insertion_index += 1
+    remaining_order.insert(insertion_index, moved_id)
+    return remaining_order

--- a/tests/unit/test_tab_order.py
+++ b/tests/unit/test_tab_order.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import pytest
+
+from tab_order import (
+    TabOrderState,
+    add_tab,
+    delete_tab,
+    move_visible_tab,
+    normalize_tab_order,
+    rename_tab,
+)
+
+A_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+B_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+C_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+D_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+H_ID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+OBSOLETE_ID = "11111111-1111-4111-8111-111111111111"
+UNKNOWN_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _id_factory(values: list[str]) -> Callable[[], str]:
+    identifiers = iter(values)
+    return lambda: next(identifiers)
+
+
+@pytest.mark.unit
+def test_legacy_migration_preserves_existing_tab_order() -> None:
+    state = normalize_tab_order(
+        ["Main", "Work", "Personal"],
+        None,
+        None,
+        _id_factory([A_ID, B_ID, C_ID]),
+    )
+
+    assert state.tabs == ["Main", "Work", "Personal"]
+    assert state.tab_ids == {"Main": A_ID, "Work": B_ID, "Personal": C_ID}
+    assert state.tab_order == [A_ID, B_ID, C_ID]
+
+
+@pytest.mark.unit
+def test_saved_order_uses_identifiers_and_reorders_titles() -> None:
+    state = normalize_tab_order(
+        ["Main", "Renamed Work"],
+        {"Main": A_ID.upper(), "Renamed Work": B_ID},
+        [B_ID, A_ID.upper()],
+    )
+
+    assert state.tabs == ["Renamed Work", "Main"]
+    assert state.tab_ids == {"Renamed Work": B_ID, "Main": A_ID}
+    assert state.tab_order == [B_ID, A_ID]
+
+
+@pytest.mark.unit
+def test_normalized_persistence_fields_round_trip_through_json() -> None:
+    state = normalize_tab_order(
+        ["Main", "Work"],
+        {"Main": A_ID, "Work": B_ID},
+        [B_ID, A_ID],
+    )
+    payload = json.loads(
+        json.dumps({"tab_ids": state.tab_ids, "tab_order": state.tab_order})
+    )
+
+    reloaded = normalize_tab_order(
+        state.tabs,
+        payload["tab_ids"],
+        payload["tab_order"],
+    )
+
+    assert reloaded == state
+
+
+@pytest.mark.unit
+def test_partial_and_malformed_saved_data_is_safely_normalized() -> None:
+    state = normalize_tab_order(
+        ["A", "B", "C", "D"],
+        {
+            "A": A_ID,
+            "B": A_ID,
+            "C": C_ID,
+            "D": "not-a-uuid",
+            "Obsolete": OBSOLETE_ID,
+        },
+        [None, C_ID, UNKNOWN_ID, A_ID, C_ID, "not-a-uuid", 42],
+        _id_factory([A_ID, OBSOLETE_ID, B_ID, C_ID, D_ID]),
+    )
+
+    assert state.tabs == ["C", "A", "B", "D"]
+    assert state.tab_ids == {"C": C_ID, "A": A_ID, "B": B_ID, "D": D_ID}
+    assert state.tab_order == [C_ID, A_ID, B_ID, D_ID]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw_tab_ids", "raw_tab_order"),
+    [
+        ([A_ID], [A_ID]),
+        ({"A": A_ID}, "not-a-list"),
+        ("not-a-mapping", {"not": "a-list"}),
+    ],
+)
+def test_malformed_top_level_saved_data_falls_back_to_current_order(
+    raw_tab_ids: object, raw_tab_order: object
+) -> None:
+    state = normalize_tab_order(
+        ["A", "B"],
+        raw_tab_ids,
+        raw_tab_order,
+        _id_factory([B_ID, C_ID]),
+    )
+
+    assert state.tabs == ["A", "B"]
+    assert state.tab_order == list(state.tab_ids.values())
+
+
+@pytest.mark.unit
+def test_rename_transfers_identifier_without_moving_tab() -> None:
+    state = TabOrderState(
+        tabs=["B", "A"],
+        tab_ids={"B": B_ID, "A": A_ID},
+        tab_order=[B_ID, A_ID],
+    )
+
+    renamed = rename_tab(state, "A", "Renamed A")
+
+    assert renamed.tabs == ["B", "Renamed A"]
+    assert renamed.tab_ids == {"B": B_ID, "Renamed A": A_ID}
+    assert renamed.tab_order == [B_ID, A_ID]
+
+
+@pytest.mark.unit
+def test_add_appends_unique_identifier_after_factory_collision() -> None:
+    state = TabOrderState(["A"], {"A": A_ID}, [A_ID])
+
+    added = add_tab(state, "B", _id_factory([A_ID, B_ID]))
+
+    assert added.tabs == ["A", "B"]
+    assert added.tab_ids == {"A": A_ID, "B": B_ID}
+    assert added.tab_order == [A_ID, B_ID]
+
+
+@pytest.mark.unit
+def test_delete_removes_identifier_and_all_order_occurrences() -> None:
+    state = TabOrderState(
+        ["A", "B", "C"],
+        {"A": A_ID, "B": B_ID, "C": C_ID},
+        [A_ID, B_ID, B_ID, C_ID],
+    )
+
+    deleted = delete_tab(state, "B")
+
+    assert deleted.tabs == ["A", "C"]
+    assert deleted.tab_ids == {"A": A_ID, "C": C_ID}
+    assert deleted.tab_order == [A_ID, C_ID]
+
+
+@pytest.mark.unit
+def test_move_visible_tab_to_front_across_hidden_tab() -> None:
+    moved = move_visible_tab(
+        [A_ID, H_ID, B_ID, C_ID],
+        [H_ID],
+        2,
+        0,
+        [C_ID, A_ID, B_ID],
+    )
+
+    assert moved == [C_ID, A_ID, H_ID, B_ID]
+
+
+@pytest.mark.unit
+def test_move_visible_tab_to_back_across_hidden_tab() -> None:
+    moved = move_visible_tab(
+        [A_ID, H_ID, B_ID, C_ID],
+        [H_ID],
+        0,
+        2,
+        [B_ID, C_ID, A_ID],
+    )
+
+    assert moved == [H_ID, B_ID, C_ID, A_ID]
+
+
+@pytest.mark.unit
+def test_move_visible_tab_left_keeps_hidden_tab_before_destination() -> None:
+    moved = move_visible_tab(
+        [A_ID, H_ID, B_ID, C_ID],
+        [H_ID],
+        2,
+        1,
+        [A_ID, C_ID, B_ID],
+    )
+
+    assert moved == [A_ID, H_ID, C_ID, B_ID]
+
+
+@pytest.mark.unit
+def test_move_visible_tab_right_keeps_hidden_tab_with_non_dragged_tabs() -> None:
+    moved = move_visible_tab(
+        [A_ID, H_ID, B_ID, C_ID],
+        [H_ID],
+        0,
+        1,
+        [B_ID, A_ID, C_ID],
+    )
+
+    assert moved == [H_ID, B_ID, A_ID, C_ID]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("full_order", "hidden_ids", "from_index", "to_index", "visible_after"),
+    [
+        ([A_ID, H_ID, B_ID], [H_ID], -1, 1, [B_ID, A_ID]),
+        ([A_ID, H_ID, B_ID], [H_ID], 0, 2, [B_ID, A_ID]),
+        ([A_ID, H_ID, B_ID], [H_ID], 0, 0, [A_ID, B_ID]),
+        ([A_ID, H_ID, B_ID], [H_ID], 0, 1, [A_ID, B_ID]),
+        ([A_ID, H_ID, B_ID], [H_ID], 0, 1, [B_ID, B_ID]),
+        ([A_ID, H_ID, B_ID], [H_ID], 0, 1, [B_ID, None]),
+        ([A_ID, H_ID, B_ID], [UNKNOWN_ID], 0, 1, [B_ID, A_ID]),
+        ([A_ID, H_ID, B_ID], [H_ID, H_ID], 0, 1, [B_ID, A_ID]),
+        ([A_ID, A_ID, B_ID], [], 0, 1, [B_ID, A_ID, A_ID]),
+        (["not-a-uuid", B_ID], [], 0, 1, [B_ID, "not-a-uuid"]),
+    ],
+)
+def test_invalid_or_inconsistent_move_is_safe_no_op(
+    full_order: list[str],
+    hidden_ids: list[object],
+    from_index: int,
+    to_index: int,
+    visible_after: list[object],
+) -> None:
+    original = list(full_order)
+
+    moved = move_visible_tab(
+        full_order, hidden_ids, from_index, to_index, visible_after
+    )
+
+    assert moved == original
+    assert full_order == original

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -77,6 +77,14 @@ from debug_scaffold import (
     sanitize_url,
 )
 from tile_editor_dialog import TileEditorDialog
+from tab_order import (
+    TabOrderState,
+    add_tab as add_tab_to_order,
+    delete_tab as delete_tab_from_order,
+    move_visible_tab,
+    normalize_tab_order,
+    rename_tab as rename_tab_in_order,
+)
 from browser_chrome_win import (
     is_windows_default_browser_chrome,
     is_chrome_path,
@@ -261,6 +269,8 @@ class LauncherConfig:
     tiles: list["Tile"] = field(default_factory=list)
     tabs: list[str] = field(default_factory=lambda: ["Main"])
     hidden_tabs: list[str] = field(default_factory=list)
+    tab_ids: dict[str, str] = field(default_factory=dict)
+    tab_order: list[str] = field(default_factory=list)
     auto_fit: bool = True
     window_x: Optional[int] = None
     window_y: Optional[int] = None
@@ -294,7 +304,11 @@ class LauncherConfig:
                 window_w=data.get("window_w"),
                 window_h=data.get("window_h"),
             )
-            enforce_tab_invariants(cfg)
+            enforce_tab_invariants(
+                cfg,
+                raw_tab_ids=data.get("tab_ids"),
+                raw_tab_order=data.get("tab_order"),
+            )
             return cfg
         # first run – create a friendly default
         cfg = LauncherConfig(
@@ -313,7 +327,8 @@ class LauncherConfig:
         cfg.save()
         return cfg
 
-    def save(self):
+    def save(self) -> None:
+        enforce_tab_invariants(self)
         tiles = []
         for t in self.tiles:
             d = asdict(t)
@@ -326,6 +341,8 @@ class LauncherConfig:
             "tiles": tiles,
             "tabs": self.tabs,
             "hidden_tabs": self.hidden_tabs,
+            "tab_ids": self.tab_ids,
+            "tab_order": self.tab_order,
             "auto_fit": self.auto_fit,
             "window_x": self.window_x,
             "window_y": self.window_y,
@@ -335,10 +352,30 @@ class LauncherConfig:
         CFG_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
-def enforce_tab_invariants(cfg: LauncherConfig) -> None:
+def _tab_order_state(cfg: LauncherConfig) -> TabOrderState:
+    return TabOrderState(
+        tabs=list(cfg.tabs),
+        tab_ids=dict(cfg.tab_ids),
+        tab_order=list(cfg.tab_order),
+    )
+
+
+def _apply_tab_order_state(cfg: LauncherConfig, state: TabOrderState) -> None:
+    cfg.tabs = state.tabs
+    cfg.tab_ids = state.tab_ids
+    cfg.tab_order = state.tab_order
+
+
+def enforce_tab_invariants(
+    cfg: LauncherConfig,
+    *,
+    raw_tab_ids: object | None = None,
+    raw_tab_order: object | None = None,
+) -> None:
     """Ensure tab-related invariants for a configuration.
 
     - ``cfg.tabs`` is a de-duplicated, non-empty list of strings.
+    - Each tab has one stable ID in a canonical full-tab order.
     - ``cfg.hidden_tabs`` is a subset of ``cfg.tabs`` and does not hide all tabs.
     - Every tile's ``tab`` exists in ``cfg.tabs``; invalid entries are remapped to
       the first tab.
@@ -350,7 +387,13 @@ def enforce_tab_invariants(cfg: LauncherConfig) -> None:
             clean_tabs.append(t)
     if not clean_tabs:
         clean_tabs = ["Main"]
-    cfg.tabs = clean_tabs
+
+    state = normalize_tab_order(
+        clean_tabs,
+        cfg.tab_ids if raw_tab_ids is None else raw_tab_ids,
+        cfg.tab_order if raw_tab_order is None else raw_tab_order,
+    )
+    _apply_tab_order_state(cfg, state)
 
     first_tab = cfg.tabs[0]
     valid_tabs = set(cfg.tabs)
@@ -905,6 +948,8 @@ class Main(QMainWindow):
         debug_menu.addAction("Qt Warning", lambda: qWarning("test"))
 
         self.tabs_widget = QTabWidget()
+        self.tabs_widget.setMovable(True)
+        self.tabs_widget.tabBar().tabMoved.connect(self._on_tab_moved)
         self.tabs_widget.currentChanged.connect(
             lambda _=0: QTimer.singleShot(
                 0, lambda: self.resize_to_fit_tiles(snap_window=self.cfg.auto_fit)
@@ -932,6 +977,30 @@ class Main(QMainWindow):
 
     def _enforce_tab_invariants(self) -> None:
         enforce_tab_invariants(self.cfg)
+
+    def _on_tab_moved(self, from_index: int, to_index: int) -> None:
+        tab_bar = self.tabs_widget.tabBar()
+        visible_ids_after = [tab_bar.tabData(index) for index in range(tab_bar.count())]
+        hidden_ids = [self.cfg.tab_ids.get(title) for title in self.cfg.hidden_tabs]
+        updated_order = move_visible_tab(
+            self.cfg.tab_order,
+            hidden_ids,
+            from_index,
+            to_index,
+            visible_ids_after,
+        )
+        if updated_order == self.cfg.tab_order:
+            return
+
+        state = normalize_tab_order(
+            self.cfg.tabs,
+            self.cfg.tab_ids,
+            updated_order,
+        )
+        if state.tab_ids != self.cfg.tab_ids or state.tab_order != updated_order:
+            return
+        _apply_tab_order_state(self.cfg, state)
+        self.cfg.save()
 
     def _set_current_tab_by_name(self, name: str) -> None:
         vis = self._visible_tabs()
@@ -967,6 +1036,7 @@ class Main(QMainWindow):
         self.tabs_widget.clear()
         self._grids: dict[str, QGridLayout] = {}
         self._tab_viewports.clear()
+        tab_bar = self.tabs_widget.tabBar()
         for tab in self._visible_tabs():
             scroll = QScrollArea()
             scroll.setWidgetResizable(True)
@@ -976,7 +1046,8 @@ class Main(QMainWindow):
             grid.setContentsMargins(16, 16, 16, 16)
             scroll.setWidget(container)
             self._wire_tab_whitespace_menu(scroll)
-            self.tabs_widget.addTab(scroll, tab)
+            tab_index = self.tabs_widget.addTab(scroll, tab)
+            tab_bar.setTabData(tab_index, self.cfg.tab_ids[tab])
             self._grids[tab] = grid
             self._populate_tab(tab)
         QTimer.singleShot(
@@ -1561,7 +1632,8 @@ class Main(QMainWindow):
                 self, "Tab exists", "A tab with that name exists already."
             )
             return
-        self.cfg.tabs.append(name)
+        state = add_tab_to_order(_tab_order_state(self.cfg), name)
+        _apply_tab_order_state(self.cfg, state)
         self._enforce_tab_invariants()
         self.cfg.save()
         self.rebuild()
@@ -1578,8 +1650,8 @@ class Main(QMainWindow):
                 self, "Tab exists", "A tab with that name exists already."
             )
             return
-        idx = self.cfg.tabs.index(current)
-        self.cfg.tabs[idx] = name
+        state = rename_tab_in_order(_tab_order_state(self.cfg), current, name)
+        _apply_tab_order_state(self.cfg, state)
         for t in self.cfg.tiles:
             if t.tab == current:
                 t.tab = name
@@ -1608,7 +1680,8 @@ class Main(QMainWindow):
         )
         if ok != QMessageBox.StandardButton.Yes:
             return
-        self.cfg.tabs = [t for t in self.cfg.tabs if t != current]
+        state = delete_tab_from_order(_tab_order_state(self.cfg), current)
+        _apply_tab_order_state(self.cfg, state)
         self.cfg.tiles = [t for t in self.cfg.tiles if t.tab != current]
         self.cfg.hidden_tabs = [t for t in self.cfg.hidden_tabs if t != current]
         self._enforce_tab_invariants()


### PR DESCRIPTION
## Summary

- Enable native browser-like drag-and-drop reordering for visible tab headers
- Persist one canonical tab order using stable UUIDs, including hidden tabs
- Preserve legacy configurations and safely normalize incomplete or malformed ordering data
- Keep tab identity synchronized across add, rename, and delete operations
- Add focused Qt-free unit coverage for migration, ordering, hidden tabs, and invalid inputs
- No changes to tile dragging, network behavior, privacy behavior, packaging, or release workflows

## Evidence

- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed
- `git diff --check` passed

## Manual Windows GUI evidence

- Tab headers could be grabbed, dragged, and dropped in both directions
- The selected tab remained selected while moving
- Tab headers remained paired with their correct tile contents
- Renaming a reordered tab preserved its position
- Hiding and restoring another tab did not lose or duplicate tabs
- Reordered tabs persisted after closing and reopening the application
- A newly added, reordered, renamed, and deleted temporary tab behaved correctly
- No visible rebuild, page mismatch, or application error was observed

Closes #94
