### PR TITLE
fix: recover safely from corrupt configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### App Behavior
+- Detect unreadable or corrupt configuration at startup and offer a safe default Exit or an
+  explicit preserve-and-reset flow before the launcher mutates configuration state.
 - Add active-tab tile selection with a selected count, Select all, Clear selection, and Done
   controls while preventing tile launches, context-menu changes, and dragging during selection.
 - Refresh selected tile names and icons only after overwrite confirmation; title and favicon
@@ -11,6 +13,8 @@
   model is swapped.
 
 ### Security/Privacy
+- Preserve and verify exact corrupt-configuration bytes before reset, keep verified copies in a
+  private recovery location, and record only curated failure categories and integer counts.
 - Disclose that an explicitly confirmed refresh attempts to contact each selected destination for
   its title and, when a host/domain can be derived, attempts to send that host/domain to Google's
   favicon service; URL import review remains offline.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ Prior releases were MIT; the text is preserved in [LICENSE-MIT](./LICENSE-MIT).
 SPDX-License-Identifier: Apache-2.0
 
 ## Usage
+
+### Configuration recovery
+
+DesktopTileLauncher reads at most 4 MiB of `config.json` for normal UTF-8 and
+JSON parsing. If an existing configuration cannot be loaded safely, startup
+offers exactly **Exit** or **Preserve and Reset**. Exit is the safe default and
+does not change the configuration or create a recovery copy.
+
+Preserve and Reset first streams the original bytes into a private per-user
+recovery directory beside, but not inside, the launcher icon directory. The
+copy is independently verified byte-for-byte before the normal first-run
+configuration is installed atomically. A reset is not attempted when copying,
+verification, or the final source-change check fails. Verified recovery copies
+are never overwritten or deleted automatically.
+
 ### Add tiles
 
 - Use the **Add** button on the toolbar.

--- a/config_persistence.py
+++ b/config_persistence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Protocol
 
@@ -21,8 +22,18 @@ def _write_and_sync(stream: _SyncableTextStream, text: str) -> None:
     os.fsync(stream.fileno())
 
 
-def atomic_write_text(path: Path, text: str) -> None:
-    """Replace *path* only after its complete text is synced in a sibling file."""
+def atomic_write_text(
+    path: Path,
+    text: str,
+    *,
+    before_replace: Callable[[], None] | None = None,
+) -> None:
+    """Replace *path* only after its complete text is synced in a sibling file.
+
+    ``before_replace`` runs after the sibling file is fully written and synced,
+    immediately before ``os.replace``. If the guard raises, this writer leaves
+    the destination unreplaced and cleans up only its own temporary file.
+    """
     temporary_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -36,6 +47,8 @@ def atomic_write_text(path: Path, text: str) -> None:
             temporary_path = Path(temporary.name)
             _write_and_sync(temporary, text)
 
+        if before_replace is not None:
+            before_replace()
         os.replace(temporary_path, path)
         temporary_path = None
     finally:

