### PR TITLE
ci: run lint and type checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: lint-and-typecheck
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- run the existing `lint-and-typecheck` workflow for pull requests targeting `main`
- retain the existing push-to-`main` and manual triggers
- leave every Ruff, mypy, offline, unit, CodeQL, build, release, and security workflow step unchanged

## Verification

- branch is one commit ahead of `main`
- diff is limited to two added workflow-trigger lines in `.github/workflows/ci.yml`
- this pull request itself should exercise the new PR trigger

Closes #104
