### PR TITLE
feat: refresh selected tile names and icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### App Behavior
+- Add active-tab tile selection with a selected count, Select all, Clear selection, and Done
+  controls while preventing tile launches, context-menu changes, and dragging during selection.
+- Refresh selected tile names and icons only after overwrite confirmation; title and favicon
+  results apply independently, failed lookups retain their existing fields, and successful
+  changes are prepared in a detached configuration that is saved atomically before the live
+  model is swapped.
+
+### Security/Privacy
+- Disclose that an explicitly confirmed refresh attempts to contact each selected destination for
+  its title and, when a host/domain can be derived, attempts to send that host/domain to Google's
+  favicon service; URL import review remains offline.
+- Keep refresh diagnostics privacy-safe by recording aggregate counts and categories rather than
+  URLs, domains, names, retrieved titles, icon paths, page content, or sensitive exception details.
+
 ## v0.3.5 - 2026-06-17
 
 ### Security/Privacy

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Review/Approval for release signing: 108thecitizen
 External pull requests are reviewed before merge; only tagged builds from `main` are submitted for release signing.
 
 **Privacy**  
-DesktopTileLauncher does not collect telemetry. Network access is limited to user-initiated actions: opening a tile URL in your browser, adding or editing a URL tile may fetch a site icon through Google's favicon service, and completing URL entry while adding a new tile may make a best-effort request to that destination page to suggest the static page title. The title lookup contacts the destination directly, requests only the top-level document, follows normal redirects, uses the response only when it is HTML/XHTML, executes no JavaScript, loads no subresources, sends no browser cookies or saved credentials, and fails silently. Full URLs, query strings, retrieved titles, and page content are not written to diagnostics. The favicon lookup may make a third-party network request and may send the tile's domain/host to the favicon service. See [Debugging & Crash Reports](#debugging--crash-reports) for local log locations.
+DesktopTileLauncher does not collect telemetry. Network access is limited to user-initiated actions: opening a tile URL in your browser, adding or editing a URL tile may fetch a site icon through Google's favicon service, and completing URL entry while adding a new tile may make a best-effort request to that destination page to suggest the static page title. Explicitly refreshing selected tiles also attempts to contact each selected destination directly for a title and, when a host/domain can be derived, attempts to send that host/domain to Google's favicon service. The title lookup contacts the destination directly, requests only the top-level document, follows normal redirects, uses the response only when it is HTML/XHTML, executes no JavaScript, loads no subresources, sends no browser cookies or saved credentials, and fails silently. Full URLs, query strings, domains, tile names, retrieved titles, icon paths, and page content are not written to refresh diagnostics; only aggregate counts and result categories are recorded. The favicon lookup may make a third-party network request and may send the tile's domain/host to the favicon service. See [Debugging & Crash Reports](#debugging--crash-reports) for local log locations.
 
 **Uninstall**  
 Delete the application folder. Optionally remove per‑user logs/config in the directories listed in the README.
@@ -137,6 +137,41 @@ added and the reviewed list remains available for another attempt. Import accept
 HTTP and HTTPS URLs only and limits a review to 500 nonblank rows and 1 MiB of
 UTF-8 text.
 
+### Refresh tile names and icons
+
+Open the tab you want to work in and choose **Select tiles**. Click individual
+tiles to select a subset, or choose **Select all** to select every tile in the
+active tab. Persistent check indicators and selected styling show the current
+selection, and the selection controls display its count. **Clear selection**
+keeps selection mode open with no tiles selected; **Done** exits selection mode.
+Switching tabs also clears the selection and exits selection mode.
+
+With at least one tile selected, choose **Refresh names and icons**. Before any
+lookup starts, the launcher shows a confirmation with the selected tile count
+and warns that successfully retrieved names and icons replace existing custom
+values. The safe default is to decline. Declining leaves the selection intact
+and performs no lookup, file write, model change, or configuration save.
+
+After confirmation, the launcher uses each selected tile's current URL to look
+up the page title and favicon independently. A retrieved title replaces that
+tile's name, and a retrieved favicon replaces its icon. If either individual
+lookup fails, that existing field is retained exactly; failure of one lookup
+does not prevent the other result from being used. Selection mode prevents URL
+launches, context-menu changes, and tile dragging while selection mode is active.
+When at least one field changes and staging preparation succeeds, the launcher
+attempts one atomic save of a detached configuration. It swaps that configuration
+into the live model and rebuilds the UI only after the save succeeds. A no-change
+result performs no configuration save. Icon staging and configuration persistence
+remain separate filesystem operations.
+
+This explicit refresh is a network action: it attempts to contact each selected
+destination directly for the best-effort page-title request and, when a
+host/domain can be derived, attempts to send that host/domain to Google's
+favicon service. Refresh diagnostics contain aggregate
+counts and result categories only—not URLs, domains, names, retrieved titles,
+icon paths, page content, or exception details that could expose those values.
+The separate **Import URLs** review remains entirely offline as described above.
+
 On Windows, selecting Google Chrome for a tile (or leaving the browser as
 Default when Chrome is the system default) reveals a **Chrome profile**
 dropdown. The list is populated from Chrome's local profile cache and includes
@@ -185,12 +220,16 @@ directory:
 
 Aside from user-initiated URL opens and optional favicon lookups described
 above, adding a URL tile may contact the destination page directly to suggest a
-static page title. That lookup requests only the top-level document, follows
-normal redirects, uses the response only when it is HTML/XHTML, executes no
-JavaScript, loads no subresources, sends no browser cookies or saved
-credentials, fails silently, and does not write full URLs, query strings,
-retrieved titles, or page content to diagnostics. Bulk URL import performs none
-of these lookups and records only aggregate, categorical diagnostics—not URLs,
+static page title. Confirmed refreshes also attempt to contact each selected
+destination for a title and, when a host/domain can be derived, attempt to send
+that host/domain to Google's favicon service. Title lookup requests only the
+top-level document, follows normal
+redirects, uses the response only when it is HTML/XHTML, executes no JavaScript,
+loads no subresources, sends no browser cookies or saved credentials, and fails
+silently. Refresh diagnostics record aggregate counts and result categories
+only—not URLs, query strings, domains, tile names, retrieved titles, icon paths,
+page content, or sensitive exception details. Bulk URL import performs none of
+these lookups and records only aggregate, categorical diagnostics—not URLs,
 tile names, pasted input, or source file paths. The application does not send
 logs or crash data over the network. When something goes wrong, use the *Create
 Crash Bundle* button on the crash dialog to zip the log files and a `crash.json`

--- a/tests/unit/test_tile_metadata_refresh.py
+++ b/tests/unit/test_tile_metadata_refresh.py
@@ -1,0 +1,635 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import gc
+import threading
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+from types import TracebackType
+
+import pytest
+import tile_metadata_refresh
+
+from tile_metadata_refresh import (
+    LookupStatus,
+    OpaqueToken,
+    OperationGuard,
+    RefreshResult,
+    ResolvedMetadata,
+    TileSnapshot,
+    create_batch_staging_directory,
+    fetch_favicon,
+    guess_domain,
+    merge_refresh_result,
+    run_metadata_refresh,
+    select_all_for_active_tab,
+    snapshot_matches,
+    summarize_refresh_results,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FaviconResponse:
+    def __init__(self, body: bytes = b"png-data") -> None:
+        self.body = body
+        self.closed = False
+
+    def read(self) -> bytes:
+        return self.body
+
+    def __enter__(self) -> _FaviconResponse:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.closed = True
+
+
+class _FaviconOpener:
+    def __init__(
+        self,
+        response: _FaviconResponse | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.response = response or _FaviconResponse()
+        self.error = error
+        self.calls: list[tuple[str, float]] = []
+
+    def __call__(self, url: str, *, timeout: float) -> _FaviconResponse:
+        self.calls.append((url, timeout))
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def _snapshot(
+    token: OpaqueToken | None = None,
+    *,
+    url: str = "https://example.test/current?token=private",
+    name: str = "Old custom name",
+    tab: str = "Main",
+    icon: str | None = "C:/private/old-icon.png",
+) -> TileSnapshot:
+    return TileSnapshot(
+        token=token or OpaqueToken(),
+        url=url,
+        name=name,
+        tab=tab,
+        icon=icon,
+        bg="#123456",
+        browser="chrome",
+        chrome_profile="Profile 1",
+        open_target="window",
+    )
+
+
+def _write_icon(url: str, *, output_directory: Path) -> Path:
+    del url
+    icon = output_directory / "icon.png"
+    icon.write_bytes(b"icon")
+    return icon
+
+
+def test_sensitive_records_are_immutable_and_repr_safe(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+    metadata = ResolvedMetadata(
+        title_status=LookupStatus.SUCCESS,
+        favicon_status=LookupStatus.SUCCESS,
+        title="Secret fetched title",
+        icon_path=tmp_path / "private-icon.png",
+    )
+    result = RefreshResult(
+        token=snapshot.token,
+        metadata=metadata,
+        staging_directory=tmp_path / "secret-batch",
+    )
+
+    rendered = repr((snapshot, metadata, result))
+
+    for secret in (
+        snapshot.url,
+        snapshot.name,
+        snapshot.tab,
+        snapshot.icon,
+        "Secret fetched title",
+        "private-icon.png",
+        "secret-batch",
+    ):
+        assert secret is not None
+        assert secret not in rendered
+    with pytest.raises(FrozenInstanceError):
+        snapshot.name = "mutated"  # type: ignore[misc]
+
+
+def test_active_tab_select_all_keeps_value_equal_tiles_distinct() -> None:
+    first = _snapshot(OpaqueToken(), url="https://example.test/same")
+    second = _snapshot(OpaqueToken(), url="https://example.test/same")
+    other = _snapshot(OpaqueToken(), tab="Other")
+
+    selected = select_all_for_active_tab((first, second, other), "Main")
+
+    assert len(selected) == 2
+    assert selected[0] is first.token
+    assert selected[1] is second.token
+
+
+def test_active_tab_select_all_deduplicates_the_same_identity() -> None:
+    snapshot = _snapshot()
+
+    assert select_all_for_active_tab((snapshot, snapshot), "Main") == (snapshot.token,)
+
+
+def test_operation_guard_rejects_duplicate_and_stale_tokens() -> None:
+    guard = OperationGuard()
+    first = OpaqueToken()
+    second = OpaqueToken()
+    first_reference = weakref.ref(first)
+
+    assert guard.start(first)
+    assert guard.active
+    assert guard.is_current(first)
+    assert not guard.start(first)
+    assert not guard.start(second)
+    assert not guard.finish(second)
+    assert guard.finish(first)
+    assert not guard.is_current(first)
+    assert not guard.start(first)
+    del first
+    gc.collect()
+    assert first_reference() is None
+    assert guard.start(second)
+    guard.invalidate()
+    assert not guard.finish(second)
+    assert not guard.active
+    assert not guard.start(second)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "replacement_value"),
+    [
+        pytest.param("token", OpaqueToken(), id="token"),
+        pytest.param("url", "https://example.test/new", id="url"),
+        pytest.param("name", "Changed name", id="name"),
+        pytest.param("tab", "Other", id="tab"),
+        pytest.param("icon", None, id="icon"),
+        pytest.param("bg", "#654321", id="background"),
+        pytest.param("browser", None, id="browser"),
+        pytest.param("chrome_profile", None, id="chrome-profile"),
+        pytest.param("open_target", "tab", id="open-target"),
+    ],
+)
+def test_snapshot_matching_requires_identity_and_every_field(
+    field_name: str,
+    replacement_value: object,
+) -> None:
+    original = _snapshot()
+
+    assert snapshot_matches(original, replace(original))
+    assert not snapshot_matches(
+        original,
+        replace(original, **{field_name: replacement_value}),
+    )
+
+
+def test_favicon_request_preserves_google_domain_size_and_timeout(
+    tmp_path: Path,
+) -> None:
+    response = _FaviconResponse()
+    opener = _FaviconOpener(response)
+
+    icon = fetch_favicon(
+        "https://user@example.test/path",
+        output_directory=tmp_path,
+        opener=opener,
+    )
+
+    assert guess_domain("https://user@example.test:8443/path") == "example.test:8443"
+    assert icon == tmp_path / "example.test_128.png"
+    assert icon.read_bytes() == b"png-data"
+    assert opener.calls == [
+        (
+            "https://www.google.com/s2/favicons?domain=example.test&sz=128",
+            5.0,
+        )
+    ]
+    assert response.closed
+
+
+def test_favicon_failure_is_silent_and_does_not_create_a_file(
+    tmp_path: Path,
+) -> None:
+    opener = _FaviconOpener(error=OSError("sensitive failure"))
+
+    assert (
+        fetch_favicon(
+            "https://example.test/private",
+            output_directory=tmp_path,
+            opener=opener,
+        )
+        is None
+    )
+    assert tuple(tmp_path.iterdir()) == ()
+
+
+def test_favicon_explicit_size_controls_request_and_filename(tmp_path: Path) -> None:
+    opener = _FaviconOpener()
+
+    icon = fetch_favicon(
+        "https://example.test/path",
+        output_directory=tmp_path,
+        size=64,
+        opener=opener,
+    )
+
+    assert icon == tmp_path / "example.test_64.png"
+    assert opener.calls == [
+        (
+            "https://www.google.com/s2/favicons?domain=example.test&sz=64",
+            5.0,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("title_succeeds", "favicon_succeeds", "expected_name", "icon_changed"),
+    [
+        (True, True, "Fetched title", True),
+        (True, False, "Fetched title", False),
+        (False, True, "Old custom name", True),
+        (False, False, "Old custom name", False),
+    ],
+)
+def test_independent_results_and_exact_old_field_retention(
+    tmp_path: Path,
+    title_succeeds: bool,
+    favicon_succeeds: bool,
+    expected_name: str,
+    icon_changed: bool,
+) -> None:
+    snapshot = _snapshot()
+    seen_titles: list[str] = []
+    seen_favicons: list[str] = []
+
+    def title_provider(url: str) -> str | None:
+        seen_titles.append(url)
+        return "Fetched title" if title_succeeds else None
+
+    def favicon_provider(url: str, *, output_directory: Path) -> Path | None:
+        seen_favicons.append(url)
+        if not favicon_succeeds:
+            return None
+        return _write_icon(url, output_directory=output_directory)
+
+    results = run_metadata_refresh(
+        (snapshot,),
+        output_directory=tmp_path / "batch",
+        title_provider=title_provider,
+        favicon_provider=favicon_provider,
+    )
+    merged = merge_refresh_result(snapshot, results[0])
+
+    assert seen_titles == [snapshot.url]
+    assert seen_favicons == [snapshot.url]
+    assert merged.name == expected_name
+    assert merged.name_changed is title_succeeds
+    assert merged.icon_changed is icon_changed
+    if favicon_succeeds:
+        assert merged.icon != snapshot.icon
+    else:
+        assert merged.icon == "C:/private/old-icon.png"
+    assert snapshot.name == "Old custom name"
+    assert snapshot.icon == "C:/private/old-icon.png"
+
+
+def test_both_providers_are_attempted_when_either_raises(tmp_path: Path) -> None:
+    snapshots = (
+        _snapshot(url="https://example.test/title-error"),
+        _snapshot(url="https://example.test/favicon-error"),
+    )
+    title_calls: list[str] = []
+    favicon_calls: list[str] = []
+
+    def title_provider(url: str) -> str | None:
+        title_calls.append(url)
+        if url.endswith("title-error"):
+            raise RuntimeError("private title failure")
+        return "Title"
+
+    def favicon_provider(url: str, *, output_directory: Path) -> Path:
+        favicon_calls.append(url)
+        if url.endswith("favicon-error"):
+            raise ValueError("private favicon failure")
+        return _write_icon(url, output_directory=output_directory)
+
+    results = run_metadata_refresh(
+        snapshots,
+        output_directory=tmp_path / "batch",
+        title_provider=title_provider,
+        favicon_provider=favicon_provider,
+    )
+
+    expected_urls = {snapshot.url for snapshot in snapshots}
+    assert set(title_calls) == expected_urls
+    assert set(favicon_calls) == expected_urls
+    assert len(title_calls) == len(snapshots)
+    assert len(favicon_calls) == len(snapshots)
+    assert results[0].metadata.title_status is LookupStatus.ERROR
+    assert results[0].metadata.favicon_status is LookupStatus.SUCCESS
+    assert results[1].metadata.title_status is LookupStatus.SUCCESS
+    assert results[1].metadata.favicon_status is LookupStatus.ERROR
+
+    title_error_merge = merge_refresh_result(snapshots[0], results[0])
+    assert title_error_merge.name == snapshots[0].name
+    assert not title_error_merge.name_changed
+    assert title_error_merge.icon != snapshots[0].icon
+    assert title_error_merge.icon_changed
+
+    favicon_error_merge = merge_refresh_result(snapshots[1], results[1])
+    assert favicon_error_merge.name == "Title"
+    assert favicon_error_merge.name_changed
+    assert favicon_error_merge.icon == snapshots[1].icon
+    assert not favicon_error_merge.icon_changed
+
+
+def test_results_preserve_input_order_with_distinct_collision_safe_directories(
+    tmp_path: Path,
+) -> None:
+    snapshots = tuple(_snapshot(url="https://example.test/same") for _ in range(3))
+    live_directory = tmp_path / "live"
+    live_directory.mkdir()
+    live_icon = live_directory / "example.test_128.png"
+    live_icon.write_bytes(b"live")
+
+    def favicon_provider(url: str, *, output_directory: Path) -> Path:
+        return fetch_favicon(
+            url,
+            output_directory=output_directory,
+            opener=_FaviconOpener(),
+        ) or Path("missing")
+
+    results = run_metadata_refresh(
+        snapshots,
+        output_directory=tmp_path / "batch",
+        title_provider=lambda _url: None,
+        favicon_provider=favicon_provider,
+    )
+
+    assert [result.token for result in results] == [
+        snapshot.token for snapshot in snapshots
+    ]
+    directories = [result.staging_directory for result in results]
+    assert all(directory is not None for directory in directories)
+    assert len(set(directories)) == len(snapshots)
+    assert live_icon.read_bytes() == b"live"
+    assert all(
+        result.metadata.icon_path is not None
+        and result.metadata.icon_path.parent == result.staging_directory
+        for result in results
+    )
+
+
+def test_default_concurrency_passes_four_workers_to_executor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_executor = tile_metadata_refresh.ThreadPoolExecutor
+    worker_counts: list[int] = []
+
+    def executor_spy(*, max_workers: int) -> ThreadPoolExecutor:
+        worker_counts.append(max_workers)
+        return real_executor(max_workers=max_workers)
+
+    monkeypatch.setattr(tile_metadata_refresh, "ThreadPoolExecutor", executor_spy)
+
+    run_metadata_refresh(
+        (_snapshot(),),
+        output_directory=tmp_path / "batch",
+        title_provider=lambda _url: None,
+        favicon_provider=lambda _url, *, output_directory: None,
+    )
+
+    assert worker_counts == [4]
+
+
+@pytest.mark.parametrize("workers", [0, 5, True, 1.5, float("nan")])
+def test_worker_count_must_be_between_one_and_four(
+    tmp_path: Path, workers: int
+) -> None:
+    with pytest.raises(ValueError, match="1 through 4"):
+        run_metadata_refresh((), output_directory=tmp_path, max_workers=workers)
+
+
+def test_precancelled_batch_runs_no_provider_and_creates_no_staging(
+    tmp_path: Path,
+) -> None:
+    cancellation = threading.Event()
+    cancellation.set()
+    calls: list[str] = []
+    batch = tmp_path / "batch"
+
+    def title_provider(url: str) -> None:
+        calls.append(url)
+        return None
+
+    results = run_metadata_refresh(
+        (_snapshot(),),
+        output_directory=batch,
+        title_provider=title_provider,
+        favicon_provider=lambda _url, *, output_directory: None,
+        cancellation=cancellation,
+    )
+
+    assert calls == []
+    assert not batch.exists()
+    assert results[0].cancelled
+
+
+def test_cancellation_between_providers_prevents_favicon_lookup(
+    tmp_path: Path,
+) -> None:
+    cancellation = threading.Event()
+    favicon_calls: list[str] = []
+
+    def title_provider(_url: str) -> str:
+        cancellation.set()
+        return "Discarded title"
+
+    def favicon_provider(url: str, *, output_directory: Path) -> None:
+        del output_directory
+        favicon_calls.append(url)
+        return None
+
+    result = run_metadata_refresh(
+        (_snapshot(),),
+        output_directory=tmp_path / "batch",
+        title_provider=title_provider,
+        favicon_provider=favicon_provider,
+        cancellation=cancellation,
+    )[0]
+
+    assert favicon_calls == []
+    assert result.cancelled
+    assert result.metadata.favicon_status is LookupStatus.CANCELLED
+
+
+def test_cancellation_during_staging_failure_starts_no_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancellation = threading.Event()
+    calls: list[str] = []
+
+    def fail_staging(*, prefix: str, dir: Path) -> str:
+        del prefix, dir
+        cancellation.set()
+        raise OSError("private staging failure")
+
+    def title_provider(url: str) -> None:
+        calls.append(url)
+        return None
+
+    monkeypatch.setattr(
+        "tile_metadata_refresh.tempfile.mkdtemp",
+        fail_staging,
+    )
+    result = run_metadata_refresh(
+        (_snapshot(),),
+        output_directory=tmp_path / "batch",
+        title_provider=title_provider,
+        favicon_provider=lambda _url, *, output_directory: None,
+        cancellation=cancellation,
+    )[0]
+
+    assert calls == []
+    assert result.cancelled
+
+
+def test_duplicate_snapshot_token_is_rejected(tmp_path: Path) -> None:
+    first = _snapshot()
+    duplicate = replace(first, url="https://example.test/other")
+
+    with pytest.raises(ValueError, match="duplicate token"):
+        run_metadata_refresh((first, duplicate), output_directory=tmp_path / "batch")
+
+
+def test_provider_cannot_return_an_icon_outside_its_target_directory(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "live-icon.png"
+    outside.write_bytes(b"live")
+
+    result = run_metadata_refresh(
+        (_snapshot(),),
+        output_directory=tmp_path / "batch",
+        title_provider=lambda _url: None,
+        favicon_provider=lambda _url, *, output_directory: outside,
+    )[0]
+
+    assert result.metadata.favicon_status is LookupStatus.ERROR
+    assert result.metadata.icon_path is None
+    assert result.metadata.favicon_error_type == "UnsafeStagingPath"
+
+
+def test_provider_symlink_is_rejected_before_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_path = Path("provider-returned-symlink.png")
+    original_is_symlink = Path.is_symlink
+    original_resolve = Path.resolve
+    provider_path_resolved = False
+
+    def is_symlink(path: Path) -> bool:
+        if path == provider_path:
+            return True
+        return original_is_symlink(path)
+
+    def resolve(path: Path, strict: bool = False) -> Path:
+        nonlocal provider_path_resolved
+        if path == provider_path:
+            provider_path_resolved = True
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "is_symlink", is_symlink)
+    monkeypatch.setattr(Path, "resolve", resolve)
+
+    result = run_metadata_refresh(
+        (_snapshot(),),
+        output_directory=tmp_path / "batch",
+        title_provider=lambda _url: None,
+        favicon_provider=lambda _url, *, output_directory: provider_path,
+    )[0]
+
+    assert result.metadata.favicon_status is LookupStatus.ERROR
+    assert result.metadata.icon_path is None
+    assert result.metadata.favicon_error_type == "UnsafeStagingPath"
+    assert not provider_path_resolved
+
+
+def test_merge_rejects_a_result_for_another_identity(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+    result = RefreshResult(
+        token=OpaqueToken(),
+        metadata=ResolvedMetadata(
+            title_status=LookupStatus.SUCCESS,
+            favicon_status=LookupStatus.SUCCESS,
+            title="Other",
+            icon_path=tmp_path / "other.png",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="token does not match"):
+        merge_refresh_result(snapshot, result)
+
+
+def test_diagnostics_contain_only_aggregate_counts_and_exception_types(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot()
+
+    def title_provider(_url: str) -> str:
+        raise RuntimeError("secret title message")
+
+    def favicon_provider(_url: str, *, output_directory: Path) -> Path:
+        del output_directory
+        raise ValueError("secret favicon message")
+
+    result = run_metadata_refresh(
+        (snapshot,),
+        output_directory=tmp_path / "batch",
+        title_provider=title_provider,
+        favicon_provider=favicon_provider,
+    )[0]
+    diagnostics = summarize_refresh_results((result,))
+    rendered = repr(diagnostics)
+
+    assert diagnostics.title_errors == 1
+    assert diagnostics.favicon_errors == 1
+    assert diagnostics.exception_types == (("RuntimeError", 1), ("ValueError", 1))
+    for secret in (
+        snapshot.url,
+        snapshot.name,
+        "secret title message",
+        "secret favicon message",
+    ):
+        assert secret not in rendered
+
+
+def test_batch_staging_directories_are_unique_and_repository_scoped(
+    tmp_path: Path,
+) -> None:
+    first = create_batch_staging_directory(tmp_path)
+    second = create_batch_staging_directory(tmp_path)
+
+    assert first != second
+    assert first.parent == tmp_path
+    assert second.parent == tmp_path
+    assert first.is_dir()
+    assert second.is_dir()

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -8,28 +8,32 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
+import shutil
 import subprocess  # nosec B404: used to launch local apps; inputs validated & shell=False
 import sys
-import math
-import webbrowser
+import threading
 import urllib.parse
-import urllib.request
+import webbrowser
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field, replace
+from enum import Enum, auto
 from pathlib import Path
 from typing import Callable, Literal, Optional, cast
-from enum import Enum, auto
-import shutil
 
 from PySide6.QtCore import (
     QEvent,
-    QObject,
     QMimeData,
+    QObject,
     QPoint,
+    QRunnable,
     QSize,
     Qt,
+    QThreadPool,
     QTimer,
+    Signal,
+    Slot,
     qWarning,
 )
 from PySide6.QtGui import (
@@ -57,6 +61,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QGridLayout,
     QInputDialog,
+    QLabel,
     QMainWindow,
     QMenu,
     QMessageBox,
@@ -76,6 +81,20 @@ from debug_scaffold import (
     sanitize_launch_command,
     sanitize_log_extra,
     sanitize_url,
+)
+from tile_metadata_refresh import (
+    OpaqueToken,
+    OperationGuard,
+    RefreshResult,
+    TileSnapshot,
+    create_batch_staging_directory,
+    fetch_favicon as fetch_favicon_to_directory,
+    guess_domain as metadata_guess_domain,
+    merge_refresh_result,
+    run_metadata_refresh,
+    select_all_for_active_tab,
+    snapshot_matches,
+    summarize_refresh_results,
 )
 from tile_editor_dialog import TileEditorDialog
 from url_import_dialog import ImportDestination, UrlImportDialog
@@ -590,26 +609,16 @@ def _auto_fit_columns(n_tiles: int, current_cols: int) -> int:
 
 
 def guess_domain(url: str) -> str:
-    try:
-        netloc = urllib.parse.urlparse(url).netloc
-        return netloc.split("@")[-1]  # strip creds if any
-    except Exception:  # nosec B110
-        return ""
+    return metadata_guess_domain(url)
 
 
 def fetch_favicon(url: str, size: int = 128) -> Optional[Path]:
     """Try to save a favicon PNG using Google's s2 service."""
-    domain = guess_domain(url)
-    if not domain:
-        return None
-    out = ICON_DIR / f"{domain}_{size}.png"
-    try:
-        src = f"https://www.google.com/s2/favicons?domain={domain}&sz={size}"
-        with urllib.request.urlopen(src, timeout=5) as r, open(out, "wb") as f:  # nosec B310
-            f.write(r.read())
-        return out
-    except Exception:  # nosec B110
-        return None
+    return fetch_favicon_to_directory(
+        url,
+        output_directory=ICON_DIR,
+        size=size,
+    )
 
 
 def letter_icon(text: str, size: int = 92, bg: str = "#F5F6FA") -> QIcon:
@@ -718,8 +727,15 @@ class TileButton(QToolButton):
         on_move: Callable[[int, int], None],
         on_change_tab: Callable[[Tile, str], None],
         tabs: list[str],
+        *,
+        selection_token: OpaqueToken | None = None,
+        selected: bool = False,
+        on_toggle_selection: Callable[[OpaqueToken, Tile], None] | None = None,
     ) -> None:
         super().__init__()
+        selection_mode = selection_token is not None
+        if selection_mode and on_toggle_selection is None:
+            raise ValueError("Selection-mode tiles require a selection callback.")
         self.tile = tile
         self.index = index
         self.on_open = on_open
@@ -729,20 +745,26 @@ class TileButton(QToolButton):
         self.on_move = on_move
         self.on_change_tab = on_change_tab
         self.tabs = tabs
+        self.selection_token = selection_token
+        self.on_toggle_selection = on_toggle_selection
+        self.selection_mode = selection_mode
         self._drag_start_pos: QPoint | None = None
 
-        self.setText(tile.name)
+        self.setCheckable(selection_mode)
+        self.setChecked(selection_mode and selected)
+        self._update_selection_presentation()
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         self.setIcon(self._icon_for_tile())
         self.setIconSize(QSize(72, 72))
         self.setFixedSize(150, 140)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.setAcceptDrops(True)
+        self.setAcceptDrops(not selection_mode)
         self._apply_style()
 
         self.clicked.connect(self._handle_click)
 
-    def _apply_style(self):
+    def _apply_style(self) -> None:
         self.setStyleSheet(f"""
         QToolButton {{
             background: {self.tile.bg};
@@ -756,17 +778,59 @@ class TileButton(QToolButton):
         QToolButton:pressed {{
             background: #ECEEF6;
         }}
+        QToolButton:checked {{
+            background: #DCEBFF;
+            border: 4px solid #0B57D0;
+            padding-top: 7px;
+        }}
+        QToolButton:checked:hover,
+        QToolButton:checked:pressed {{
+            background: #DCEBFF;
+            border-color: #0B57D0;
+        }}
+        QToolButton:focus,
+        QToolButton:focus:hover,
+        QToolButton:focus:pressed,
+        QToolButton:checked:focus,
+        QToolButton:checked:focus:hover,
+        QToolButton:checked:focus:pressed {{
+            border: 4px dashed #111827;
+            padding-top: 7px;
+        }}
         """)
+
+    def _update_selection_presentation(self) -> None:
+        if not self.selection_mode:
+            self.setText(self.tile.name)
+            self.setAccessibleName(self.tile.name)
+            self.setAccessibleDescription("Open this tile.")
+            return
+        selected = self.isChecked()
+        self.setText(f"✓ {self.tile.name}" if selected else self.tile.name)
+        state = "selected" if selected else "not selected"
+        self.setAccessibleName(f"{self.tile.name}, {state}")
+        self.setAccessibleDescription("Toggle this tile's selection.")
 
     def _icon_for_tile(self) -> QIcon:
         if self.tile.icon and Path(self.tile.icon).exists():
             return QIcon(self.tile.icon)
         return letter_icon(self.tile.name, 92, self.tile.bg)
 
-    def _handle_click(self):
+    def _handle_click(self, _checked: bool = False) -> None:
+        if self.selection_mode:
+            token = self.selection_token
+            callback = self.on_toggle_selection
+            if token is None or callback is None:
+                return
+            callback(token, self.tile)
+            self._update_selection_presentation()
+            return
         self.on_open(self.tile)
 
-    def contextMenuEvent(self, event):
+    def contextMenuEvent(self, event: QContextMenuEvent) -> None:  # noqa: N802
+        if self.selection_mode:
+            event.accept()
+            return
         m = QMenu(self)
         m.addAction("Open", lambda: self.on_open(self.tile))
         m.addSeparator()
@@ -780,11 +844,19 @@ class TileButton(QToolButton):
         m.exec(event.globalPos())
 
     def mousePressEvent(self, event: QMouseEvent) -> None:  # noqa: N802
+        if self.selection_mode:
+            self._drag_start_pos = None
+            super().mousePressEvent(event)
+            return
         if event.button() == Qt.MouseButton.LeftButton:
             self._drag_start_pos = event.position().toPoint()
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:  # noqa: N802
+        if self.selection_mode:
+            self._drag_start_pos = None
+            super().mouseMoveEvent(event)
+            return
         if self._drag_start_pos is None:
             super().mouseMoveEvent(event)
             return
@@ -800,10 +872,16 @@ class TileButton(QToolButton):
         self._drag_start_pos = None
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:  # noqa: N802
+        if self.selection_mode:
+            event.ignore()
+            return
         if event.mimeData().hasText():
             event.acceptProposedAction()
 
     def dropEvent(self, event: QDropEvent) -> None:  # noqa: N802
+        if self.selection_mode:
+            event.ignore()
+            return
         if event.mimeData().hasText():
             from_idx = int(event.mimeData().text())
             self.on_move(from_idx, self.index)
@@ -876,6 +954,155 @@ def _tile_uses_chrome(tile: Tile) -> bool:
     return is_windows_default_browser_chrome()
 
 
+_REFRESH_STAGING_PREFIX = "refresh-"
+
+
+def _owned_refresh_directory(path: Path) -> Path | None:
+    """Return a validated, directly managed refresh directory."""
+    try:
+        icon_directory = ICON_DIR.resolve()
+        candidate = path.resolve()
+    except (OSError, RuntimeError):
+        return None
+    if candidate.parent != icon_directory or not candidate.name.startswith(
+        _REFRESH_STAGING_PREFIX
+    ):
+        return None
+    return candidate
+
+
+def _remove_refresh_directory(path: Path) -> bool:
+    """Remove only a validated batch directory beneath managed icon storage."""
+    candidate = _owned_refresh_directory(path)
+    if candidate is None:
+        return False
+    try:
+        if candidate.exists():
+            shutil.rmtree(candidate)
+        return not candidate.exists()
+    except OSError:
+        return False
+
+
+def _resolved_staged_icon(batch_directory: Path, icon_path: Path) -> Path | None:
+    batch = _owned_refresh_directory(batch_directory)
+    if batch is None or icon_path.is_symlink():
+        return None
+    try:
+        icon = icon_path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    if not icon.is_file() or batch not in icon.parents:
+        return None
+    return icon
+
+
+def _prune_refresh_directory(
+    batch_directory: Path,
+    retained_icons: Iterable[Path],
+) -> bool:
+    """Keep only referenced regular files in one quiescent refresh batch."""
+    batch = _owned_refresh_directory(batch_directory)
+    if batch is None or not batch.is_dir():
+        return False
+
+    retained: set[Path] = set()
+    retained_directories: set[Path] = set()
+    for icon_path in retained_icons:
+        icon = _resolved_staged_icon(batch, icon_path)
+        if icon is None:
+            return False
+        retained.add(icon)
+        parent = icon.parent
+        while parent != batch:
+            retained_directories.add(parent)
+            parent = parent.parent
+
+    try:
+        entries = sorted(
+            batch.rglob("*"),
+            key=lambda entry: len(entry.parts),
+            reverse=True,
+        )
+        for entry in entries:
+            if entry.is_symlink():
+                entry.unlink()
+            elif entry.is_file():
+                if entry.resolve() not in retained:
+                    entry.unlink()
+            elif entry.is_dir() and entry.resolve() not in retained_directories:
+                entry.rmdir()
+            elif not entry.is_dir():
+                return False
+
+        if not retained:
+            batch.rmdir()
+            return not batch.exists()
+
+        for entry in batch.rglob("*"):
+            if entry.is_symlink():
+                return False
+            if entry.is_file() and entry.resolve() not in retained:
+                return False
+            if not entry.is_file() and not entry.is_dir():
+                return False
+        return all(icon.is_file() for icon in retained)
+    except (OSError, RuntimeError):
+        return False
+
+
+class _MetadataRefreshSignals(QObject):
+    finished = Signal(object, object, object)
+
+
+class _MetadataRefreshRunnable(QRunnable):
+    def __init__(
+        self,
+        operation_token: OpaqueToken,
+        snapshots: tuple[TileSnapshot, ...],
+        batch_directory: Path,
+        cancellation: threading.Event,
+        signals: _MetadataRefreshSignals,
+    ) -> None:
+        super().__init__()
+        self.setAutoDelete(True)
+        self._operation_token = operation_token
+        self._snapshots = snapshots
+        self._batch_directory = batch_directory
+        self._cancellation = cancellation
+        self._signals = signals
+
+    @Slot()
+    def run(self) -> None:
+        results: tuple[RefreshResult, ...] | None = None
+        error_type: str | None = None
+        try:
+            results = run_metadata_refresh(
+                self._snapshots,
+                output_directory=self._batch_directory,
+                cancellation=self._cancellation,
+            )
+        except Exception as exc:
+            error_type = type(exc).__name__ or "Exception"
+        finally:
+            self._signals.finished.emit(
+                self._operation_token,
+                results,
+                error_type,
+            )
+
+
+@dataclass(frozen=True)
+class _ActiveRefresh:
+    token: OpaqueToken
+    tab_id: str = field(repr=False)
+    tab_name: str = field(repr=False)
+    snapshots: tuple[TileSnapshot, ...] = field(repr=False)
+    tiles_by_token: dict[OpaqueToken, Tile] = field(repr=False)
+    batch_directory: Path = field(repr=False)
+    cancellation: threading.Event = field(repr=False)
+
+
 class Main(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
@@ -883,6 +1110,27 @@ class Main(QMainWindow):
         self._enforce_tab_invariants()
         self.cfg.save()
         self._fit_guard = False
+        self._rebuilding = False
+        self._closing = False
+        self._close_ready = False
+        self._operation_guard = OperationGuard()
+        self._active_refresh: _ActiveRefresh | None = None
+        self._metadata_refresh_pool = QThreadPool(self)
+        self._metadata_refresh_pool.setMaxThreadCount(1)
+        self._metadata_refresh_signals = _MetadataRefreshSignals(self)
+        self._metadata_refresh_signals.finished.connect(
+            self._on_metadata_refresh_finished,
+            Qt.ConnectionType.QueuedConnection,
+        )
+        self._metadata_close_poll = QTimer(self)
+        self._metadata_close_poll.setSingleShot(True)
+        self._metadata_close_poll.setInterval(25)
+        self._metadata_close_poll.timeout.connect(self._poll_metadata_refresh_close)
+        self._selection_tab_id: str | None = None
+        self._selection_tab_name: str | None = None
+        self._selection_tiles: dict[OpaqueToken, Tile] = {}
+        self._selection_tokens_by_identity: dict[int, OpaqueToken] = {}
+        self._selected_tokens: set[OpaqueToken] = set()
 
         # -------- Startup auto-fit: materialize columns on config when enabled --------
         if self.cfg.auto_fit:
@@ -940,21 +1188,64 @@ class Main(QMainWindow):
         # toolbar and menus
         self.toolbar = QToolBar()
         self.addToolBar(Qt.ToolBarArea.TopToolBarArea, self.toolbar)
-        add_action = QAction("➕ Add", self)
-        add_action.triggered.connect(self.add_tile)
-        self.toolbar.addAction(add_action)
-        import_action = QAction("Import URLs…", self)
-        import_action.triggered.connect(lambda: self.import_urls())
-        self.toolbar.addAction(import_action)
+        self.add_action = QAction("➕ Add", self)
+        self.add_action.triggered.connect(self.add_tile)
+        self.toolbar.addAction(self.add_action)
+        self.import_action = QAction("Import URLs…", self)
+        self.import_action.triggered.connect(lambda: self.import_urls())
+        self.toolbar.addAction(self.import_action)
+        self.select_tiles_action = QAction("Select tiles", self)
+        self.select_tiles_action.triggered.connect(self.enter_selection_mode)
+        self.toolbar.addAction(self.select_tiles_action)
+
+        self.selection_count_label = QLabel("0 selected", self)
+        self.selection_count_label.setAccessibleName("Selected tile count")
+        self.selection_count_label.setContentsMargins(8, 0, 8, 0)
+        self.selection_count_action = self.toolbar.addWidget(self.selection_count_label)
+        self.select_all_action = QAction("Select all", self)
+        self.select_all_action.triggered.connect(self.select_all_tiles)
+        self.toolbar.addAction(self.select_all_action)
+        self.clear_selection_action = QAction("Clear selection", self)
+        self.clear_selection_action.triggered.connect(self.clear_tile_selection)
+        self.toolbar.addAction(self.clear_selection_action)
+        self.refresh_metadata_action = QAction("Refresh names and icons", self)
+        self.refresh_metadata_action.triggered.connect(self.refresh_selected_metadata)
+        self.toolbar.addAction(self.refresh_metadata_action)
+        self.done_selection_action = QAction("Done", self)
+        self.done_selection_action.triggered.connect(self.exit_selection_mode)
+        self.toolbar.addAction(self.done_selection_action)
+        self._selection_toolbar_actions = (
+            self.selection_count_action,
+            self.select_all_action,
+            self.clear_selection_action,
+            self.refresh_metadata_action,
+            self.done_selection_action,
+        )
+        for action in self._selection_toolbar_actions:
+            action.setVisible(False)
 
         tab_menu = self.menuBar().addMenu("Tabs")
-        tab_menu.addAction("Add Tab", self.add_tab)
-        tab_menu.addAction("Rename Tab", self.rename_tab)
-        tab_menu.addAction("Delete Tab", self.delete_tab)
+        self.add_tab_action = QAction("Add Tab", self)
+        self.add_tab_action.triggered.connect(self.add_tab)
+        tab_menu.addAction(self.add_tab_action)
+        self.rename_tab_action = QAction("Rename Tab", self)
+        self.rename_tab_action.triggered.connect(self.rename_tab)
+        tab_menu.addAction(self.rename_tab_action)
+        self.delete_tab_action = QAction("Delete Tab", self)
+        self.delete_tab_action.triggered.connect(self.delete_tab)
+        tab_menu.addAction(self.delete_tab_action)
         self.toggle_tab_action = QAction(self)
         self.toggle_tab_action.triggered.connect(self.toggle_current_tab_visibility)
         tab_menu.addAction(self.toggle_tab_action)
-        tab_menu.addAction("Manage Tab Visibility…", self.manage_tab_visibility)
+        self.manage_tab_visibility_action = QAction("Manage Tab Visibility…", self)
+        self.manage_tab_visibility_action.triggered.connect(self.manage_tab_visibility)
+        tab_menu.addAction(self.manage_tab_visibility_action)
+        self._tab_mutation_actions = (
+            self.add_tab_action,
+            self.rename_tab_action,
+            self.delete_tab_action,
+            self.manage_tab_visibility_action,
+        )
 
         view_menu = self.menuBar().addMenu("View")
         self.auto_fit_action = QAction("Auto-fit Tiles to Display", self)
@@ -970,14 +1261,7 @@ class Main(QMainWindow):
         self.tabs_widget = QTabWidget()
         self.tabs_widget.setMovable(True)
         self.tabs_widget.tabBar().tabMoved.connect(self._on_tab_moved)
-        self.tabs_widget.currentChanged.connect(
-            lambda _=0: QTimer.singleShot(
-                0, lambda: self.resize_to_fit_tiles(snap_window=self.cfg.auto_fit)
-            )
-        )
-        self.tabs_widget.currentChanged.connect(
-            lambda _: self._update_toggle_tab_action()
-        )
+        self.tabs_widget.currentChanged.connect(self._on_current_tab_changed)
         self.setCentralWidget(self.tabs_widget)
 
         self._tab_viewports: set[QWidget] = set()
@@ -998,7 +1282,559 @@ class Main(QMainWindow):
     def _enforce_tab_invariants(self) -> None:
         enforce_tab_invariants(self.cfg)
 
+    def _selection_active(self) -> bool:
+        return self._selection_tab_id is not None
+
+    def _tab_id_at(self, index: int) -> str | None:
+        if index < 0:
+            return None
+        raw_id = self.tabs_widget.tabBar().tabData(index)
+        return raw_id if isinstance(raw_id, str) else None
+
+    def _on_current_tab_changed(self, index: int) -> None:
+        if self._rebuilding:
+            return
+        if (
+            self._selection_active()
+            and self._tab_id_at(index) != self._selection_tab_id
+        ):
+            self._exit_selection_mode(repopulate=True)
+        self._update_toggle_tab_action()
+        self._update_selection_controls()
+        QTimer.singleShot(
+            0, lambda: self.resize_to_fit_tiles(snap_window=self.cfg.auto_fit)
+        )
+
+    def enter_selection_mode(self) -> None:
+        if self._selection_active() or self._active_refresh is not None:
+            return
+        tab_name = self.current_tab()
+        tab_id = self._tab_id_at(self.tabs_widget.currentIndex())
+        if tab_id is None:
+            return
+
+        self._selection_tab_id = tab_id
+        self._selection_tab_name = tab_name
+        self._selection_tiles = {}
+        self._selection_tokens_by_identity = {}
+        for tile in self.cfg.tiles:
+            if tile.tab != tab_name:
+                continue
+            identity = id(tile)
+            if identity in self._selection_tokens_by_identity:
+                continue
+            token = OpaqueToken()
+            self._selection_tiles[token] = tile
+            self._selection_tokens_by_identity[identity] = token
+        self._selected_tokens.clear()
+        self._update_selection_controls()
+        if tab_name in self._grids:
+            self._populate_tab(tab_name)
+
+    def exit_selection_mode(self) -> None:
+        if self._active_refresh is not None:
+            return
+        self._exit_selection_mode(repopulate=True)
+
+    def _exit_selection_mode(self, *, repopulate: bool) -> None:
+        tab_name = self._selection_tab_name
+        self._selection_tab_id = None
+        self._selection_tab_name = None
+        self._selection_tiles.clear()
+        self._selection_tokens_by_identity.clear()
+        self._selected_tokens.clear()
+        self._update_selection_controls()
+        if repopulate and tab_name is not None and tab_name in self._grids:
+            self._populate_tab(tab_name)
+
+    def _selection_token_for_tile(self, tile: Tile) -> OpaqueToken | None:
+        token = self._selection_tokens_by_identity.get(id(tile))
+        if token is None or self._selection_tiles.get(token) is not tile:
+            return None
+        return token
+
+    def _toggle_tile_selection(self, token: OpaqueToken, tile: Tile) -> None:
+        if self._active_refresh is not None:
+            return
+        selection_tab = self._selection_tab_name
+        if (
+            not self._selection_active()
+            or selection_tab is None
+            or self._selection_tiles.get(token) is not tile
+            or tile.tab != selection_tab
+            or not any(candidate is tile for candidate in self.cfg.tiles)
+        ):
+            if selection_tab is not None and selection_tab in self._grids:
+                self._populate_tab(selection_tab)
+            return
+        if token in self._selected_tokens:
+            self._selected_tokens.remove(token)
+        else:
+            self._selected_tokens.add(token)
+        self._update_selection_controls()
+
+    @staticmethod
+    def _snapshot_tile(token: OpaqueToken, tile: Tile) -> TileSnapshot:
+        return TileSnapshot(
+            token=token,
+            url=tile.url,
+            name=tile.name,
+            tab=tile.tab,
+            icon=tile.icon,
+            bg=tile.bg,
+            browser=tile.browser,
+            chrome_profile=tile.chrome_profile,
+            open_target=tile.open_target,
+        )
+
+    def _selected_tile_snapshots(self) -> tuple[TileSnapshot, ...]:
+        return tuple(
+            self._snapshot_tile(token, tile)
+            for token, tile in self._selection_tiles.items()
+            if token in self._selected_tokens
+        )
+
+    def select_all_tiles(self) -> None:
+        if not self._selection_active() or self._active_refresh is not None:
+            return
+        tab_name = self._selection_tab_name
+        if tab_name is None:
+            return
+        snapshots = tuple(
+            self._snapshot_tile(token, tile)
+            for token, tile in self._selection_tiles.items()
+        )
+        self._selected_tokens = set(select_all_for_active_tab(snapshots, tab_name))
+        self._update_selection_controls()
+        if tab_name is not None and tab_name in self._grids:
+            self._populate_tab(tab_name)
+
+    def clear_tile_selection(self) -> None:
+        if not self._selection_active() or self._active_refresh is not None:
+            return
+        self._selected_tokens.clear()
+        self._update_selection_controls()
+        tab_name = self._selection_tab_name
+        if tab_name is not None and tab_name in self._grids:
+            self._populate_tab(tab_name)
+
+    def refresh_selected_metadata(self) -> None:
+        if (
+            self._closing
+            or not self._selection_active()
+            or self._active_refresh is not None
+            or self._metadata_refresh_pool.activeThreadCount() > 0
+        ):
+            return
+        confirmed_tokens = frozenset(self._selected_tokens)
+        selected_count = len(confirmed_tokens)
+        if selected_count == 0:
+            return
+
+        response = QMessageBox.warning(
+            self,
+            "Refresh names and icons?",
+            (
+                f"Refresh names and icons for {selected_count} selected "
+                f"{'tile' if selected_count == 1 else 'tiles'}?\n\n"
+                "Successful results replace the current name or icon, including "
+                "custom values. A failed lookup keeps that field unchanged."
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if response != QMessageBox.StandardButton.Yes:
+            return
+        if (
+            self._closing
+            or not self._selection_active()
+            or self._active_refresh is not None
+            or self._metadata_refresh_pool.activeThreadCount() > 0
+            or self._selected_tokens != confirmed_tokens
+        ):
+            return
+
+        snapshots = self._selected_tile_snapshots()
+        tab_id = self._selection_tab_id
+        tab_name = self._selection_tab_name
+        if not snapshots or tab_id is None or tab_name is None:
+            return
+
+        operation_token = OpaqueToken()
+        if not self._operation_guard.start(operation_token):
+            return
+        try:
+            batch_directory = create_batch_staging_directory(ICON_DIR)
+        except OSError as exc:
+            self._operation_guard.finish(operation_token)
+            error_type = type(exc).__name__ or "OSError"
+            record_breadcrumb(
+                "metadata_refresh_failed",
+                selected_count=selected_count,
+                error_type=error_type,
+                cleanup_ok=True,
+            )
+            QMessageBox.warning(
+                self,
+                "Refresh failed",
+                "The refresh could not be started. No tiles were changed.",
+            )
+            return
+
+        cancellation = threading.Event()
+        runnable = _MetadataRefreshRunnable(
+            operation_token,
+            snapshots,
+            batch_directory,
+            cancellation,
+            self._metadata_refresh_signals,
+        )
+        operation = _ActiveRefresh(
+            token=operation_token,
+            tab_id=tab_id,
+            tab_name=tab_name,
+            snapshots=snapshots,
+            tiles_by_token={
+                snapshot.token: self._selection_tiles[snapshot.token]
+                for snapshot in snapshots
+            },
+            batch_directory=batch_directory,
+            cancellation=cancellation,
+        )
+        self._active_refresh = operation
+        self._update_selection_controls()
+        record_breadcrumb(
+            "metadata_refresh_started",
+            selected_count=selected_count,
+        )
+        try:
+            self._metadata_refresh_pool.start(runnable)
+        except RuntimeError as exc:
+            error_type = type(exc).__name__ or "RuntimeError"
+            cleanup_ok = _remove_refresh_directory(batch_directory)
+            self._operation_guard.finish(operation_token)
+            self._active_refresh = None
+            self._update_selection_controls()
+            record_breadcrumb(
+                "metadata_refresh_failed",
+                selected_count=selected_count,
+                error_type=error_type,
+                cleanup_ok=cleanup_ok,
+            )
+            QMessageBox.warning(
+                self,
+                "Refresh failed",
+                "The refresh could not be started. No tiles were changed.",
+            )
+
+    def _refresh_completion_matches(
+        self,
+        operation: _ActiveRefresh,
+        results: tuple[RefreshResult, ...],
+    ) -> bool:
+        if (
+            self._selection_tab_id != operation.tab_id
+            or self._selection_tab_name != operation.tab_name
+            or self._tab_id_at(self.tabs_widget.currentIndex()) != operation.tab_id
+            or len(results) != len(operation.snapshots)
+            or len(self._selected_tokens) != len(operation.snapshots)
+        ):
+            return False
+        if any(
+            result.token is not snapshot.token
+            for snapshot, result in zip(operation.snapshots, results, strict=True)
+        ):
+            return False
+        for snapshot in operation.snapshots:
+            tile = operation.tiles_by_token.get(snapshot.token)
+            if (
+                tile is None
+                or snapshot.token not in self._selected_tokens
+                or not any(candidate is tile for candidate in self.cfg.tiles)
+                or not snapshot_matches(
+                    snapshot,
+                    self._snapshot_tile(snapshot.token, tile),
+                )
+            ):
+                return False
+        return True
+
+    def _detached_configuration(self) -> tuple[LauncherConfig, dict[int, Tile]]:
+        tiles_by_identity: dict[int, Tile] = {}
+        detached_tiles: list[Tile] = []
+        for tile in self.cfg.tiles:
+            identity = id(tile)
+            detached = tiles_by_identity.get(identity)
+            if detached is None:
+                detached = replace(tile)
+                tiles_by_identity[identity] = detached
+            detached_tiles.append(detached)
+        return (
+            replace(
+                self.cfg,
+                tiles=detached_tiles,
+                tabs=list(self.cfg.tabs),
+                hidden_tabs=list(self.cfg.hidden_tabs),
+                tab_ids=dict(self.cfg.tab_ids),
+                tab_order=list(self.cfg.tab_order),
+            ),
+            tiles_by_identity,
+        )
+
+    def _retire_metadata_refresh(
+        self,
+        operation: _ActiveRefresh,
+        *,
+        remove_staging: bool,
+    ) -> bool:
+        cleanup_ok = True
+        if remove_staging:
+            cleanup_ok = _remove_refresh_directory(operation.batch_directory)
+        self._operation_guard.finish(operation.token)
+        if self._active_refresh is operation:
+            self._active_refresh = None
+        return cleanup_ok
+
+    def _schedule_metadata_refresh_close_poll(self) -> None:
+        if (
+            self._closing
+            and not self._close_ready
+            and not self._metadata_close_poll.isActive()
+        ):
+            self._metadata_close_poll.start()
+
+    @Slot()
+    def _poll_metadata_refresh_close(self) -> None:
+        if not self._closing or self._close_ready:
+            return
+        if (
+            self._active_refresh is not None
+            or self._metadata_refresh_pool.activeThreadCount() > 0
+        ):
+            self._schedule_metadata_refresh_close_poll()
+            return
+        self._close_ready = True
+        self.close()
+
+    def _metadata_refresh_failed(
+        self,
+        operation: _ActiveRefresh,
+        error_type: str,
+    ) -> None:
+        safe_error_type = error_type if error_type.isidentifier() else "RefreshError"
+        cleanup_ok = self._retire_metadata_refresh(
+            operation,
+            remove_staging=True,
+        )
+        self._update_selection_controls()
+        record_breadcrumb(
+            "metadata_refresh_failed",
+            selected_count=len(operation.snapshots),
+            error_type=safe_error_type,
+            cleanup_ok=cleanup_ok,
+        )
+        QMessageBox.warning(
+            self,
+            "Refresh failed",
+            "The refresh could not be completed. No tiles were changed.",
+        )
+
+    @Slot(object, object, object)
+    def _on_metadata_refresh_finished(
+        self,
+        operation_token: object,
+        results_payload: object,
+        error_payload: object,
+    ) -> None:
+        operation = self._active_refresh
+        if operation is None or operation.token is not operation_token:
+            return
+
+        if (
+            self._closing
+            or operation.cancellation.is_set()
+            or not self._operation_guard.is_current(operation.token)
+        ):
+            cleanup_ok = self._retire_metadata_refresh(
+                operation,
+                remove_staging=True,
+            )
+            record_breadcrumb(
+                "metadata_refresh_cancelled",
+                selected_count=len(operation.snapshots),
+                cleanup_ok=cleanup_ok,
+            )
+            if self._closing:
+                self._schedule_metadata_refresh_close_poll()
+            else:
+                self._update_selection_controls()
+            return
+
+        if error_payload is not None:
+            error_type = (
+                error_payload if isinstance(error_payload, str) else "WorkerError"
+            )
+            self._metadata_refresh_failed(operation, error_type)
+            return
+        if not isinstance(results_payload, tuple) or not all(
+            isinstance(result, RefreshResult) for result in results_payload
+        ):
+            self._metadata_refresh_failed(operation, "InvalidWorkerResult")
+            return
+
+        results = cast(tuple[RefreshResult, ...], results_payload)
+        if any(result.cancelled for result in results):
+            self._metadata_refresh_failed(operation, "CancelledRefresh")
+            return
+        if not self._refresh_completion_matches(operation, results):
+            self._metadata_refresh_failed(operation, "StaleTileState")
+            return
+
+        candidate, detached_by_identity = self._detached_configuration()
+        retained_icons: set[Path] = set()
+        changed_tiles = 0
+        name_updates = 0
+        icon_updates = 0
+        for snapshot, result in zip(operation.snapshots, results, strict=True):
+            original = operation.tiles_by_token[snapshot.token]
+            detached = detached_by_identity.get(id(original))
+            if detached is None:
+                self._metadata_refresh_failed(operation, "StaleTileState")
+                return
+            merged = merge_refresh_result(snapshot, result)
+            refreshed_icon = merged.icon
+            if merged.icon_changed:
+                if refreshed_icon is None:
+                    self._metadata_refresh_failed(operation, "InvalidIconResult")
+                    return
+                staged_icon = _resolved_staged_icon(
+                    operation.batch_directory,
+                    Path(refreshed_icon),
+                )
+                if staged_icon is None:
+                    self._metadata_refresh_failed(operation, "InvalidIconResult")
+                    return
+                refreshed_icon = str(staged_icon)
+                retained_icons.add(staged_icon)
+            detached.name = merged.name
+            detached.icon = refreshed_icon
+            if merged.changed:
+                changed_tiles += 1
+            name_updates += int(merged.name_changed)
+            icon_updates += int(merged.icon_changed)
+
+        diagnostics = summarize_refresh_results(results)
+        if changed_tiles == 0:
+            cleanup_ok = self._retire_metadata_refresh(
+                operation,
+                remove_staging=True,
+            )
+            self._update_selection_controls()
+            record_breadcrumb(
+                "metadata_refresh_no_changes",
+                selected_count=len(operation.snapshots),
+                title_errors=diagnostics.title_errors,
+                favicon_errors=diagnostics.favicon_errors,
+                cleanup_ok=cleanup_ok,
+            )
+            if cleanup_ok:
+                QMessageBox.information(
+                    self,
+                    "Nothing updated",
+                    "No names or icons were updated. Existing values were kept.",
+                )
+            else:
+                QMessageBox.warning(
+                    self,
+                    "Refresh failed",
+                    "The refresh could not be completed. No tiles were changed.",
+                )
+            return
+
+        if not _prune_refresh_directory(
+            operation.batch_directory,
+            retained_icons,
+        ):
+            self._metadata_refresh_failed(operation, "StagingPruneError")
+            return
+
+        try:
+            candidate.save()
+        except Exception as exc:
+            # Keep every persistence failure on the detached side of the transaction.
+            self._metadata_refresh_failed(
+                operation,
+                type(exc).__name__ or "SaveError",
+            )
+            return
+
+        selected_tab = operation.tab_name
+        self._retire_metadata_refresh(operation, remove_staging=False)
+        self.cfg = candidate
+        self._exit_selection_mode(repopulate=False)
+        self.rebuild()
+        self._set_current_tab_by_name(selected_tab)
+        record_breadcrumb(
+            "metadata_refresh_completed",
+            selected_count=len(operation.snapshots),
+            changed_tiles=changed_tiles,
+            name_updates=name_updates,
+            icon_updates=icon_updates,
+            title_errors=diagnostics.title_errors,
+            favicon_errors=diagnostics.favicon_errors,
+        )
+        QMessageBox.information(
+            self,
+            "Refresh complete",
+            (
+                f"Updated {changed_tiles} "
+                f"{'tile' if changed_tiles == 1 else 'tiles'}: "
+                f"{name_updates} {'name' if name_updates == 1 else 'names'} and "
+                f"{icon_updates} {'icon' if icon_updates == 1 else 'icons'}."
+            ),
+        )
+
+    def _update_selection_controls(self) -> None:
+        selecting = self._selection_active()
+        busy = self._active_refresh is not None
+        selected_count = len(self._selected_tokens)
+        total_count = len(self._selection_tiles)
+
+        for action in (self.add_action, self.import_action, self.select_tiles_action):
+            action.setVisible(not selecting)
+        for action in self._selection_toolbar_actions:
+            action.setVisible(selecting)
+
+        self.add_action.setEnabled(not selecting and not busy)
+        self.import_action.setEnabled(not selecting and not busy)
+        active_tab_has_tiles = any(
+            tile.tab == self.current_tab() for tile in self.cfg.tiles
+        )
+        self.select_tiles_action.setEnabled(not busy and active_tab_has_tiles)
+        self.selection_count_label.setText(
+            f"Refreshing {selected_count}…" if busy else f"{selected_count} selected"
+        )
+        self.select_all_action.setEnabled(
+            selecting and not busy and selected_count < total_count
+        )
+        self.clear_selection_action.setEnabled(
+            selecting and not busy and selected_count > 0
+        )
+        self.refresh_metadata_action.setEnabled(
+            selecting and not busy and selected_count > 0
+        )
+        self.done_selection_action.setEnabled(selecting and not busy)
+
+        for action in self._tab_mutation_actions:
+            action.setEnabled(not selecting and not busy)
+        self._update_toggle_tab_action()
+        self.auto_fit_action.setEnabled(not selecting and not busy)
+        self.tabs_widget.tabBar().setMovable(not selecting and not busy)
+        self.tabs_widget.setEnabled(not busy)
+
     def _on_tab_moved(self, from_index: int, to_index: int) -> None:
+        if self._selection_active() or self._active_refresh is not None:
+            return
         tab_bar = self.tabs_widget.tabBar()
         visible_ids_after = [tab_bar.tabData(index) for index in range(tab_bar.count())]
         hidden_ids = [self.cfg.tab_ids.get(title) for title in self.cfg.hidden_tabs]
@@ -1038,6 +1874,8 @@ class Main(QMainWindow):
         visible = self._visible_tabs()
         allow_hide = not hidden and len(visible) > 1
         self.toggle_tab_action.setEnabled(hidden or allow_hide)
+        if self._selection_active() or self._active_refresh is not None:
+            self.toggle_tab_action.setEnabled(False)
 
     def _toggle_auto_fit(self, checked: bool) -> None:
         self.cfg.auto_fit = checked
@@ -1053,27 +1891,34 @@ class Main(QMainWindow):
         record_breadcrumb("window_shown")
 
     def rebuild(self) -> None:
-        self.tabs_widget.clear()
-        self._grids: dict[str, QGridLayout] = {}
-        self._tab_viewports.clear()
-        tab_bar = self.tabs_widget.tabBar()
-        for tab in self._visible_tabs():
-            scroll = QScrollArea()
-            scroll.setWidgetResizable(True)
-            container = QWidget()
-            grid = QGridLayout(container)
-            grid.setSpacing(12)
-            grid.setContentsMargins(16, 16, 16, 16)
-            scroll.setWidget(container)
-            self._wire_tab_whitespace_menu(scroll)
-            tab_index = self.tabs_widget.addTab(scroll, tab)
-            tab_bar.setTabData(tab_index, self.cfg.tab_ids[tab])
-            self._grids[tab] = grid
-            self._populate_tab(tab)
+        if self._selection_active():
+            self._exit_selection_mode(repopulate=False)
+        self._rebuilding = True
+        try:
+            self.tabs_widget.clear()
+            self._grids: dict[str, QGridLayout] = {}
+            self._tab_viewports.clear()
+            tab_bar = self.tabs_widget.tabBar()
+            for tab in self._visible_tabs():
+                scroll = QScrollArea()
+                scroll.setWidgetResizable(True)
+                container = QWidget()
+                grid = QGridLayout(container)
+                grid.setSpacing(12)
+                grid.setContentsMargins(16, 16, 16, 16)
+                scroll.setWidget(container)
+                self._wire_tab_whitespace_menu(scroll)
+                tab_index = self.tabs_widget.addTab(scroll, tab)
+                tab_bar.setTabData(tab_index, self.cfg.tab_ids[tab])
+                self._grids[tab] = grid
+                self._populate_tab(tab)
+        finally:
+            self._rebuilding = False
         QTimer.singleShot(
             0, lambda: self.resize_to_fit_tiles(snap_window=self.cfg.auto_fit)
         )
         self._update_toggle_tab_action()
+        self._update_selection_controls()
 
     def _populate_tab(self, tab: str) -> None:
         grid = self._grids[tab]
@@ -1081,6 +1926,8 @@ class Main(QMainWindow):
             item = grid.takeAt(0)
             w = item.widget()
             if w:
+                w.setEnabled(False)
+                w.hide()
                 w.deleteLater()
 
         if self.cfg.auto_fit:
@@ -1095,6 +1942,9 @@ class Main(QMainWindow):
             def move(f: int, t: int, tab_name: str = tab) -> None:
                 self.move_tile(tab_name, f, t)
 
+            selection_token = None
+            if tab == self._selection_tab_name:
+                selection_token = self._selection_token_for_tile(tile)
             btn = TileButton(
                 tile,
                 idx,
@@ -1105,6 +1955,11 @@ class Main(QMainWindow):
                 on_move=move,
                 on_change_tab=self.change_tile_tab,
                 tabs=all_tabs,
+                selection_token=selection_token,
+                selected=selection_token in self._selected_tokens,
+                on_toggle_selection=(
+                    self._toggle_tile_selection if selection_token is not None else None
+                ),
             )
             grid.addWidget(btn, r, c)
             c += 1
@@ -1122,6 +1977,8 @@ class Main(QMainWindow):
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # noqa: N802
         try:
             if event.type() == QEvent.Type.ContextMenu and obj in self._tab_viewports:
+                if self._selection_active():
+                    return True
                 cme = cast(QContextMenuEvent, event)
                 # Use the event's globalPos() to avoid touching the (possibly deleted) widget.
                 global_pos = cme.globalPos()
@@ -1151,6 +2008,8 @@ class Main(QMainWindow):
         return False
 
     def _show_whitespace_menu(self, global_pos: QPoint) -> None:
+        if self._selection_active():
+            return
         menu = QMenu(self)
         act = menu.addAction("Add Tile…")
         act.triggered.connect(lambda: self.add_tile(self.current_tab()))
@@ -1253,6 +2112,21 @@ class Main(QMainWindow):
             self._fit_guard = False
 
     def closeEvent(self, event: QCloseEvent) -> None:  # noqa: D401
+        operation = self._active_refresh
+        pool_active = self._metadata_refresh_pool.activeThreadCount() > 0
+        if not self._close_ready and (
+            self._closing or operation is not None or pool_active
+        ):
+            self._closing = True
+            if operation is not None:
+                operation.cancellation.set()
+            self._operation_guard.invalidate()
+            self.setEnabled(False)
+            event.ignore()
+            self._schedule_metadata_refresh_close_poll()
+            return
+
+        self._closing = True
         try:
             g = self.normalGeometry() if self.isMaximized() else self.frameGeometry()
             self.cfg.window_w = int(g.width())
@@ -1279,6 +2153,10 @@ class Main(QMainWindow):
 
     # -------- actions --------
     def open_tile(self, tile: Tile) -> None:
+        if isinstance(self, Main) and (
+            self._selection_active() or self._active_refresh is not None
+        ):
+            return
         logger = logging.getLogger(__name__)
         plan = build_launch_plan(tile)
         url = sanitize_url(tile.url)
@@ -1549,6 +2427,8 @@ class Main(QMainWindow):
             )
 
     def move_tile(self, tab: str, from_idx: int, to_idx: int) -> None:
+        if self._selection_active() or self._active_refresh is not None:
+            return
         if from_idx == to_idx:
             return
         indices = [i for i, t in enumerate(self.cfg.tiles) if t.tab == tab]

--- a/tile_metadata_refresh.py
+++ b/tile_metadata_refresh.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import tempfile
+import urllib.parse
+import urllib.request
+import weakref
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from types import TracebackType
+from typing import Literal, Protocol, cast
+
+from page_title_lookup import fetch_page_title
+
+DEFAULT_FAVICON_SIZE = 128
+FAVICON_TIMEOUT_SECONDS = 5.0
+MAX_REFRESH_WORKERS = 4
+
+
+class OpaqueToken:
+    """An identity-only token with a deliberately non-descriptive repr."""
+
+    __slots__ = ("__weakref__",)
+
+    def __repr__(self) -> str:
+        return "<opaque-token>"
+
+
+@dataclass(frozen=True, eq=False)
+class TileSnapshot:
+    """Immutable tile state captured before any refresh work starts."""
+
+    token: OpaqueToken
+    url: str = field(repr=False)
+    name: str = field(repr=False)
+    tab: str = field(default="Main", repr=False)
+    icon: str | None = field(default=None, repr=False)
+    bg: str = field(default="#F5F6FA", repr=False)
+    browser: str | None = field(default=None, repr=False)
+    chrome_profile: str | None = field(default=None, repr=False)
+    open_target: Literal["tab", "window"] = field(default="tab", repr=False)
+
+
+class LookupStatus(Enum):
+    SUCCESS = "success"
+    NO_RESULT = "no_result"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class ResolvedMetadata:
+    """Provider outcomes without exception messages or other diagnostic payloads."""
+
+    title_status: LookupStatus
+    favicon_status: LookupStatus
+    title: str | None = field(default=None, repr=False)
+    icon_path: Path | None = field(default=None, repr=False)
+    title_error_type: str | None = None
+    favicon_error_type: str | None = None
+
+
+@dataclass(frozen=True, eq=False)
+class RefreshResult:
+    """Metadata result associated with one snapshot by object identity."""
+
+    token: OpaqueToken
+    metadata: ResolvedMetadata
+    staging_directory: Path | None = field(default=None, repr=False)
+    cancelled: bool = False
+
+
+@dataclass(frozen=True)
+class MergedMetadata:
+    """Values to apply to a detached tile plus precise change information."""
+
+    name: str = field(repr=False)
+    icon: str | None = field(repr=False)
+    name_changed: bool
+    icon_changed: bool
+
+    @property
+    def changed(self) -> bool:
+        return self.name_changed or self.icon_changed
+
+
+@dataclass(frozen=True)
+class RefreshDiagnostics:
+    """Aggregate-only information safe for diagnostics and breadcrumbs."""
+
+    tile_count: int
+    title_successes: int
+    favicon_successes: int
+    title_no_results: int
+    favicon_no_results: int
+    title_errors: int
+    favicon_errors: int
+    cancelled_results: int
+    exception_types: tuple[tuple[str, int], ...]
+
+
+class CancellationFlag(Protocol):
+    def is_set(self) -> bool: ...
+
+
+class TitleProvider(Protocol):
+    def __call__(self, url: str) -> str | None: ...
+
+
+class FaviconProvider(Protocol):
+    def __call__(self, url: str, *, output_directory: Path) -> Path | None: ...
+
+
+class FaviconResponse(Protocol):
+    def read(self) -> bytes: ...
+
+    def __enter__(self) -> FaviconResponse: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None: ...
+
+
+class FaviconOpener(Protocol):
+    def __call__(self, url: str, *, timeout: float) -> FaviconResponse: ...
+
+
+class OperationGuard:
+    """Accept one operation at a time and retire tokens by object identity."""
+
+    def __init__(self) -> None:
+        self._active: OpaqueToken | None = None
+        self._retired_or_active: weakref.WeakSet[OpaqueToken] = weakref.WeakSet()
+
+    @property
+    def active(self) -> bool:
+        return self._active is not None
+
+    def start(self, token: OpaqueToken) -> bool:
+        if self._active is not None or token in self._retired_or_active:
+            return False
+        self._active = token
+        self._retired_or_active.add(token)
+        return True
+
+    def is_current(self, token: OpaqueToken) -> bool:
+        return self._active is token
+
+    def finish(self, token: OpaqueToken) -> bool:
+        if self._active is not token:
+            return False
+        self._active = None
+        return True
+
+    def invalidate(self) -> None:
+        self._active = None
+
+
+def select_all_for_active_tab(
+    snapshots: Iterable[TileSnapshot], active_tab: str
+) -> tuple[OpaqueToken, ...]:
+    """Return each distinct token on the active tab, preserving input order."""
+
+    selected: list[OpaqueToken] = []
+    seen: set[OpaqueToken] = set()
+    for snapshot in snapshots:
+        if snapshot.tab == active_tab and snapshot.token not in seen:
+            selected.append(snapshot.token)
+            seen.add(snapshot.token)
+    return tuple(selected)
+
+
+def snapshot_matches(expected: TileSnapshot, current: TileSnapshot) -> bool:
+    """Compare captured fields only after confirming token identity."""
+
+    return (
+        expected.token is current.token
+        and expected.url == current.url
+        and expected.name == current.name
+        and expected.tab == current.tab
+        and expected.icon == current.icon
+        and expected.bg == current.bg
+        and expected.browser == current.browser
+        and expected.chrome_profile == current.chrome_profile
+        and expected.open_target == current.open_target
+    )
+
+
+def guess_domain(url: str) -> str:
+    """Preserve the launcher's existing netloc-based favicon domain rule."""
+
+    try:
+        netloc = urllib.parse.urlparse(url).netloc
+        return netloc.split("@")[-1]
+    except Exception:  # nosec B110 - existing silent-failure behavior
+        return ""
+
+
+def fetch_favicon(
+    url: str,
+    *,
+    output_directory: Path,
+    size: int = DEFAULT_FAVICON_SIZE,
+    timeout: float = FAVICON_TIMEOUT_SECONDS,
+    opener: FaviconOpener | None = None,
+) -> Path | None:
+    """Save a Google S2 favicon into an explicitly supplied directory."""
+
+    domain = guess_domain(url)
+    if not domain:
+        return None
+
+    output_path = _contained_favicon_path(output_directory, domain, size)
+    if output_path is None:
+        return None
+
+    source_url = f"https://www.google.com/s2/favicons?domain={domain}&sz={size}"
+    active_opener = opener or _default_favicon_opener
+    try:
+        with active_opener(source_url, timeout=timeout) as response:
+            with output_path.open("wb") as output_file:
+                output_file.write(response.read())
+        return output_path
+    except Exception:  # nosec B110 - preserve optional lookup's silent failure
+        return None
+
+
+def create_batch_staging_directory(managed_icon_directory: Path) -> Path:
+    """Create one uniquely owned refresh directory under managed icon storage."""
+
+    return Path(tempfile.mkdtemp(prefix="refresh-", dir=managed_icon_directory))
+
+
+def run_metadata_refresh(
+    snapshots: Sequence[TileSnapshot],
+    *,
+    output_directory: Path,
+    title_provider: TitleProvider = fetch_page_title,
+    favicon_provider: FaviconProvider = fetch_favicon,
+    cancellation: CancellationFlag | None = None,
+    max_workers: int = MAX_REFRESH_WORKERS,
+) -> tuple[RefreshResult, ...]:
+    """Resolve metadata off-thread with bounded, per-tile concurrency."""
+
+    _validate_max_workers(max_workers)
+    items = tuple(snapshots)
+    _validate_unique_tokens(items)
+    if not items:
+        return ()
+    if _is_cancelled(cancellation):
+        return tuple(_cancelled_result(snapshot) for snapshot in items)
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(
+                _resolve_one,
+                index,
+                snapshot,
+                output_directory,
+                title_provider,
+                favicon_provider,
+                cancellation,
+            )
+            for index, snapshot in enumerate(items)
+        ]
+        return tuple(future.result() for future in futures)
+
+
+def merge_refresh_result(
+    snapshot: TileSnapshot, result: RefreshResult
+) -> MergedMetadata:
+    """Resolve independent provider failures without mutating the snapshot."""
+
+    if snapshot.token is not result.token:
+        raise ValueError("refresh result token does not match snapshot")
+
+    metadata = result.metadata
+    refreshed_name = snapshot.name
+    refreshed_icon = snapshot.icon
+    if not result.cancelled:
+        if metadata.title_status is LookupStatus.SUCCESS and metadata.title is not None:
+            refreshed_name = metadata.title
+        if (
+            metadata.favicon_status is LookupStatus.SUCCESS
+            and metadata.icon_path is not None
+        ):
+            refreshed_icon = str(metadata.icon_path)
+
+    return MergedMetadata(
+        name=refreshed_name,
+        icon=refreshed_icon,
+        name_changed=refreshed_name != snapshot.name,
+        icon_changed=refreshed_icon != snapshot.icon,
+    )
+
+
+def summarize_refresh_results(
+    results: Iterable[RefreshResult],
+) -> RefreshDiagnostics:
+    """Build an aggregate summary that cannot disclose tile metadata."""
+
+    items = tuple(results)
+    error_types: Counter[str] = Counter()
+    for result in items:
+        metadata = result.metadata
+        if metadata.title_error_type is not None:
+            error_types[metadata.title_error_type] += 1
+        if metadata.favicon_error_type is not None:
+            error_types[metadata.favicon_error_type] += 1
+
+    return RefreshDiagnostics(
+        tile_count=len(items),
+        title_successes=_count_status(items, "title_status", LookupStatus.SUCCESS),
+        favicon_successes=_count_status(items, "favicon_status", LookupStatus.SUCCESS),
+        title_no_results=_count_status(items, "title_status", LookupStatus.NO_RESULT),
+        favicon_no_results=_count_status(
+            items, "favicon_status", LookupStatus.NO_RESULT
+        ),
+        title_errors=_count_status(items, "title_status", LookupStatus.ERROR),
+        favicon_errors=_count_status(items, "favicon_status", LookupStatus.ERROR),
+        cancelled_results=sum(result.cancelled for result in items),
+        exception_types=tuple(sorted(error_types.items())),
+    )
+
+
+def _default_favicon_opener(url: str, *, timeout: float) -> FaviconResponse:
+    return cast(
+        FaviconResponse,
+        urllib.request.urlopen(url, timeout=timeout),  # nosec B310
+    )
+
+
+def _contained_favicon_path(
+    output_directory: Path, domain: str, size: int
+) -> Path | None:
+    try:
+        resolved_directory = output_directory.resolve()
+        output_path = (resolved_directory / f"{domain}_{size}.png").resolve()
+    except (OSError, RuntimeError):
+        return None
+    if output_path.parent != resolved_directory:
+        return None
+    return output_path
+
+
+def _validate_max_workers(max_workers: int) -> None:
+    if type(max_workers) is not int or not 1 <= max_workers <= MAX_REFRESH_WORKERS:
+        raise ValueError("max_workers must be an integer from 1 through 4")
+
+
+def _validate_unique_tokens(snapshots: Sequence[TileSnapshot]) -> None:
+    seen: set[OpaqueToken] = set()
+    for snapshot in snapshots:
+        if snapshot.token in seen:
+            raise ValueError("refresh snapshots contain a duplicate token")
+        seen.add(snapshot.token)
+
+
+def _resolve_one(
+    index: int,
+    snapshot: TileSnapshot,
+    batch_directory: Path,
+    title_provider: TitleProvider,
+    favicon_provider: FaviconProvider,
+    cancellation: CancellationFlag | None,
+) -> RefreshResult:
+    if _is_cancelled(cancellation):
+        return _cancelled_result(snapshot)
+
+    try:
+        target_directory = Path(
+            tempfile.mkdtemp(prefix=f"tile-{index:04d}-", dir=batch_directory)
+        )
+    except OSError as exc:
+        if _is_cancelled(cancellation):
+            return _cancelled_result(snapshot)
+        title_status, title, title_error = _resolve_title(snapshot.url, title_provider)
+        return RefreshResult(
+            token=snapshot.token,
+            metadata=ResolvedMetadata(
+                title_status=title_status,
+                favicon_status=LookupStatus.ERROR,
+                title=title,
+                title_error_type=title_error,
+                favicon_error_type=_exception_type(exc),
+            ),
+            cancelled=_is_cancelled(cancellation),
+        )
+
+    if _is_cancelled(cancellation):
+        return _cancelled_result(snapshot, target_directory)
+
+    title_status, title, title_error = _resolve_title(snapshot.url, title_provider)
+    if _is_cancelled(cancellation):
+        return RefreshResult(
+            token=snapshot.token,
+            metadata=ResolvedMetadata(
+                title_status=title_status,
+                favicon_status=LookupStatus.CANCELLED,
+                title=title,
+                title_error_type=title_error,
+            ),
+            staging_directory=target_directory,
+            cancelled=True,
+        )
+
+    favicon_status, icon_path, favicon_error = _resolve_favicon(
+        snapshot.url, target_directory, favicon_provider
+    )
+    return RefreshResult(
+        token=snapshot.token,
+        metadata=ResolvedMetadata(
+            title_status=title_status,
+            favicon_status=favicon_status,
+            title=title,
+            icon_path=icon_path,
+            title_error_type=title_error,
+            favicon_error_type=favicon_error,
+        ),
+        staging_directory=target_directory,
+        cancelled=_is_cancelled(cancellation),
+    )
+
+
+def _resolve_title(
+    url: str, provider: TitleProvider
+) -> tuple[LookupStatus, str | None, str | None]:
+    try:
+        title = provider(url)
+    except Exception as exc:
+        return LookupStatus.ERROR, None, _exception_type(exc)
+    if title is None:
+        return LookupStatus.NO_RESULT, None, None
+    return LookupStatus.SUCCESS, title, None
+
+
+def _resolve_favicon(
+    url: str,
+    target_directory: Path,
+    provider: FaviconProvider,
+) -> tuple[LookupStatus, Path | None, str | None]:
+    try:
+        icon_path = provider(url, output_directory=target_directory)
+    except Exception as exc:
+        return LookupStatus.ERROR, None, _exception_type(exc)
+    if icon_path is None:
+        return LookupStatus.NO_RESULT, None, None
+    try:
+        if icon_path.is_symlink():
+            return LookupStatus.ERROR, None, "UnsafeStagingPath"
+        resolved_icon = icon_path.resolve()
+        resolved_target = target_directory.resolve()
+    except (OSError, RuntimeError) as exc:
+        return LookupStatus.ERROR, None, _exception_type(exc)
+    if resolved_icon.parent != resolved_target or not resolved_icon.is_file():
+        return LookupStatus.ERROR, None, "UnsafeStagingPath"
+    return LookupStatus.SUCCESS, resolved_icon, None
+
+
+def _cancelled_result(
+    snapshot: TileSnapshot, staging_directory: Path | None = None
+) -> RefreshResult:
+    return RefreshResult(
+        token=snapshot.token,
+        metadata=ResolvedMetadata(
+            title_status=LookupStatus.CANCELLED,
+            favicon_status=LookupStatus.CANCELLED,
+        ),
+        staging_directory=staging_directory,
+        cancelled=True,
+    )
+
+
+def _is_cancelled(cancellation: CancellationFlag | None) -> bool:
+    return cancellation is not None and cancellation.is_set()
+
+
+def _exception_type(exc: Exception) -> str:
+    return type(exc).__name__ or "Exception"
+
+
+def _count_status(
+    results: Sequence[RefreshResult],
+    attribute: Literal["title_status", "favicon_status"],
+    expected: LookupStatus,
+) -> int:
+    return sum(getattr(result.metadata, attribute) is expected for result in results)


### PR DESCRIPTION
Closes #102

## Summary

- Add active-tab tile selection with Select all, Clear selection, count, and Done controls.
- Suppress tile launching, context-menu mutations, and dragging during selection.
- Refresh selected names and icons independently from each tile’s current URL.
- Run bounded metadata work off the UI thread while retaining fields whose lookups fail.
- Stage icons safely, reject stale results, and save a detached configuration before swapping the live model.
- Cancel safely during application close without late refresh saves or leaked staging.
- Add visible mouse/keyboard focus, checked-state styling, and accessibility descriptions.
- Document network behavior and privacy-safe diagnostics.

## Validation

- `make format-check`
- `make lint`
- `make lint_tests`
- `.venv/Scripts/python.exe -m ruff check tests`
- `make typecheck`
- `make test_unit` — 285 unit-filtered nodes passed
- `git diff --check`

Manual Windows validation passed for selection, keyboard focus, reflow, toolbar overflow, interaction suppression, tab switching, confirmation, no-change cleanup, live refresh, independent lookup failure, persistence, and close-time cancellation.

No configuration schema changes were introduced.