--- a/config_recovery.py
+++ b/config_recovery.py
@@ -1,0 +1,784 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, Qt-free loading and explicit recovery for ``config.json``.
+
+Normal parsing admits at most four MiB of encoded JSON.  Explicit recovery may
+stream a larger regular file with bounded memory after the user has chosen to
+preserve it.  The final source comparison and ``os.replace`` are adjacent, but
+portable Python does not provide a kernel-level compare-and-swap for file
+contents; a hostile same-user writer can therefore race that final boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, Generic, Protocol, TypeAlias, TypeVar, cast
+
+from config_persistence import atomic_write_text
+
+MAX_CONFIG_BYTES: Final = 4 * 1024 * 1024
+_IO_CHUNK_BYTES: Final = 64 * 1024
+_MAX_NAME_ATTEMPTS: Final = 32
+_TOKEN_PATTERN: Final = re.compile(r"[0-9a-f]{32}")
+_LEGACY_TILE_FIELDS: Final = frozenset(
+    {
+        "name",
+        "url",
+        "tab",
+        "icon",
+        "bg",
+        "browser",
+        "chrome_profile",
+        "open_target",
+    }
+)
+
+T = TypeVar("T")
+DiagnosticValue: TypeAlias = str | bool | int
+
+
+class ConfigLoadFailureCategory(StrEnum):
+    """Expected, privacy-safe reasons an existing configuration was rejected."""
+
+    FILE_READ_FAILURE = "file_read_failure"
+    SIZE_LIMIT_EXCEEDED = "size_limit_exceeded"
+    INVALID_UTF8 = "invalid_utf8"
+    MALFORMED_JSON = "malformed_json"
+    NON_OBJECT_ROOT = "non_object_root"
+    LEGACY_CONSTRUCTION_FAILURE = "legacy_construction_failure"
+
+
+class RecoveryFailureCategory(StrEnum):
+    """Expected, privacy-safe stages at which explicit recovery can fail."""
+
+    SOURCE_UNAVAILABLE = "source_unavailable"
+    SOURCE_CHANGED = "source_changed"
+    RECOVERY_DIRECTORY_FAILURE = "recovery_directory_failure"
+    RECOVERY_COPY_FAILURE = "recovery_copy_failure"
+    RECOVERY_VERIFICATION_FAILURE = "recovery_verification_failure"
+    RESET_FAILURE = "reset_failure"
+
+
+class LegacyConstructionFailure(Exception):
+    """Signal an expected incompatible shape in the current legacy object."""
+
+    def __init__(self) -> None:
+        super().__init__(ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE.value)
+
+
+def _is_legacy_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _require_legacy_field(
+    mapping: dict[str, object],
+    name: str,
+    predicate: Callable[[object], bool],
+) -> None:
+    if name in mapping and not predicate(mapping[name]):
+        raise LegacyConstructionFailure
+
+
+def _validate_legacy_tile(value: object) -> None:
+    if not isinstance(value, dict):
+        raise LegacyConstructionFailure
+    if not set(value).issubset(_LEGACY_TILE_FIELDS):
+        raise LegacyConstructionFailure
+
+    for name in ("name", "url"):
+        if name not in value or not isinstance(value[name], str):
+            raise LegacyConstructionFailure
+    for name in ("tab", "bg"):
+        if name in value and not isinstance(value[name], str):
+            raise LegacyConstructionFailure
+    for name in ("icon", "browser", "chrome_profile"):
+        field_value = value.get(name)
+        if (
+            name in value
+            and field_value is not None
+            and not isinstance(field_value, str)
+        ):
+            raise LegacyConstructionFailure
+    if "open_target" in value and value["open_target"] not in ("tab", "window"):
+        raise LegacyConstructionFailure
+
+
+def validate_legacy_mapping(mapping: dict[str, object]) -> None:
+    """Reject legacy values that cannot safely construct the current runtime model."""
+
+    _require_legacy_field(mapping, "title", lambda value: isinstance(value, str))
+    _require_legacy_field(mapping, "columns", _is_legacy_int)
+    _require_legacy_field(mapping, "auto_fit", lambda value: isinstance(value, bool))
+    for name in ("window_x", "window_y", "window_w", "window_h"):
+        _require_legacy_field(
+            mapping,
+            name,
+            lambda value: value is None or _is_legacy_int(value),
+        )
+    for name in ("tabs", "hidden_tabs"):
+        _require_legacy_field(
+            mapping,
+            name,
+            lambda value: value is None or isinstance(value, list),
+        )
+
+    if "tiles" not in mapping:
+        return
+    tiles = mapping["tiles"]
+    if not isinstance(tiles, list):
+        raise LegacyConstructionFailure
+    for tile in tiles:
+        _validate_legacy_tile(tile)
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _FileFingerprint:
+    device: int
+    inode: int
+    mode: int
+    size: int
+    mtime_ns: int
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class SourceSnapshot:
+    """Private evidence identifying the bytes rejected during bounded loading."""
+
+    path_fingerprint: _FileFingerprint = field(repr=False)
+    target_fingerprint: _FileFingerprint = field(repr=False)
+    content_fingerprint: _FileFingerprint = field(repr=False)
+    evidence_byte_count: int
+    evidence_sha256: bytes = field(repr=False)
+    evidence_is_complete: bool
+    source_is_redirected: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigMissing:
+    """The expected configuration path did not exist."""
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigLoaded(Generic[T]):
+    """A configuration was parsed and constructed successfully."""
+
+    value: T = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigRecoveryRequired:
+    """An existing configuration could not be safely constructed."""
+
+    category: ConfigLoadFailureCategory
+    snapshot: SourceSnapshot | None = field(default=None, repr=False)
+
+
+ConfigLoadResult: TypeAlias = ConfigMissing | ConfigLoaded[T] | ConfigRecoveryRequired
+
+
+class ConfigurationLoadError(Exception):
+    """Category-only exception for legacy callers of ``LauncherConfig.load``."""
+
+    def __init__(
+        self,
+        category: ConfigLoadFailureCategory,
+        snapshot: SourceSnapshot | None,
+    ) -> None:
+        self.category = category
+        self.snapshot = snapshot
+        super().__init__(category.value)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(category={self.category.value!r})"
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverySucceeded:
+    """A reset succeeded after one permanent recovery path was published."""
+
+    recovery_copy_count: int = 1
+    reset_count: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryFailed:
+    """A failed recovery, counting permanent paths published before failure."""
+
+    category: RecoveryFailureCategory
+    recovery_copy_count: int = 0
+    reset_count: int = 0
+
+
+RecoveryResult: TypeAlias = RecoverySucceeded | RecoveryFailed
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _OpenedSource:
+    descriptor: int
+    path_fingerprint: _FileFingerprint
+    target_fingerprint: _FileFingerprint
+    content_fingerprint: _FileFingerprint
+    redirected: bool
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _VerifiedCopy:
+    path: Path = field(repr=False)
+    byte_count: int
+    sha256: bytes = field(repr=False)
+
+
+class _FileSafetyFailure(Exception):
+    pass
+
+
+class _SourceChanged(Exception):
+    pass
+
+
+class _GuardFailure(Exception):
+    def __init__(self, category: RecoveryFailureCategory) -> None:
+        self.category = category
+        super().__init__(category.value)
+
+
+class _BinaryStream(Protocol):
+    def write(self, data: bytes, /) -> int: ...
+
+    def flush(self) -> None: ...
+
+    def fileno(self) -> int: ...
+
+
+def recovery_required_diagnostics(
+    category: ConfigLoadFailureCategory,
+) -> dict[str, DiagnosticValue]:
+    return {"failure_category": category.value, "failure_count": 1}
+
+
+def recovery_exit_diagnostics(
+    category: ConfigLoadFailureCategory,
+) -> dict[str, DiagnosticValue]:
+    return {"failure_category": category.value, "exit_count": 1}
+
+
+def recovery_result_diagnostics(result: RecoveryResult) -> dict[str, DiagnosticValue]:
+    fields: dict[str, DiagnosticValue] = {
+        "recovery_copy_count": result.recovery_copy_count,
+        "reset_count": result.reset_count,
+    }
+    if isinstance(result, RecoveryFailed):
+        fields["failure_category"] = result.category.value
+    return fields
+
+
+def _fingerprint(metadata: os.stat_result) -> _FileFingerprint:
+    return _FileFingerprint(
+        device=metadata.st_dev,
+        inode=metadata.st_ino,
+        mode=metadata.st_mode,
+        size=metadata.st_size,
+        mtime_ns=metadata.st_mtime_ns,
+    )
+
+
+def _is_reparse_point(metadata: os.stat_result) -> bool:
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    return (
+        isinstance(attributes, int)
+        and isinstance(reparse_flag, int)
+        and bool(attributes & reparse_flag)
+    )
+
+
+def _require_regular(metadata: os.stat_result) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise _FileSafetyFailure
+
+
+def _open_flags(*, no_follow: bool) -> int:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    if no_follow:
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _open_source(path: Path) -> _OpenedSource:
+    path_metadata = path.lstat()
+    redirected = stat.S_ISLNK(path_metadata.st_mode) or _is_reparse_point(path_metadata)
+    if not redirected:
+        _require_regular(path_metadata)
+
+    target_metadata = path.stat()
+    _require_regular(target_metadata)
+    descriptor = os.open(path, _open_flags(no_follow=not redirected))
+    try:
+        opened_metadata = os.fstat(descriptor)
+        _require_regular(opened_metadata)
+        if not os.path.samestat(target_metadata, opened_metadata):
+            raise _SourceChanged
+        if _fingerprint(path.lstat()) != _fingerprint(path_metadata):
+            raise _SourceChanged
+    except Exception:
+        os.close(descriptor)
+        raise
+
+    return _OpenedSource(
+        descriptor=descriptor,
+        path_fingerprint=_fingerprint(path_metadata),
+        target_fingerprint=_fingerprint(target_metadata),
+        content_fingerprint=_fingerprint(opened_metadata),
+        redirected=redirected,
+    )
+
+
+def _read_bounded(descriptor: int, maximum: int) -> bytes:
+    content = bytearray()
+    admitted = maximum + 1
+    while len(content) < admitted:
+        chunk = os.read(descriptor, min(_IO_CHUNK_BYTES, admitted - len(content)))
+        if not chunk:
+            break
+        content.extend(chunk)
+    return bytes(content)
+
+
+def _source_still_matches(path: Path, opened: _OpenedSource) -> bool:
+    try:
+        opened_metadata = os.fstat(opened.descriptor)
+        target_metadata = path.stat()
+        return (
+            _fingerprint(opened_metadata) == opened.content_fingerprint
+            and _fingerprint(path.lstat()) == opened.path_fingerprint
+            and _fingerprint(target_metadata) == opened.target_fingerprint
+            and os.path.samestat(target_metadata, opened_metadata)
+        )
+    except OSError:
+        return False
+
+
+def load_config(
+    path: Path,
+    constructor: Callable[[dict[str, object]], T],
+    *,
+    max_bytes: int = MAX_CONFIG_BYTES,
+) -> ConfigLoadResult[T]:
+    """Read and construct an existing configuration without modifying it."""
+
+    if not 0 < max_bytes <= MAX_CONFIG_BYTES:
+        raise ValueError(f"max_bytes must be between 1 and {MAX_CONFIG_BYTES}")
+
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return ConfigMissing()
+    except OSError:
+        return ConfigRecoveryRequired(ConfigLoadFailureCategory.FILE_READ_FAILURE)
+
+    try:
+        opened = _open_source(path)
+        try:
+            raw = _read_bounded(opened.descriptor, max_bytes)
+            stable = _source_still_matches(path, opened)
+        finally:
+            os.close(opened.descriptor)
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        return ConfigRecoveryRequired(ConfigLoadFailureCategory.FILE_READ_FAILURE)
+
+    if not stable:
+        return ConfigRecoveryRequired(ConfigLoadFailureCategory.FILE_READ_FAILURE)
+
+    oversized = len(raw) > max_bytes
+    snapshot = SourceSnapshot(
+        path_fingerprint=opened.path_fingerprint,
+        target_fingerprint=opened.target_fingerprint,
+        content_fingerprint=opened.content_fingerprint,
+        evidence_byte_count=len(raw),
+        evidence_sha256=hashlib.sha256(raw).digest(),
+        evidence_is_complete=not oversized,
+        source_is_redirected=opened.redirected,
+    )
+    if oversized:
+        return ConfigRecoveryRequired(
+            ConfigLoadFailureCategory.SIZE_LIMIT_EXCEEDED,
+            snapshot,
+        )
+
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return ConfigRecoveryRequired(ConfigLoadFailureCategory.INVALID_UTF8, snapshot)
+
+    try:
+        parsed = json.loads(decoded)
+    except (ValueError, RecursionError):
+        return ConfigRecoveryRequired(
+            ConfigLoadFailureCategory.MALFORMED_JSON, snapshot
+        )
+
+    if not isinstance(parsed, dict):
+        return ConfigRecoveryRequired(
+            ConfigLoadFailureCategory.NON_OBJECT_ROOT, snapshot
+        )
+
+    try:
+        value = constructor(cast(dict[str, object], parsed))
+    except LegacyConstructionFailure:
+        return ConfigRecoveryRequired(
+            ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE,
+            snapshot,
+        )
+    return ConfigLoaded(value)
+
+
+def _snapshot_matches_opened(snapshot: SourceSnapshot, opened: _OpenedSource) -> bool:
+    return (
+        not snapshot.source_is_redirected
+        and not opened.redirected
+        and opened.path_fingerprint == snapshot.path_fingerprint
+        and opened.target_fingerprint == snapshot.target_fingerprint
+        and opened.content_fingerprint == snapshot.content_fingerprint
+    )
+
+
+def _read_evidence(descriptor: int, byte_count: int) -> bytes:
+    evidence = bytearray()
+    while len(evidence) < byte_count:
+        chunk = os.read(
+            descriptor,
+            min(_IO_CHUNK_BYTES, byte_count - len(evidence)),
+        )
+        if not chunk:
+            break
+        evidence.extend(chunk)
+    return bytes(evidence)
+
+
+def _open_matching_source(path: Path, snapshot: SourceSnapshot) -> _OpenedSource:
+    opened = _open_source(path)
+    try:
+        if not _snapshot_matches_opened(snapshot, opened):
+            raise _SourceChanged
+        evidence = _read_evidence(opened.descriptor, snapshot.evidence_byte_count)
+        if len(evidence) != snapshot.evidence_byte_count:
+            raise _SourceChanged
+        if hashlib.sha256(evidence).digest() != snapshot.evidence_sha256:
+            raise _SourceChanged
+        if snapshot.evidence_is_complete and os.read(opened.descriptor, 1):
+            raise _SourceChanged
+        if not _source_still_matches(path, opened):
+            raise _SourceChanged
+        os.lseek(opened.descriptor, 0, os.SEEK_SET)
+        return opened
+    except Exception:
+        os.close(opened.descriptor)
+        raise
+
+
+def _resolved_recovery_directory(config_path: Path) -> Path:
+    config_parent = config_path.parent.resolve(strict=True)
+    recovery_directory = config_path.parent / "recovery"
+    try:
+        recovery_directory.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+
+    metadata = recovery_directory.lstat()
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or _is_reparse_point(metadata)
+    ):
+        raise _FileSafetyFailure
+    resolved = recovery_directory.resolve(strict=True)
+    if resolved.parent != config_parent or resolved.name != "recovery":
+        raise _FileSafetyFailure
+    if os.name != "nt":
+        recovery_directory.chmod(0o700)
+        if stat.S_IMODE(recovery_directory.stat().st_mode) & 0o077:
+            raise _FileSafetyFailure
+    return recovery_directory
+
+
+def _new_token() -> str:
+    return secrets.token_hex(16)
+
+
+def _safe_token() -> str:
+    token = _new_token()
+    if _TOKEN_PATTERN.fullmatch(token) is None:
+        raise _FileSafetyFailure
+    return token
+
+
+def _allocate_staging_file(recovery_directory: Path) -> tuple[Path, int]:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    for _attempt in range(_MAX_NAME_ATTEMPTS):
+        path = recovery_directory / f".config-{_safe_token()}.partial"
+        if path.parent != recovery_directory:
+            raise _FileSafetyFailure
+        try:
+            descriptor = os.open(path, flags, 0o600)
+        except FileExistsError:
+            continue
+        try:
+            if os.name != "nt":
+                path.chmod(0o600)
+        except OSError:
+            os.close(descriptor)
+            _cleanup_staging(path)
+            raise
+        return path, descriptor
+    raise OSError("recovery staging name allocation failed")
+
+
+def _write_chunk(stream: _BinaryStream, chunk: bytes) -> None:
+    if stream.write(chunk) != len(chunk):
+        raise OSError("short recovery write")
+
+
+def _flush_and_sync(stream: _BinaryStream) -> None:
+    stream.flush()
+    os.fsync(stream.fileno())
+
+
+def _copy_source(
+    source: _OpenedSource,
+    source_path: Path,
+    destination_descriptor: int,
+) -> tuple[int, bytes]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    with os.fdopen(destination_descriptor, "wb") as destination:
+        remaining = source.content_fingerprint.size
+        while remaining:
+            chunk = os.read(source.descriptor, min(_IO_CHUNK_BYTES, remaining))
+            if not chunk:
+                raise _SourceChanged
+            _write_chunk(destination, chunk)
+            digest.update(chunk)
+            byte_count += len(chunk)
+            remaining -= len(chunk)
+        if os.read(source.descriptor, 1):
+            raise _SourceChanged
+        _flush_and_sync(destination)
+    if not _source_still_matches(source_path, source):
+        raise _SourceChanged
+    return byte_count, digest.digest()
+
+
+def _hash_stable_path(
+    path: Path,
+    *,
+    allow_redirected: bool = False,
+) -> tuple[_FileFingerprint, int, bytes]:
+    opened = _open_source(path)
+    try:
+        if opened.redirected and not allow_redirected:
+            raise _FileSafetyFailure
+        digest = hashlib.sha256()
+        byte_count = 0
+        while True:
+            chunk = os.read(opened.descriptor, _IO_CHUNK_BYTES)
+            if not chunk:
+                break
+            digest.update(chunk)
+            byte_count += len(chunk)
+        if not _source_still_matches(path, opened):
+            raise _SourceChanged
+        return opened.content_fingerprint, byte_count, digest.digest()
+    finally:
+        os.close(opened.descriptor)
+
+
+def _cleanup_staging(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def _publish_verified_copy(
+    staging_path: Path,
+    recovery_directory: Path,
+    expected_count: int,
+    expected_digest: bytes,
+) -> _VerifiedCopy:
+    for _attempt in range(_MAX_NAME_ATTEMPTS):
+        final_path = recovery_directory / f"config-{_safe_token()}.recovery"
+        if final_path.parent != recovery_directory:
+            raise _FileSafetyFailure
+        try:
+            if os.name == "nt":
+                os.rename(staging_path, final_path)
+            else:
+                os.link(staging_path, final_path)
+        except FileExistsError:
+            continue
+        # Windows rename does not replace an existing destination.  POSIX uses
+        # a hard link because its rename operation would replace one.
+        return _VerifiedCopy(final_path, expected_count, expected_digest)
+    raise OSError("recovery filename allocation failed")
+
+
+def _verify_source_and_copy(
+    config_path: Path,
+    snapshot: SourceSnapshot,
+    verified: _VerifiedCopy,
+) -> None:
+    try:
+        opened = _open_matching_source(config_path, snapshot)
+        try:
+            source_digest = hashlib.sha256()
+            source_count = 0
+            while True:
+                chunk = os.read(opened.descriptor, _IO_CHUNK_BYTES)
+                if not chunk:
+                    break
+                source_digest.update(chunk)
+                source_count += len(chunk)
+            if not _source_still_matches(config_path, opened):
+                raise _SourceChanged
+        finally:
+            os.close(opened.descriptor)
+        if (
+            source_count != verified.byte_count
+            or source_digest.digest() != verified.sha256
+        ):
+            raise _SourceChanged
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        raise _GuardFailure(RecoveryFailureCategory.SOURCE_CHANGED) from None
+
+    try:
+        _copy_fingerprint, copy_count, copy_digest = _hash_stable_path(verified.path)
+        if copy_count != verified.byte_count or copy_digest != verified.sha256:
+            raise _GuardFailure(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
+    except _GuardFailure:
+        raise
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        raise _GuardFailure(
+            RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+        ) from None
+
+
+def preserve_and_reset(
+    config_path: Path,
+    snapshot: SourceSnapshot | None,
+    replacement_text: str,
+) -> RecoveryResult:
+    """Preserve the detected source, verify it, then atomically install reset text."""
+
+    if snapshot is None or snapshot.source_is_redirected:
+        return RecoveryFailed(RecoveryFailureCategory.SOURCE_UNAVAILABLE)
+
+    try:
+        source = _open_matching_source(config_path, snapshot)
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        return RecoveryFailed(RecoveryFailureCategory.SOURCE_CHANGED)
+
+    staging_path: Path | None = None
+    try:
+        copy_outcome: tuple[Path, Path, int, bytes] | RecoveryFailed = RecoveryFailed(
+            RecoveryFailureCategory.RECOVERY_COPY_FAILURE
+        )
+        try:
+            try:
+                recovery_directory = _resolved_recovery_directory(config_path)
+            except (OSError, RuntimeError, _FileSafetyFailure):
+                copy_outcome = RecoveryFailed(
+                    RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE
+                )
+            else:
+                try:
+                    staging_path, destination_descriptor = _allocate_staging_file(
+                        recovery_directory
+                    )
+                    byte_count, digest = _copy_source(
+                        source,
+                        config_path,
+                        destination_descriptor,
+                    )
+                except _SourceChanged:
+                    copy_outcome = RecoveryFailed(
+                        RecoveryFailureCategory.SOURCE_CHANGED
+                    )
+                except (OSError, _FileSafetyFailure):
+                    copy_outcome = RecoveryFailed(
+                        RecoveryFailureCategory.RECOVERY_COPY_FAILURE
+                    )
+                else:
+                    copy_outcome = (
+                        staging_path,
+                        recovery_directory,
+                        byte_count,
+                        digest,
+                    )
+        finally:
+            try:
+                os.close(source.descriptor)
+            except OSError:
+                if isinstance(copy_outcome, tuple):
+                    copy_outcome = RecoveryFailed(
+                        RecoveryFailureCategory.RECOVERY_COPY_FAILURE
+                    )
+
+        if isinstance(copy_outcome, RecoveryFailed):
+            return copy_outcome
+        staged_path, recovery_directory, byte_count, digest = copy_outcome
+
+        try:
+            _stage_fingerprint, verified_count, verified_digest = _hash_stable_path(
+                staged_path
+            )
+        except (OSError, _FileSafetyFailure, _SourceChanged):
+            return RecoveryFailed(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
+        if verified_count != byte_count or verified_digest != digest:
+            return RecoveryFailed(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
+
+        try:
+            verified = _publish_verified_copy(
+                staged_path,
+                recovery_directory,
+                byte_count,
+                digest,
+            )
+        except (OSError, _FileSafetyFailure, _SourceChanged):
+            return RecoveryFailed(RecoveryFailureCategory.RECOVERY_COPY_FAILURE)
+
+        _cleanup_staging(staged_path)
+        staging_path = None
+
+        def guard() -> None:
+            _verify_source_and_copy(config_path, snapshot, verified)
+
+        try:
+            atomic_write_text(config_path, replacement_text, before_replace=guard)
+        except _GuardFailure as failure:
+            return RecoveryFailed(
+                failure.category,
+                recovery_copy_count=1,
+            )
+        except OSError:
+            return RecoveryFailed(
+                RecoveryFailureCategory.RESET_FAILURE,
+                recovery_copy_count=1,
+            )
+        return RecoverySucceeded()
+    finally:
+        _cleanup_staging(staging_path)

--- a/tests/test_auto_columns.py
+++ b/tests/test_auto_columns.py
@@ -17,7 +17,7 @@ def test_expands_to_seven_columns(tmp_path, monkeypatch):
     cfg.save()
 
     app = QApplication([])
-    main = Main()
+    main = Main(cfg)
     assert main.cfg.columns == 7  # nosec B101
 
     app.quit()

--- a/tests/unit/test_config_persistence.py
+++ b/tests/unit/test_config_persistence.py
@@ -79,3 +79,58 @@ def test_replace_failure_preserves_original_and_removes_temporary_file(
     assert not observed_temporary_paths[0].exists()
     assert config_path.read_bytes() == original
     assert set(tmp_path.iterdir()) == {config_path}
+
+
+def test_before_replace_runs_after_sync_and_immediately_before_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("original", encoding="utf-8")
+    events: list[str] = []
+    real_write_and_sync = config_persistence._write_and_sync
+    real_replace = config_persistence.os.replace
+
+    def tracked_write_and_sync(
+        stream: config_persistence._SyncableTextStream,
+        text: str,
+    ) -> None:
+        events.append("write_and_sync")
+        real_write_and_sync(stream, text)
+
+    def guard() -> None:
+        events.append("guard")
+        assert config_path.read_text(encoding="utf-8") == "original"  # nosec B101
+
+    def tracked_replace(source: Path, destination: Path) -> None:
+        events.append("replace")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(config_persistence, "_write_and_sync", tracked_write_and_sync)
+    monkeypatch.setattr(config_persistence.os, "replace", tracked_replace)
+
+    atomic_write_text(config_path, "replacement", before_replace=guard)
+
+    assert events == ["write_and_sync", "guard", "replace"]  # nosec B101
+    assert config_path.read_text(encoding="utf-8") == "replacement"  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_before_replace_failure_preserves_original_and_removes_temporary_file(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"original"
+    config_path.write_bytes(original)
+
+    def reject_replace() -> None:
+        raise RuntimeError("synthetic guard rejection")
+
+    with pytest.raises(RuntimeError, match="synthetic guard rejection"):
+        atomic_write_text(
+            config_path,
+            "replacement",
+            before_replace=reject_replace,
+        )
+
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101

--- a/tests/unit/test_config_recovery.py
+++ b/tests/unit/test_config_recovery.py
@@ -1,0 +1,1036 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
+from typing import NoReturn
+
+import pytest
+
+import config_recovery
+from config_recovery import (
+    MAX_CONFIG_BYTES,
+    ConfigLoaded,
+    ConfigLoadFailureCategory,
+    ConfigMissing,
+    ConfigRecoveryRequired,
+    ConfigurationLoadError,
+    LegacyConstructionFailure,
+    RecoveryFailed,
+    RecoveryFailureCategory,
+    RecoverySucceeded,
+    load_config,
+    preserve_and_reset,
+    recovery_exit_diagnostics,
+    recovery_required_diagnostics,
+    recovery_result_diagnostics,
+    validate_legacy_mapping,
+)
+
+pytestmark = pytest.mark.unit
+
+_RESET_TEXT = '{"title": "Reset"}'
+_CORRUPT_BYTES = b'{"private":"https://example.test/?token=sample"'
+
+
+def _identity(mapping: dict[str, object]) -> dict[str, object]:
+    return mapping
+
+
+def _rejected(
+    path: Path,
+    *,
+    max_bytes: int = MAX_CONFIG_BYTES,
+) -> ConfigRecoveryRequired:
+    result = load_config(path, _identity, max_bytes=max_bytes)
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    return result
+
+
+def _recovery_files(config_path: Path) -> list[Path]:
+    recovery_directory = config_path.parent / "recovery"
+    if not recovery_directory.exists():
+        return []
+    return sorted(recovery_directory.glob("config-*.recovery"))
+
+
+def _fail_source_close_after_real_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[int]:
+    real_open_matching_source = config_recovery._open_matching_source
+    real_close = config_recovery.os.close
+    source_descriptors: set[int] = set()
+    failed_descriptors: list[int] = []
+
+    def track_source(
+        path: Path,
+        snapshot: config_recovery.SourceSnapshot,
+    ) -> config_recovery._OpenedSource:
+        source = real_open_matching_source(path, snapshot)
+        source_descriptors.add(source.descriptor)
+        return source
+
+    def close_then_fail(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor in source_descriptors:
+            source_descriptors.remove(descriptor)
+            failed_descriptors.append(descriptor)
+            raise OSError("synthetic source close failure")
+
+    monkeypatch.setattr(config_recovery, "_open_matching_source", track_source)
+    monkeypatch.setattr(config_recovery.os, "close", close_then_fail)
+    return failed_descriptors
+
+
+def test_missing_configuration_returns_missing_without_mutation(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    constructor_called = False
+
+    def constructor(_mapping: dict[str, object]) -> object:
+        nonlocal constructor_called
+        constructor_called = True
+        return object()
+
+    result = load_config(config_path, constructor)
+
+    assert isinstance(result, ConfigMissing)  # nosec B101
+    assert not constructor_called  # nosec B101
+    assert list(tmp_path.iterdir()) == []  # nosec B101
+
+
+def test_valid_unicode_configuration_loads_without_mutation(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = {"title": "Café 東京", "tiles": []}
+    original = json.dumps(payload, ensure_ascii=False).encode()
+    config_path.write_bytes(original)
+    calls: list[dict[str, object]] = []
+
+    def constructor(mapping: dict[str, object]) -> dict[str, object]:
+        calls.append(mapping)
+        return mapping
+
+    result = load_config(config_path, constructor)
+
+    assert isinstance(result, ConfigLoaded)  # nosec B101
+    assert result.value == payload  # nosec B101
+    assert calls == [payload]  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def _object_payload_of_size(size: int) -> bytes:
+    prefix = b'{"padding":"'
+    suffix = b'"}'
+    return prefix + (b"x" * (size - len(prefix) - len(suffix))) + suffix
+
+
+def test_exactly_four_mib_is_admitted(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_object_payload_of_size(MAX_CONFIG_BYTES))
+
+    result = load_config(config_path, _identity)
+
+    assert isinstance(result, ConfigLoaded)  # nosec B101
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1, MAX_CONFIG_BYTES + 1])
+def test_configured_limit_cannot_bypass_four_mib_ceiling(
+    tmp_path: Path,
+    max_bytes: int,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="max_bytes must be between"):
+        load_config(config_path, _identity, max_bytes=max_bytes)
+
+
+def test_four_mib_plus_one_is_rejected_before_construction(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_object_payload_of_size(MAX_CONFIG_BYTES + 1))
+    constructor_called = False
+
+    def constructor(_mapping: dict[str, object]) -> object:
+        nonlocal constructor_called
+        constructor_called = True
+        return object()
+
+    result = load_config(config_path, constructor)
+
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    assert result.category is ConfigLoadFailureCategory.SIZE_LIMIT_EXCEEDED  # nosec B101
+    assert result.snapshot is not None  # nosec B101
+    assert result.snapshot.evidence_byte_count == MAX_CONFIG_BYTES + 1  # nosec B101
+    assert not constructor_called  # nosec B101
+
+
+def test_loading_reads_no_more_than_configured_limit_plus_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    max_bytes = 32
+    config_path.write_bytes(_object_payload_of_size(128))
+    real_read = config_recovery.os.read
+    requested_sizes: list[int] = []
+    returned_sizes: list[int] = []
+
+    def tracked_read(descriptor: int, size: int) -> bytes:
+        requested_sizes.append(size)
+        content = real_read(descriptor, size)
+        returned_sizes.append(len(content))
+        return content
+
+    monkeypatch.setattr(config_recovery.os, "read", tracked_read)
+
+    result = load_config(config_path, _identity, max_bytes=max_bytes)
+
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    assert result.category is ConfigLoadFailureCategory.SIZE_LIMIT_EXCEEDED  # nosec B101
+    assert sum(returned_sizes) == max_bytes + 1  # nosec B101
+    assert requested_sizes  # nosec B101
+    assert max(requested_sizes) <= max_bytes + 1  # nosec B101
+
+
+def test_file_read_failure_is_sanitized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    def fail_open(_path: Path) -> NoReturn:
+        raise PermissionError("synthetic-private-path")
+
+    monkeypatch.setattr(config_recovery, "_open_source", fail_open)
+
+    result = load_config(config_path, _identity)
+
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    assert result.category is ConfigLoadFailureCategory.FILE_READ_FAILURE  # nosec B101
+    assert "synthetic-private-path" not in repr(result)  # nosec B101
+    assert str(config_path) not in repr(result)  # nosec B101
+
+
+def test_invalid_utf8_is_classified(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(b"\xff\xfe")
+
+    result = _rejected(config_path)
+
+    assert result.category is ConfigLoadFailureCategory.INVALID_UTF8  # nosec B101
+
+
+@pytest.mark.parametrize("payload", [b"{", b"\xef\xbb\xbf{}"])
+def test_malformed_json_and_bom_are_classified(tmp_path: Path, payload: bytes) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(payload)
+
+    result = _rejected(config_path)
+
+    assert result.category is ConfigLoadFailureCategory.MALFORMED_JSON  # nosec B101
+
+
+@pytest.mark.parametrize("payload", [b"[]", b'"text"', b"1", b"true", b"null"])
+def test_every_non_object_root_is_rejected(tmp_path: Path, payload: bytes) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(payload)
+
+    result = _rejected(config_path)
+
+    assert result.category is ConfigLoadFailureCategory.NON_OBJECT_ROOT  # nosec B101
+
+
+def test_expected_legacy_construction_failure_is_classified(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    def incompatible(_mapping: dict[str, object]) -> NoReturn:
+        raise LegacyConstructionFailure
+
+    result = load_config(config_path, incompatible)
+
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    assert (  # nosec B101
+        result.category is ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE
+    )
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    [
+        (TypeError, "synthetic type defect"),
+        (RuntimeError, "synthetic runtime defect"),
+    ],
+)
+def test_unexpected_constructor_failure_remains_visible(
+    tmp_path: Path,
+    exception_type: type[Exception],
+    message: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    def broken_implementation(_mapping: dict[str, object]) -> NoReturn:
+        validate_legacy_mapping(_mapping)
+        raise exception_type(message)
+
+    with pytest.raises(exception_type, match=message):
+        load_config(config_path, broken_implementation)
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        pytest.param({"title": []}, id="title-list"),
+        pytest.param({"title": None}, id="title-null"),
+        pytest.param({"columns": "five"}, id="columns-string"),
+        pytest.param({"columns": 5.0}, id="columns-float"),
+        pytest.param({"columns": True}, id="columns-bool"),
+        pytest.param({"auto_fit": 1}, id="auto-fit-non-bool"),
+        pytest.param({"window_x": True}, id="window-x-bool"),
+        pytest.param({"window_y": 1.5}, id="window-y-float"),
+        pytest.param({"window_w": "100"}, id="window-w-string"),
+        pytest.param({"window_h": []}, id="window-h-list"),
+        pytest.param({"tiles": None}, id="tiles-null"),
+        pytest.param({"tiles": {}}, id="tiles-object"),
+        pytest.param({"tiles": ["tile"]}, id="tile-non-object"),
+        pytest.param({"tiles": [{"url": "https://example.test"}]}, id="missing-name"),
+        pytest.param({"tiles": [{"name": "Example"}]}, id="missing-url"),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "unknown": "value",
+                    }
+                ]
+            },
+            id="unknown-tile-field",
+        ),
+        pytest.param(
+            {"tiles": [{"name": 1, "url": "https://example.test"}]},
+            id="tile-name-type",
+        ),
+        pytest.param(
+            {"tiles": [{"name": "Example", "url": None}]},
+            id="tile-url-type",
+        ),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "tab": None,
+                    }
+                ]
+            },
+            id="tile-tab-type",
+        ),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "bg": 1,
+                    }
+                ]
+            },
+            id="tile-bg-type",
+        ),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "icon": 1,
+                    }
+                ]
+            },
+            id="tile-icon-type",
+        ),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "browser": False,
+                    }
+                ]
+            },
+            id="tile-browser-type",
+        ),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "chrome_profile": [],
+                    }
+                ]
+            },
+            id="tile-chrome-profile-type",
+        ),
+        pytest.param(
+            {
+                "tiles": [
+                    {
+                        "name": "Example",
+                        "url": "https://example.test",
+                        "open_target": "popup",
+                    }
+                ]
+            },
+            id="invalid-open-target",
+        ),
+        pytest.param({"tabs": "Main"}, id="tabs-string"),
+        pytest.param({"tabs": {}}, id="tabs-object"),
+        pytest.param({"hidden_tabs": "Hidden"}, id="hidden-tabs-string"),
+        pytest.param({"hidden_tabs": {}}, id="hidden-tabs-object"),
+    ],
+)
+def test_shallow_legacy_validator_rejects_incompatible_values(
+    mapping: dict[str, object],
+) -> None:
+    with pytest.raises(LegacyConstructionFailure):
+        validate_legacy_mapping(mapping)
+
+
+def test_shallow_legacy_validator_accepts_current_unicode_values() -> None:
+    mapping: dict[str, object] = {
+        "title": "Café 東京",
+        "columns": 5,
+        "auto_fit": True,
+        "window_x": None,
+        "window_y": -25,
+        "window_w": 800,
+        "window_h": 600,
+        "tiles": [
+            {
+                "name": "Résumé",
+                "url": "https://例え.test",
+                "tab": "メイン",
+                "icon": None,
+                "bg": "#ffffff",
+                "browser": "chrome",
+                "chrome_profile": None,
+                "open_target": "window",
+            }
+        ],
+        "tabs": ["メイン"],
+        "hidden_tabs": None,
+    }
+    original = deepcopy(mapping)
+
+    validate_legacy_mapping(mapping)
+
+    assert mapping == original  # nosec B101
+
+
+def test_shallow_legacy_validator_allows_filtered_tab_entries() -> None:
+    mapping: dict[str, object] = {
+        "tabs": ["Main", 1, None, {"ignored": True}, []],
+        "hidden_tabs": ["Hidden", False, None, ["ignored"]],
+    }
+    original = deepcopy(mapping)
+
+    validate_legacy_mapping(mapping)
+
+    assert mapping == original  # nosec B101
+
+
+def test_shallow_legacy_validator_allows_unknown_top_level_fields() -> None:
+    mapping: dict[str, object] = {
+        "title": "Launcher",
+        "tabs": None,
+        "tab_ids": ["malformed-but-normalized-later"],
+        "tab_order": {"malformed": True},
+        "future_extension": {"retained": True},
+    }
+    original = deepcopy(mapping)
+
+    validate_legacy_mapping(mapping)
+
+    assert mapping == original  # nosec B101
+
+
+def test_invalid_legacy_value_is_classified_without_mutation(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"columns":"five"}'
+    config_path.write_bytes(original)
+    constructor_reached = False
+
+    def validated_constructor(mapping: dict[str, object]) -> dict[str, object]:
+        nonlocal constructor_reached
+        validate_legacy_mapping(mapping)
+        constructor_reached = True
+        return mapping
+
+    result = load_config(config_path, validated_constructor)
+
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    assert (  # nosec B101
+        result.category is ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE
+    )
+    assert not constructor_reached  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert not (tmp_path / "recovery").exists()  # nosec B101
+
+
+def test_sensitive_snapshot_and_exception_repr_are_protected(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    result = _rejected(config_path)
+
+    error = ConfigurationLoadError(result.category, result.snapshot)
+    rendered = f"{result!r} {result.snapshot!r} {error!r} {error}"
+
+    assert "example.test" not in rendered  # nosec B101
+    assert "sample" not in rendered  # nosec B101
+    assert str(config_path) not in rendered  # nosec B101
+    assert "sha256" not in rendered  # nosec B101
+
+
+def test_recovery_is_not_started_until_explicitly_requested(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+
+    result = _rejected(config_path)
+
+    assert result.category is ConfigLoadFailureCategory.MALFORMED_JSON  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert not (tmp_path / "recovery").exists()  # nosec B101
+
+
+def test_preserve_and_reset_is_byte_for_byte(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"\xffprivate\x00bytes"
+    config_path.write_bytes(original)
+    rejected = _rejected(config_path)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoverySucceeded)  # nosec B101
+    assert config_path.read_text(encoding="utf-8") == _RESET_TEXT  # nosec B101
+    recovery_files = _recovery_files(config_path)
+    assert len(recovery_files) == 1  # nosec B101
+    assert recovery_files[0].read_bytes() == original  # nosec B101
+    assert list((tmp_path / "recovery").glob("*.partial")) == []  # nosec B101
+
+
+def test_oversized_input_is_streamed_and_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"x" * (config_recovery._IO_CHUNK_BYTES + 257)
+    config_path.write_bytes(original)
+    rejected = _rejected(config_path, max_bytes=32)
+    assert rejected.category is ConfigLoadFailureCategory.SIZE_LIMIT_EXCEEDED  # nosec B101
+    real_read = config_recovery.os.read
+    requested_sizes: list[int] = []
+
+    def tracked_read(descriptor: int, size: int) -> bytes:
+        requested_sizes.append(size)
+        return real_read(descriptor, size)
+
+    monkeypatch.setattr(config_recovery.os, "read", tracked_read)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoverySucceeded)  # nosec B101
+    assert config_recovery._IO_CHUNK_BYTES in requested_sizes  # nosec B101
+    assert max(requested_sizes) <= config_recovery._IO_CHUNK_BYTES  # nosec B101
+    assert _recovery_files(config_path)[0].read_bytes() == original  # nosec B101
+
+
+def test_missing_snapshot_does_not_start_recovery(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+
+    result = preserve_and_reset(config_path, None, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.SOURCE_UNAVAILABLE  # nosec B101
+    assert result.recovery_copy_count == 0  # nosec B101
+    assert result.reset_count == 0  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert not (tmp_path / "recovery").exists()  # nosec B101
+
+
+def test_source_close_failure_blocks_publish_and_reset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    failed_descriptors = _fail_source_close_after_real_close(monkeypatch)
+
+    def unexpected_call(*_args: object, **_kwargs: object) -> NoReturn:
+        pytest.fail("source close failure must prevent publication and reset")
+
+    monkeypatch.setattr(config_recovery, "_publish_verified_copy", unexpected_call)
+    monkeypatch.setattr(config_recovery, "atomic_write_text", unexpected_call)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.RECOVERY_COPY_FAILURE  # nosec B101
+    assert result.recovery_copy_count == 0  # nosec B101
+    assert result.reset_count == 0  # nosec B101
+    assert len(failed_descriptors) == 1  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert list((tmp_path / "recovery").glob("*.partial")) == []  # nosec B101
+
+
+def test_source_close_failure_preserves_prior_controlled_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    failed_descriptors = _fail_source_close_after_real_close(monkeypatch)
+
+    def fail_directory(_config_path: Path) -> NoReturn:
+        raise OSError("synthetic recovery directory failure")
+
+    monkeypatch.setattr(config_recovery, "_resolved_recovery_directory", fail_directory)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert (  # nosec B101
+        result.category is RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE
+    )
+    assert result.recovery_copy_count == 0  # nosec B101
+    assert result.reset_count == 0  # nosec B101
+    assert len(failed_descriptors) == 1  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert not (tmp_path / "recovery").exists()  # nosec B101
+
+
+def test_exclusive_final_name_collision_never_overwrites(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    recovery_directory = tmp_path / "recovery"
+    recovery_directory.mkdir()
+    stage_token = "a" * 32
+    collision_token = "b" * 32
+    final_token = "c" * 32
+    sentinel = recovery_directory / f"config-{collision_token}.recovery"
+    sentinel.write_bytes(b"sentinel")
+    tokens = iter([stage_token, collision_token, final_token])
+    monkeypatch.setattr(config_recovery, "_new_token", lambda: next(tokens))
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoverySucceeded)  # nosec B101
+    assert sentinel.read_bytes() == b"sentinel"  # nosec B101
+    assert (recovery_directory / f"config-{final_token}.recovery").exists()  # nosec B101
+
+
+def test_repeated_recovery_keeps_unique_verified_copies(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    originals = [b"{first", b"{second"]
+
+    for original in originals:
+        config_path.write_bytes(original)
+        rejected = _rejected(config_path)
+        result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+        assert isinstance(result, RecoverySucceeded)  # nosec B101
+
+    recovery_files = _recovery_files(config_path)
+    assert len(recovery_files) == 2  # nosec B101
+    assert {path.read_bytes() for path in recovery_files} == set(originals)  # nosec B101
+
+
+@pytest.mark.parametrize("failure_point", ["write", "flush", "sync"])
+def test_staging_failures_do_not_reset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+
+    def fail(*_args: object) -> NoReturn:
+        raise OSError(f"synthetic {failure_point} failure")
+
+    if failure_point == "write":
+        monkeypatch.setattr(config_recovery, "_write_chunk", fail)
+    elif failure_point == "flush":
+        monkeypatch.setattr(config_recovery, "_flush_and_sync", fail)
+    else:
+        monkeypatch.setattr(config_recovery.os, "fsync", fail)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.RECOVERY_COPY_FAILURE  # nosec B101
+    assert result.recovery_copy_count == 0  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+
+
+def test_failed_partial_is_never_counted_or_given_final_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+
+    def fail_write(*_args: object) -> NoReturn:
+        raise OSError("synthetic write failure")
+
+    monkeypatch.setattr(config_recovery, "_write_chunk", fail_write)
+    monkeypatch.setattr(config_recovery, "_cleanup_staging", lambda _path: None)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.recovery_copy_count == 0  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    partials = list((tmp_path / "recovery").glob("*.partial"))
+    assert len(partials) == 1  # nosec B101
+    assert partials[0].name.startswith(".config-")  # nosec B101
+
+
+@pytest.mark.parametrize("mismatch", ["length", "digest"])
+def test_verification_mismatch_prevents_reset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    real_hash = config_recovery._hash_stable_path
+    calls = 0
+
+    def mismatched_hash(
+        path: Path,
+        *,
+        allow_redirected: bool = False,
+    ) -> tuple[config_recovery._FileFingerprint, int, bytes]:
+        nonlocal calls
+        fingerprint, count, digest = real_hash(
+            path,
+            allow_redirected=allow_redirected,
+        )
+        calls += 1
+        if calls == 1:
+            if mismatch == "length":
+                count += 1
+            else:
+                digest = bytes([digest[0] ^ 1]) + digest[1:]
+        return fingerprint, count, digest
+
+    monkeypatch.setattr(config_recovery, "_hash_stable_path", mismatched_hash)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert (  # nosec B101
+        result.category is RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+    )
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+
+
+def test_final_copy_access_failure_is_a_verification_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    real_hash = config_recovery._hash_stable_path
+    calls = 0
+
+    def fail_final_copy(
+        path: Path,
+        *,
+        allow_redirected: bool = False,
+    ) -> tuple[config_recovery._FileFingerprint, int, bytes]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise PermissionError("synthetic final-copy access failure")
+        return real_hash(path, allow_redirected=allow_redirected)
+
+    monkeypatch.setattr(config_recovery, "_hash_stable_path", fail_final_copy)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert (  # nosec B101
+        result.category is RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+    )
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert len(_recovery_files(config_path)) == 1  # nosec B101
+
+
+@pytest.mark.parametrize("mismatch", ["count", "digest"])
+def test_final_copy_mismatch_is_a_verification_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    real_hash = config_recovery._hash_stable_path
+    calls = 0
+
+    def mismatch_final_copy(
+        path: Path,
+        *,
+        allow_redirected: bool = False,
+    ) -> tuple[config_recovery._FileFingerprint, int, bytes]:
+        nonlocal calls
+        fingerprint, count, digest = real_hash(
+            path,
+            allow_redirected=allow_redirected,
+        )
+        calls += 1
+        if calls == 2:
+            if mismatch == "count":
+                count += 1
+            else:
+                digest = bytes([digest[0] ^ 1]) + digest[1:]
+        return fingerprint, count, digest
+
+    monkeypatch.setattr(config_recovery, "_hash_stable_path", mismatch_final_copy)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert (  # nosec B101
+        result.category is RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+    )
+    assert calls == 2  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert result.reset_count == 0  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    recovery_files = _recovery_files(config_path)
+    assert len(recovery_files) == 1  # nosec B101
+    assert recovery_files[0].read_bytes() == _CORRUPT_BYTES  # nosec B101
+
+
+def test_source_changed_before_recovery_is_not_replaced(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    changed = b"changed-before-recovery"
+    config_path.write_bytes(changed)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.SOURCE_CHANGED  # nosec B101
+    assert config_path.read_bytes() == changed  # nosec B101
+    assert not (tmp_path / "recovery").exists()  # nosec B101
+
+
+def test_source_changed_during_copy_is_not_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    real_write = config_recovery._write_chunk
+    changed = False
+
+    def change_during_write(
+        stream: config_recovery._BinaryStream,
+        chunk: bytes,
+    ) -> None:
+        nonlocal changed
+        real_write(stream, chunk)
+        if not changed:
+            changed = True
+            config_path.write_bytes(b"changed-during-copy")
+
+    monkeypatch.setattr(config_recovery, "_write_chunk", change_during_write)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.SOURCE_CHANGED  # nosec B101
+    assert config_path.read_bytes() == b"changed-during-copy"  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+
+
+def test_source_changed_immediately_before_replace_is_not_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    real_atomic_write = config_recovery.atomic_write_text
+    changed = b"changed-before-replace"
+
+    def mutate_then_write(
+        path: Path,
+        text: str,
+        *,
+        before_replace: Callable[[], None] | None = None,
+    ) -> None:
+        path.write_bytes(changed)
+        real_atomic_write(path, text, before_replace=before_replace)
+
+    monkeypatch.setattr(config_recovery, "atomic_write_text", mutate_then_write)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.SOURCE_CHANGED  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert config_path.read_bytes() == changed  # nosec B101
+    assert _recovery_files(config_path)[0].read_bytes() == _CORRUPT_BYTES  # nosec B101
+
+
+def test_atomic_reset_failure_retains_source_and_verified_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+
+    def fail_reset(*_args: object, **_kwargs: object) -> NoReturn:
+        raise OSError("synthetic reset failure")
+
+    monkeypatch.setattr(config_recovery, "atomic_write_text", fail_reset)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.RESET_FAILURE  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    recovery_file = _recovery_files(config_path)[0]
+    assert recovery_file.read_bytes() == _CORRUPT_BYTES  # nosec B101
+
+
+def test_recovery_directory_redirection_fails_closed(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    external = tmp_path / "external"
+    external.mkdir()
+    recovery_link = tmp_path / "recovery"
+    try:
+        recovery_link.symlink_to(external, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable in this environment")
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert (  # nosec B101
+        result.category is RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE
+    )
+    assert list(external.iterdir()) == []  # nosec B101
+    assert config_path.read_bytes() == _CORRUPT_BYTES  # nosec B101
+
+
+def test_final_recovery_names_are_direct_children(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoverySucceeded)  # nosec B101
+    recovery_file = _recovery_files(config_path)[0]
+    assert recovery_file.parent == tmp_path / "recovery"  # nosec B101
+    assert re.fullmatch(r"config-[0-9a-f]{32}\.recovery", recovery_file.name)  # nosec B101
+
+
+def test_redirected_valid_source_still_loads_but_is_not_auto_recovered(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target.json"
+    target.write_text('{"title": "Valid"}', encoding="utf-8")
+    config_path = tmp_path / "config.json"
+    try:
+        config_path.symlink_to(target)
+    except OSError:
+        pytest.skip("file symlinks are unavailable in this environment")
+
+    loaded = load_config(config_path, _identity)
+    assert isinstance(loaded, ConfigLoaded)  # nosec B101
+
+    target.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    result = preserve_and_reset(config_path, rejected.snapshot, _RESET_TEXT)
+
+    assert isinstance(result, RecoveryFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.SOURCE_UNAVAILABLE  # nosec B101
+    assert target.read_bytes() == _CORRUPT_BYTES  # nosec B101
+    assert config_path.is_symlink()  # nosec B101
+
+
+def test_diagnostics_contain_only_curated_categories_and_counts() -> None:
+    failed = RecoveryFailed(
+        RecoveryFailureCategory.RECOVERY_COPY_FAILURE,
+        recovery_copy_count=0,
+    )
+    required = recovery_required_diagnostics(ConfigLoadFailureCategory.MALFORMED_JSON)
+    exited = recovery_exit_diagnostics(ConfigLoadFailureCategory.INVALID_UTF8)
+    failed_result = recovery_result_diagnostics(failed)
+    succeeded = recovery_result_diagnostics(RecoverySucceeded())
+    assert required == {  # nosec B101
+        "failure_category": "malformed_json",
+        "failure_count": 1,
+    }
+    assert exited == {  # nosec B101
+        "failure_category": "invalid_utf8",
+        "exit_count": 1,
+    }
+    assert failed_result == {  # nosec B101
+        "recovery_copy_count": 0,
+        "reset_count": 0,
+        "failure_category": "recovery_copy_failure",
+    }
+    assert succeeded == {  # nosec B101
+        "recovery_copy_count": 1,
+        "reset_count": 1,
+    }
+    diagnostics = [required, exited, failed_result, succeeded]
+    allowed_strings = {category.value for category in ConfigLoadFailureCategory} | {
+        category.value for category in RecoveryFailureCategory
+    }
+    allowed_keys = {
+        "failure_category",
+        "failure_count",
+        "exit_count",
+        "recovery_copy_count",
+        "reset_count",
+    }
+
+    for fields in diagnostics:
+        assert set(fields).issubset(allowed_keys)  # nosec B101
+        for value in fields.values():
+            assert isinstance(value, (str, bool, int))  # nosec B101
+            if isinstance(value, str):
+                assert value in allowed_strings  # nosec B101
+    rendered = repr(diagnostics)
+    for forbidden in ("example.test", "token", "password", "config.json", "sha256"):
+        assert forbidden not in rendered  # nosec B101

--- a/tests/unit/test_whitespace_context_menu.py
+++ b/tests/unit/test_whitespace_context_menu.py
@@ -10,16 +10,18 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 from PySide6.QtWidgets import QApplication, QScrollArea  # noqa: E402
 from PySide6.QtCore import Qt  # noqa: E402
 
-from tile_launcher import Main  # noqa: E402
+from tile_launcher import LauncherConfig, Main  # noqa: E402
 
 
 @pytest.mark.unit
+@pytest.mark.qt
+@pytest.mark.gui
 def test_tab_viewport_has_context_menu_policy():
     try:
         _ = QApplication.instance() or QApplication([])
     except Exception:  # pragma: no cover - Qt may be missing plugins
         pytest.skip("Qt platform plugin not available")
-    main = Main()
+    main = Main(LauncherConfig.first_run())
     scroll = main.tabs_widget.widget(0)
     assert isinstance(scroll, QScrollArea)
     vp = scroll.viewport()

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field, replace
 from enum import Enum, auto
 from pathlib import Path
-from typing import Callable, Literal, Optional, cast
+from typing import Any, Callable, Literal, Optional, cast
 
 from PySide6.QtCore import (
     QEvent,
@@ -76,6 +76,20 @@ from PySide6.QtWidgets import (
 
 import debug_scaffold
 from config_persistence import atomic_write_text
+from config_recovery import (
+    ConfigLoadFailureCategory,
+    ConfigLoaded,
+    ConfigMissing,
+    ConfigurationLoadError,
+    RecoveryFailed,
+    RecoveryFailureCategory,
+    load_config,
+    preserve_and_reset,
+    recovery_exit_diagnostics,
+    recovery_required_diagnostics,
+    recovery_result_diagnostics,
+    validate_legacy_mapping,
+)
 from debug_scaffold import (
     record_breadcrumb,
     sanitize_launch_command,
@@ -298,41 +312,44 @@ class LauncherConfig:
     window_w: Optional[int] = None
     window_h: Optional[int] = None
 
-    @staticmethod
-    def load() -> "LauncherConfig":
-        if CFG_PATH.exists():
-            data = json.loads(CFG_PATH.read_text(encoding="utf-8"))
-            tiles = [Tile(**t) for t in data.get("tiles", [])]
-            raw_tabs = data.get("tabs") or []
-            tabs: list[str] = []
-            for t in raw_tabs:
-                if isinstance(t, str) and t not in tabs:
-                    tabs.append(t)
-            for tile in tiles:
-                if tile.tab not in tabs:
-                    tabs.append(tile.tab)
-            hidden_raw = data.get("hidden_tabs") or []
-            hidden_tabs = [t for t in hidden_raw if isinstance(t, str)]
-            cfg = LauncherConfig(
-                title=data.get("title", "Launcher"),
-                columns=data.get("columns", 5),
-                tiles=tiles,
-                tabs=tabs,
-                hidden_tabs=hidden_tabs,
-                auto_fit=data.get("auto_fit", True),
-                window_x=data.get("window_x"),
-                window_y=data.get("window_y"),
-                window_w=data.get("window_w"),
-                window_h=data.get("window_h"),
-            )
-            enforce_tab_invariants(
-                cfg,
-                raw_tab_ids=data.get("tab_ids"),
-                raw_tab_order=data.get("tab_order"),
-            )
-            return cfg
-        # first run – create a friendly default
-        cfg = LauncherConfig(
+    @classmethod
+    def from_legacy_mapping(cls, data: dict[str, object]) -> "LauncherConfig":
+        """Construct the current unversioned model with its existing behavior."""
+        legacy = cast(dict[str, Any], data)
+        tiles = [Tile(**tile) for tile in legacy.get("tiles", [])]
+        raw_tabs = legacy.get("tabs") or []
+        tabs: list[str] = []
+        for tab in raw_tabs:
+            if isinstance(tab, str) and tab not in tabs:
+                tabs.append(tab)
+        for tile in tiles:
+            if tile.tab not in tabs:
+                tabs.append(tile.tab)
+        hidden_raw = legacy.get("hidden_tabs") or []
+        hidden_tabs = [tab for tab in hidden_raw if isinstance(tab, str)]
+        cfg = cls(
+            title=legacy.get("title", "Launcher"),
+            columns=legacy.get("columns", 5),
+            tiles=tiles,
+            tabs=tabs,
+            hidden_tabs=hidden_tabs,
+            auto_fit=legacy.get("auto_fit", True),
+            window_x=legacy.get("window_x"),
+            window_y=legacy.get("window_y"),
+            window_w=legacy.get("window_w"),
+            window_h=legacy.get("window_h"),
+        )
+        enforce_tab_invariants(
+            cfg,
+            raw_tab_ids=legacy.get("tab_ids"),
+            raw_tab_order=legacy.get("tab_order"),
+        )
+        return cfg
+
+    @classmethod
+    def first_run(cls) -> "LauncherConfig":
+        """Return the single friendly first-run configuration definition."""
+        cfg = cls(
             title="My Launcher",
             columns=5,
             tiles=[
@@ -345,10 +362,21 @@ class LauncherConfig:
             auto_fit=True,
         )
         enforce_tab_invariants(cfg)
-        cfg.save()
         return cfg
 
-    def save(self) -> None:
+    @staticmethod
+    def load() -> "LauncherConfig":
+        result = load_config(CFG_PATH, _construct_legacy_configuration)
+        if isinstance(result, ConfigMissing):
+            cfg = LauncherConfig.first_run()
+            cfg.save()
+            return cfg
+        if isinstance(result, ConfigLoaded):
+            return result.value
+        raise ConfigurationLoadError(result.category, result.snapshot)
+
+    def serialize(self) -> str:
+        """Serialize using the existing unversioned schema and formatting."""
         enforce_tab_invariants(self)
         tiles = []
         for t in self.tiles:
@@ -370,8 +398,15 @@ class LauncherConfig:
             "window_w": self.window_w,
             "window_h": self.window_h,
         }
-        payload = json.dumps(data, indent=2)
-        atomic_write_text(CFG_PATH, payload)
+        return json.dumps(data, indent=2)
+
+    def save(self) -> None:
+        atomic_write_text(CFG_PATH, self.serialize())
+
+
+def _construct_legacy_configuration(data: dict[str, object]) -> LauncherConfig:
+    validate_legacy_mapping(data)
+    return LauncherConfig.from_legacy_mapping(data)
 
 
 def _tab_order_state(cfg: LauncherConfig) -> TabOrderState:
@@ -1104,11 +1139,9 @@ class _ActiveRefresh:
 
 
 class Main(QMainWindow):
-    def __init__(self) -> None:
+    def __init__(self, config: LauncherConfig) -> None:
         super().__init__()
-        self.cfg = LauncherConfig.load()
-        self._enforce_tab_invariants()
-        self.cfg.save()
+        self.cfg = config
         self._fit_guard = False
         self._rebuilding = False
         self._closing = False
@@ -2716,9 +2749,146 @@ class Main(QMainWindow):
         raise RuntimeError("Test exception")
 
 
-if __name__ == "__main__":
+class _RecoveryChoice(Enum):
+    EXIT = auto()
+    PRESERVE_AND_RESET = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class _StartupReady:
+    config: LauncherConfig = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class _StartupExit:
+    exit_code: int
+
+
+_LOAD_FAILURE_MESSAGES: dict[ConfigLoadFailureCategory, str] = {
+    ConfigLoadFailureCategory.FILE_READ_FAILURE: (
+        "The saved configuration could not be read safely."
+    ),
+    ConfigLoadFailureCategory.SIZE_LIMIT_EXCEEDED: (
+        "The saved configuration exceeds the 4 MiB parsing safety limit."
+    ),
+    ConfigLoadFailureCategory.INVALID_UTF8: (
+        "The saved configuration is not valid UTF-8 text."
+    ),
+    ConfigLoadFailureCategory.MALFORMED_JSON: (
+        "The saved configuration contains malformed JSON."
+    ),
+    ConfigLoadFailureCategory.NON_OBJECT_ROOT: (
+        "The saved configuration does not contain a JSON object."
+    ),
+    ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE: (
+        "The saved configuration is incompatible with the current format."
+    ),
+}
+
+_RECOVERY_FAILURE_MESSAGES: dict[RecoveryFailureCategory, str] = {
+    RecoveryFailureCategory.SOURCE_UNAVAILABLE: (
+        "The saved configuration could not be safely reopened for preservation."
+    ),
+    RecoveryFailureCategory.SOURCE_CHANGED: (
+        "The saved configuration changed after it was inspected. No reset was performed."
+    ),
+    RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE: (
+        "The private recovery location could not be prepared safely."
+    ),
+    RecoveryFailureCategory.RECOVERY_COPY_FAILURE: (
+        "A complete recovery copy could not be written."
+    ),
+    RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE: (
+        "The recovery copy could not be verified."
+    ),
+    RecoveryFailureCategory.RESET_FAILURE: (
+        "The preserved configuration could not be atomically reset."
+    ),
+}
+
+
+def _prompt_config_recovery(
+    category: ConfigLoadFailureCategory,
+) -> _RecoveryChoice:
+    box = QMessageBox()
+    box.setIcon(QMessageBox.Icon.Warning)
+    box.setWindowTitle("DesktopTileLauncher")
+    box.setText("The saved configuration could not be loaded.")
+    box.setInformativeText(
+        f"{_LOAD_FAILURE_MESSAGES[category]} "
+        "Exit leaves it unchanged. Preserve and Reset first keeps an exact recovery copy."
+    )
+    exit_button = box.addButton("Exit", QMessageBox.ButtonRole.RejectRole)
+    reset_button = box.addButton(
+        "Preserve and Reset",
+        QMessageBox.ButtonRole.DestructiveRole,
+    )
+    box.setDefaultButton(exit_button)
+    box.setEscapeButton(exit_button)
+    exit_button.setFocus()
+    box.exec()
+    if box.clickedButton() is reset_button:
+        return _RecoveryChoice.PRESERVE_AND_RESET
+    return _RecoveryChoice.EXIT
+
+
+def _show_recovery_failure(category: RecoveryFailureCategory) -> None:
+    QMessageBox.critical(
+        None,
+        "DesktopTileLauncher",
+        f"{_RECOVERY_FAILURE_MESSAGES[category]} The application will exit.",
+    )
+
+
+def _resolve_startup_configuration() -> _StartupReady | _StartupExit:
+    result = load_config(CFG_PATH, _construct_legacy_configuration)
+    if isinstance(result, ConfigMissing):
+        config = LauncherConfig.first_run()
+        config.save()
+        return _StartupReady(config)
+    if isinstance(result, ConfigLoaded):
+        config = result.value
+        config.save()
+        return _StartupReady(config)
+
+    record_breadcrumb(
+        "config_recovery_required",
+        **recovery_required_diagnostics(result.category),
+    )
+    if _prompt_config_recovery(result.category) is _RecoveryChoice.EXIT:
+        record_breadcrumb(
+            "config_recovery_exit",
+            **recovery_exit_diagnostics(result.category),
+        )
+        return _StartupExit(0)
+
+    config = LauncherConfig.first_run()
+    recovery = preserve_and_reset(CFG_PATH, result.snapshot, config.serialize())
+    if isinstance(recovery, RecoveryFailed):
+        record_breadcrumb(
+            "config_recovery_failed",
+            **recovery_result_diagnostics(recovery),
+        )
+        _show_recovery_failure(recovery.category)
+        return _StartupExit(1)
+
+    record_breadcrumb(
+        "config_recovery_succeeded",
+        **recovery_result_diagnostics(recovery),
+    )
+    return _StartupReady(config)
+
+
+def main() -> int:
     app = QApplication(sys.argv)
     debug_scaffold.install_debug_scaffold(app, app_name="DesktopTileLauncher")
-    mw = Main()
+    startup = _resolve_startup_configuration()
+    if isinstance(startup, _StartupExit):
+        return startup.exit_code
+    mw = Main(startup.config)
     mw.show()
-    sys.exit(app.exec())
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a bounded, Qt-free configuration-loading boundary with sanitized failure categories
- validate incompatible legacy values before construction or canonical save
- offer explicit startup **Exit** or **Preserve and Reset** choices
- preserve corrupt bytes in a collision-safe recovery file, verify the copy, and guard the atomic reset against source changes
- fail closed across copy, verification, publication, source-close, and reset errors
- document recovery behavior and add focused recovery/persistence coverage

## Scope

This is Q3 / STAB-04 only. It does not add a schema version, migration registry, Workspace migration, Resource/Placement model, ImportBatch behavior, or malformed-JSON repair.

## Automated validation

- `make format-check`
- `make lint`
- `make lint_tests`
- `.venv/Scripts/python.exe -m ruff check tests`
- `make typecheck`
- `make test_unit`: 381 collected, 17 deselected, 364 selected and passed
- `git diff --check`

All final gates passed.

## Manual Windows validation

Validation used isolated `APPDATA`, `LOCALAPPDATA`, `TEMP`, and `TMP` directories:

- missing configuration created the friendly first-run state
- a valid configuration restarted normally without recovery
- default Enter, Escape, and window-close all selected Exit, returned 0, left the corrupt file byte-identical, and created no recovery state
- Preserve and Reset retained one byte-identical, collision-safe recovery copy, left no partial files, installed the friendly configuration, and restarted normally without changing the recovery copy
- a deliberately blocked recovery location produced a controlled failure, returned 1, left the corrupt configuration and blocking path unchanged, and published no recovery or staging artifact
- diagnostics contained only expected categories/counts and did not contain the test URL or secret marker
- recovery-directory ACLs contained only SYSTEM, Administrators, and Owner Rights
- the normal user configuration remained byte-identical and the normal environment was restored

## Notes

- STAB-05 remains separate: pre-existing Qt marker/classification debt was not broadened into this change.
- One earlier local run hit a transient Windows `os.replace` access denial in the pre-existing atomic-writer test with no guard; the unchanged rerun and the final post-fix run passed.
- Portable Python still leaves the documented narrow same-user race between the final source comparison and `os.replace`.

Closes #108
