### PR TITLE
feat: add schema-versioned configuration migration harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### App Behavior
 - Detect unreadable or corrupt configuration at startup and offer a safe default Exit or an
   explicit preserve-and-reset flow before the launcher mutates configuration state.
+- Add a Qt-free, schema-versioned migration harness while production remains on implicit,
+  unversioned legacy v0 with no registered migration step and no `schema_version` 1 output.
+- Give malformed, explicit-zero, unsupported, and migration-failure outcomes distinct fixed
+  Exit-only handling without changing the existing corrupt-configuration Exit / Preserve and
+  Reset flow.
+- Guard the normal implicit-v0 normalization save with the successfully classified source
+  snapshot so a concurrent replacement is not overwritten by stale legacy state.
 - Add active-tab tile selection with a selected count, Select all, Clear selection, and Done
   controls while preventing tile launches, context-menu changes, and dragging during selection.
 - Refresh selected tile names and icons only after overwrite confirmation; title and favicon
@@ -15,6 +22,15 @@
 ### Security/Privacy
 - Preserve and verify exact corrupt-configuration bytes before reset, keep verified copies in a
   private recovery location, and record only curated failure categories and integer counts.
+- For future registered migrations, preserve and verify the exact source before the first step,
+  guard deterministic candidate replacement, and retain and roll back only after the exact
+  installed candidate is proven and post-write target validation then fails.
+- Treat reload failure, exact-byte mismatch, or later ownership loss as fail-closed Exit-only
+  outcomes with no retention or rollback over the unproven live path; restore only verified
+  recovery bytes while ownership remains proven.
+- Document the non-journaled crash boundary: interruption after candidate replacement can leave
+  the complete candidate installed, and the next startup classifies it normally without guessing
+  or automatically restoring a recovery artifact.
 - Disclose that an explicitly confirmed refresh attempts to contact each selected destination for
   its title and, when a host/domain can be derived, attempts to send that host/domain to Google's
   favicon service; URL import review remains offline.

--- a/README.md
+++ b/README.md
@@ -113,12 +113,25 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Usage
 
-### Configuration recovery
+### Configuration versions and recovery
 
 DesktopTileLauncher reads at most 4 MiB of `config.json` for normal UTF-8 and
-JSON parsing. If an existing configuration cannot be loaded safely, startup
-offers exactly **Exit** or **Preserve and Reset**. Exit is the safe default and
-does not change the configuration or create a recovery copy.
+JSON parsing. Production remains on the existing implicit, unversioned legacy
+v0 format: a configuration without `schema_version` is constructed, normalized,
+and saved using the existing behavior. The production migration registry has no
+registered steps, no v0-to-v1 migration runs, and the application does not emit
+`schema_version` 1.
+
+An explicit `schema_version` of 0 is invalid. A malformed version value or any
+positive explicit version, including version 1, receives fixed **Exit**-only
+handling before legacy construction, normalization, or saving. Migration
+failures also use fixed Exit-only handling. These version and migration cases
+never offer Preserve and Reset.
+
+The existing recovery choices remain unchanged for the established corrupt or
+unreadable configuration categories. Startup offers exactly **Exit** or
+**Preserve and Reset**. Exit is the safe default and does not change the
+configuration or create a recovery copy.
 
 Preserve and Reset first streams the original bytes into a private per-user
 recovery directory beside, but not inside, the launcher icon directory. The
@@ -126,6 +139,45 @@ copy is independently verified byte-for-byte before the normal first-run
 configuration is installed atomically. A reset is not attempted when copying,
 verification, or the final source-change check fails. Verified recovery copies
 are never overwritten or deleted automatically.
+
+The Qt-free migration harness is ready for future consecutive, registered
+schema steps. It validates the source before preservation; a source-validation
+rejection creates no recovery artifact and performs no write. When at least one
+step will run, the harness preserves and independently verifies one exact
+recovery copy before the first step, validates every detached intermediate and
+target document, and writes deterministic UTF-8 JSON through a guarded atomic
+replacement. Candidate JSON preserves non-ASCII text, sorts keys, uses two-space
+indentation and LF line endings, rejects non-finite numbers, and has no trailing
+newline. The harness reverifies both the source and recovery copy immediately
+before replacement, then reloads and validates the installed candidate.
+
+After replacement, the harness must successfully reload the exact candidate
+bytes before treating the installed file as transaction-owned. Retention and
+rollback occur only when that exact installed candidate is first proven and its
+post-write target validation then fails. With ownership still proven, the
+harness retains the failed candidate privately, reverifies the permanent
+recovery artifact, restores its exact original bytes atomically, and verifies
+the rollback.
+
+A reload failure or exact-byte mismatch leaves ownership unproven, and a later
+live-file change revokes ownership. These cases receive fixed Exit-only,
+fail-closed handling. The harness performs no retention or rollback over an
+unproven live path, so it does not overwrite possibly external bytes. A rollback
+that cannot be completed or verified also fails closed. Published recovery
+copies and failed candidates are private, never overwritten, and never deleted
+automatically.
+
+The normal implicit-v0 startup save has a separate overwrite guard. Immediately
+before installing the normalized legacy text, the application verifies that the
+source still matches the bytes classified at startup. If another process changed
+or replaced the file, the save is cancelled and the application exits without
+overwriting the newer source.
+
+Migration recovery is not journaled. A process interruption after an atomic
+candidate replacement but before post-write verification or rollback can leave
+the complete candidate installed. On the next launch, DesktopTileLauncher
+classifies and validates that live file normally; it does not guess which
+recovery artifact to restore or automatically select one.
 
 ### Add tiles
 

--- a/config_migration.py
+++ b/config_migration.py
@@ -1,0 +1,1743 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qt-free configuration migration engine and guarded transaction coordinator.
+
+The pure engine is isolated from the filesystem.  The coordinator preserves the
+source before invoking it, proves ownership before each replacement, and either
+commits a verified candidate or restores the exact preserved bytes.  Callback
+exceptions are reduced to fixed categories; their objects and text are never kept.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, Generic, Protocol, TypeAlias, TypeVar, cast
+
+from config_persistence import atomic_write_bytes, atomic_write_text
+from config_recovery import (
+    MAX_CONFIG_BYTES,
+    CandidateRetained,
+    CandidateRetentionFailed,
+    CandidateRetentionFailureCategory,
+    ConfigLoadFailureCategory,
+    ConfigMissing,
+    ConfigRecoveryRequired,
+    LegacyConstructionFailure,
+    PreservedBytesRead,
+    RawConfigLoaded,
+    RecoveryFailureCategory,
+    RecoveryVerificationFailed,
+    SourcePreservationFailed,
+    load_raw_config,
+    preserve_source,
+    read_preserved_bytes,
+    retain_failed_candidate,
+    reverify_preserved_source,
+    reverify_source_bytes,
+    verify_preserved_artifact,
+)
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+DiagnosticValue: TypeAlias = str | int
+T = TypeVar("T")
+
+_STEP_NAME_PATTERN: Final = re.compile(r"[a-z][a-z0-9_]{0,63}\Z", re.ASCII)
+
+
+class VersionRejectionCategory(StrEnum):
+    """Privacy-safe reasons a source version cannot enter migration."""
+
+    MALFORMED_VERSION = "malformed_version"
+    UNSUPPORTED_OLDER = "unsupported_older"
+    UNSUPPORTED_NEWER = "unsupported_newer"
+
+
+class RegistryRejectionCategory(StrEnum):
+    """Developer-controlled migration registry defects."""
+
+    INVALID_BOUNDS = "invalid_bounds"
+    INVALID_STEP_ENDPOINT = "invalid_step_endpoint"
+    DUPLICATE_STEP_SOURCE = "duplicate_step_source"
+    STEP_GAP = "step_gap"
+    UNSAFE_STEP_NAME = "unsafe_step_name"
+    DUPLICATE_STEP_NAME = "duplicate_step_name"
+    INVALID_VALIDATOR_VERSION = "invalid_validator_version"
+    DUPLICATE_VALIDATOR_VERSION = "duplicate_validator_version"
+    MISSING_VALIDATOR = "missing_validator"
+
+
+class PureExecutionRejectionCategory(StrEnum):
+    """Expected callback decisions that reject a document or step."""
+
+    SOURCE_VALIDATION_FAILURE = "source_validation_failure"
+    STEP_REJECTION = "step_rejection"
+    INTERMEDIATE_VALIDATION_FAILURE = "intermediate_validation_failure"
+    TARGET_VALIDATION_FAILURE = "target_validation_failure"
+
+
+class PureEngineFailureCategory(StrEnum):
+    """Curated failures in engine-owned, deterministic operations."""
+
+    JSON_DETACHMENT_FAILURE = "json_detachment_failure"
+    SERIALIZATION_FAILURE = "serialization_failure"
+    CANDIDATE_SIZE_LIMIT_EXCEEDED = "candidate_size_limit_exceeded"
+
+
+class PureEngineDefectCategory(StrEnum):
+    """Sanitized violations of a migration callback contract."""
+
+    CALLBACK_EXCEPTION = "callback_exception"
+    INVALID_CALLBACK_RESULT = "invalid_callback_result"
+    INVALID_STEP_OUTPUT = "invalid_step_output"
+    UNEXPECTED_TARGET_VERSION = "unexpected_target_version"
+
+
+class PureExecutionStage(StrEnum):
+    """Safe stage names used by pure outcomes and diagnostics."""
+
+    SOURCE_VALIDATION = "source_validation"
+    STEP = "step"
+    INTERMEDIATE_VALIDATION = "intermediate_validation"
+    TARGET_VALIDATION = "target_validation"
+    SERIALIZATION = "serialization"
+
+
+class MigrationStartupRoute(StrEnum):
+    """Qt-free routing foundation for a later startup coordinator."""
+
+    LEGACY = "legacy"
+    CURRENT = "current"
+    MIGRATION_REQUIRED = "migration_required"
+    MIGRATED = "migrated"
+    EXIT_ONLY = "exit_only"
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationAccepted:
+    """A version validator accepted its detached document."""
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationRejected:
+    """A version validator deliberately rejected its detached document."""
+
+
+ValidationDecision: TypeAlias = ValidationAccepted | ValidationRejected
+
+
+@dataclass(frozen=True, slots=True)
+class StepApplied:
+    """A step produced a candidate for its declared target version."""
+
+    document: Mapping[str, JsonValue] = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class StepRejected:
+    """A step deliberately declined to transform its source document."""
+
+
+StepDecision: TypeAlias = StepApplied | StepRejected
+
+
+class Validator(Protocol):
+    """Validate detached JSON without raising expected validation errors."""
+
+    def __call__(self, document: Mapping[str, JsonValue], /) -> ValidationDecision: ...
+
+
+class StepTransform(Protocol):
+    """Transform detached JSON or return a controlled rejection."""
+
+    def __call__(self, document: Mapping[str, JsonValue], /) -> StepDecision: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationStep:
+    """One declared, consecutive migration step."""
+
+    source_version: int
+    target_version: int
+    name: str
+    transform: StepTransform = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class VersionValidator:
+    """The validator registered for one supported version."""
+
+    version: int
+    validate: Validator = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class RegistrySpec:
+    """Untrusted registry declaration accepted by ``validate_registry``."""
+
+    oldest_supported_version: int | None
+    current_version: int | None
+    steps: tuple[MigrationStep, ...]
+    validators: tuple[VersionValidator, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedMigrationRegistry:
+    """Opaque, internally consistent registry safe for pure execution."""
+
+    oldest_supported_version: int | None
+    current_version: int | None
+    _steps: tuple[MigrationStep, ...] = field(repr=False, compare=False)
+    _validators: tuple[VersionValidator, ...] = field(repr=False, compare=False)
+
+    @property
+    def is_empty(self) -> bool:
+        """Return whether this is the production legacy-only registry."""
+
+        return self.current_version is None
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryReady:
+    """A registry specification passed all structural checks."""
+
+    registry: ValidatedMigrationRegistry = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryRejected:
+    """A registry specification failed a fixed structural check."""
+
+    category: RegistryRejectionCategory
+
+
+RegistryBuildResult: TypeAlias = RegistryReady | RegistryRejected
+
+
+@dataclass(frozen=True, slots=True)
+class ImplicitLegacyV0:
+    """A missing ``schema_version`` identifies current legacy version zero."""
+
+    version: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ExplicitVersion:
+    """A supported-shaped positive explicit version value."""
+
+    version: int
+
+
+@dataclass(frozen=True, slots=True)
+class VersionRejected:
+    """A malformed or unsupported version, safe for Exit-only handling."""
+
+    category: VersionRejectionCategory
+    version: int | None = None
+
+
+VersionIdentification: TypeAlias = ImplicitLegacyV0 | ExplicitVersion | VersionRejected
+
+
+@dataclass(frozen=True, slots=True)
+class PureExecutionRejected:
+    """An expected source, step, intermediate, or target rejection."""
+
+    category: PureExecutionRejectionCategory
+    stage: PureExecutionStage
+    source_version: int
+    target_version: int | None = None
+    step_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PureEngineFailure:
+    """A deterministic engine operation failed without exposing its input."""
+
+    category: PureEngineFailureCategory
+    stage: PureExecutionStage
+    source_version: int | None = None
+    target_version: int | None = None
+    step_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PureEngineDefect:
+    """A callback violated its contract; its exception and text are discarded."""
+
+    category: PureEngineDefectCategory
+    stage: PureExecutionStage
+    source_version: int
+    target_version: int | None = None
+    step_name: str | None = None
+
+
+PureProblem: TypeAlias = PureExecutionRejected | PureEngineFailure | PureEngineDefect
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyV0Current:
+    """Production legacy input remains on the existing constructor path."""
+
+    document: JsonObject = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class VersionedCurrent:
+    """A versioned document passed its current-version validator."""
+
+    version: int
+    document: JsonObject = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedMigration:
+    """Validated source ready for preservation before any step is invoked."""
+
+    source_version: int
+    target_version: int
+    step_count: int
+    _source_document: JsonObject = field(repr=False, compare=False)
+    _steps: tuple[MigrationStep, ...] = field(repr=False, compare=False)
+    _validators: tuple[VersionValidator, ...] = field(repr=False, compare=False)
+
+
+PreparationResult: TypeAlias = (
+    LegacyV0Current
+    | VersionedCurrent
+    | PreparedMigration
+    | VersionRejected
+    | PureProblem
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SerializedDocument:
+    """Deterministic UTF-8 JSON admitted by the candidate size ceiling."""
+
+    data: bytes = field(repr=False)
+    byte_count: int
+
+
+SerializationResult: TypeAlias = SerializedDocument | PureEngineFailure
+
+
+@dataclass(frozen=True, slots=True)
+class SerializedMigration:
+    """A complete detached target and its deterministic serialized bytes."""
+
+    source_version: int
+    target_version: int
+    step_count: int
+    document: JsonObject = field(repr=False)
+    serialized: bytes = field(repr=False)
+    byte_count: int
+
+
+ExecutionResult: TypeAlias = SerializedMigration | PureProblem
+
+
+DocumentValidationResult: TypeAlias = ValidationAccepted | VersionRejected | PureProblem
+
+
+class _JsonDetachmentError(Exception):
+    """Internal marker that deliberately carries no source value or message."""
+
+
+def _is_version_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _detach_json_value(value: object, active: set[int]) -> JsonValue:
+    value_type = type(value)
+    if value is None or value_type is bool or value_type is int or value_type is str:
+        return cast(JsonScalar, value)
+    if value_type is float:
+        float_value = cast(float, value)
+        if not math.isfinite(float_value):
+            raise _JsonDetachmentError
+        return float_value
+    if value_type is list:
+        marker = id(value)
+        if marker in active:
+            raise _JsonDetachmentError
+        active.add(marker)
+        try:
+            return [
+                _detach_json_value(item, active) for item in cast(list[object], value)
+            ]
+        finally:
+            active.remove(marker)
+    if isinstance(value, Mapping):
+        marker = id(value)
+        if marker in active:
+            raise _JsonDetachmentError
+        active.add(marker)
+        try:
+            detached: JsonObject = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise _JsonDetachmentError
+                detached[key] = _detach_json_value(item, active)
+            return detached
+        finally:
+            active.remove(marker)
+    raise _JsonDetachmentError
+
+
+def _detach_json_object(value: object) -> JsonObject:
+    try:
+        detached = _detach_json_value(value, set())
+    except _JsonDetachmentError:
+        raise
+    except Exception:
+        raise _JsonDetachmentError from None
+    if not isinstance(detached, dict):
+        raise _JsonDetachmentError
+    return detached
+
+
+def identify_version(document: Mapping[str, JsonValue]) -> VersionIdentification:
+    """Identify implicit v0 or a positive explicit version without coercion."""
+
+    if "schema_version" not in document:
+        return ImplicitLegacyV0()
+    value = document["schema_version"]
+    if not _is_version_int(value) or cast(int, value) <= 0:
+        rejected_value = cast(int, value) if _is_version_int(value) else None
+        return VersionRejected(
+            VersionRejectionCategory.MALFORMED_VERSION,
+            rejected_value,
+        )
+    return ExplicitVersion(cast(int, value))
+
+
+def _bounds_are_valid(spec: RegistrySpec) -> bool:
+    oldest = spec.oldest_supported_version
+    current = spec.current_version
+    if oldest is None or current is None:
+        return (
+            oldest is None
+            and current is None
+            and not spec.steps
+            and not spec.validators
+        )
+    if not _is_version_int(oldest) or not _is_version_int(current):
+        return False
+    return oldest >= 0 and oldest <= current
+
+
+def validate_registry(spec: RegistrySpec) -> RegistryBuildResult:
+    """Validate bounds, consecutive steps, validators, and diagnostic names."""
+
+    if not _bounds_are_valid(spec):
+        return RegistryRejected(RegistryRejectionCategory.INVALID_BOUNDS)
+    if spec.current_version is None:
+        return RegistryReady(ValidatedMigrationRegistry(None, None, (), ()))
+
+    oldest = cast(int, spec.oldest_supported_version)
+    current = spec.current_version
+    step_sources: set[int] = set()
+    step_names: set[str] = set()
+    for step in spec.steps:
+        if (
+            not _is_version_int(step.source_version)
+            or not _is_version_int(step.target_version)
+            or step.target_version != step.source_version + 1
+            or step.source_version < oldest
+            or step.target_version > current
+        ):
+            return RegistryRejected(RegistryRejectionCategory.INVALID_STEP_ENDPOINT)
+        if step.source_version in step_sources:
+            return RegistryRejected(RegistryRejectionCategory.DUPLICATE_STEP_SOURCE)
+        step_sources.add(step.source_version)
+        if (
+            not isinstance(step.name, str)
+            or _STEP_NAME_PATTERN.fullmatch(step.name) is None
+        ):
+            return RegistryRejected(RegistryRejectionCategory.UNSAFE_STEP_NAME)
+        if step.name in step_names:
+            return RegistryRejected(RegistryRejectionCategory.DUPLICATE_STEP_NAME)
+        step_names.add(step.name)
+
+    if len(step_sources) != current - oldest:
+        return RegistryRejected(RegistryRejectionCategory.STEP_GAP)
+
+    validator_versions: set[int] = set()
+    for validator in spec.validators:
+        if (
+            not _is_version_int(validator.version)
+            or validator.version < oldest
+            or validator.version > current
+        ):
+            return RegistryRejected(RegistryRejectionCategory.INVALID_VALIDATOR_VERSION)
+        if validator.version in validator_versions:
+            return RegistryRejected(
+                RegistryRejectionCategory.DUPLICATE_VALIDATOR_VERSION
+            )
+        validator_versions.add(validator.version)
+
+    if len(validator_versions) != current - oldest + 1:
+        return RegistryRejected(RegistryRejectionCategory.MISSING_VALIDATOR)
+
+    steps = tuple(sorted(spec.steps, key=lambda step: step.source_version))
+    validators = tuple(sorted(spec.validators, key=lambda validator: validator.version))
+    return RegistryReady(ValidatedMigrationRegistry(oldest, current, steps, validators))
+
+
+def _validator_for(
+    validators: tuple[VersionValidator, ...], version: int
+) -> VersionValidator | None:
+    for validator in validators:
+        if validator.version == version:
+            return validator
+    return None
+
+
+def _run_validator(
+    document: JsonObject,
+    validators: tuple[VersionValidator, ...],
+    *,
+    version: int,
+    stage: PureExecutionStage,
+    source_version: int,
+    target_version: int | None,
+    step_name: str | None,
+) -> PureProblem | None:
+    try:
+        callback_document = _detach_json_object(document)
+    except _JsonDetachmentError:
+        return PureEngineFailure(
+            PureEngineFailureCategory.JSON_DETACHMENT_FAILURE,
+            stage,
+            source_version,
+            target_version,
+            step_name,
+        )
+
+    validator = _validator_for(validators, version)
+    if validator is None:
+        return PureEngineDefect(
+            PureEngineDefectCategory.INVALID_CALLBACK_RESULT,
+            stage,
+            source_version,
+            target_version,
+            step_name,
+        )
+    try:
+        decision: object = validator.validate(callback_document)
+    except Exception:
+        return PureEngineDefect(
+            PureEngineDefectCategory.CALLBACK_EXCEPTION,
+            stage,
+            source_version,
+            target_version,
+            step_name,
+        )
+
+    if isinstance(decision, ValidationRejected):
+        if stage is PureExecutionStage.SOURCE_VALIDATION:
+            category = PureExecutionRejectionCategory.SOURCE_VALIDATION_FAILURE
+        elif stage is PureExecutionStage.INTERMEDIATE_VALIDATION:
+            category = PureExecutionRejectionCategory.INTERMEDIATE_VALIDATION_FAILURE
+        else:
+            category = PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+        return PureExecutionRejected(
+            category,
+            stage,
+            source_version,
+            target_version,
+            step_name,
+        )
+    if not isinstance(decision, ValidationAccepted):
+        return PureEngineDefect(
+            PureEngineDefectCategory.INVALID_CALLBACK_RESULT,
+            stage,
+            source_version,
+            target_version,
+            step_name,
+        )
+    return None
+
+
+def prepare_migration(
+    document: Mapping[str, JsonValue],
+    registry: ValidatedMigrationRegistry,
+) -> PreparationResult:
+    """Identify and validate a source without running or preserving any step."""
+
+    identity = identify_version(document)
+    if isinstance(identity, VersionRejected):
+        return identity
+
+    source_version = identity.version
+    if registry.is_empty:
+        if isinstance(identity, ExplicitVersion):
+            return VersionRejected(
+                VersionRejectionCategory.UNSUPPORTED_NEWER,
+                source_version,
+            )
+        try:
+            return LegacyV0Current(_detach_json_object(document))
+        except _JsonDetachmentError:
+            return PureEngineFailure(
+                PureEngineFailureCategory.JSON_DETACHMENT_FAILURE,
+                PureExecutionStage.SOURCE_VALIDATION,
+                source_version,
+            )
+
+    oldest = cast(int, registry.oldest_supported_version)
+    current = cast(int, registry.current_version)
+    if source_version < oldest:
+        return VersionRejected(
+            VersionRejectionCategory.UNSUPPORTED_OLDER,
+            source_version,
+        )
+    if source_version > current:
+        return VersionRejected(
+            VersionRejectionCategory.UNSUPPORTED_NEWER,
+            source_version,
+        )
+
+    try:
+        source_document = _detach_json_object(document)
+    except _JsonDetachmentError:
+        return PureEngineFailure(
+            PureEngineFailureCategory.JSON_DETACHMENT_FAILURE,
+            PureExecutionStage.SOURCE_VALIDATION,
+            source_version,
+        )
+
+    validation = _run_validator(
+        source_document,
+        registry._validators,
+        version=source_version,
+        stage=PureExecutionStage.SOURCE_VALIDATION,
+        source_version=source_version,
+        target_version=None,
+        step_name=None,
+    )
+    if validation is not None:
+        return validation
+    if source_version == current:
+        return VersionedCurrent(source_version, source_document)
+
+    steps = tuple(
+        step for step in registry._steps if step.source_version >= source_version
+    )
+    return PreparedMigration(
+        source_version,
+        current,
+        len(steps),
+        source_document,
+        steps,
+        registry._validators,
+    )
+
+
+def validate_document(
+    document: Mapping[str, JsonValue],
+    identity: ImplicitLegacyV0 | ExplicitVersion,
+    registry: ValidatedMigrationRegistry,
+    *,
+    stage: PureExecutionStage = PureExecutionStage.SOURCE_VALIDATION,
+) -> DocumentValidationResult:
+    """Defensively validate one supported document without migration."""
+
+    observed = identify_version(document)
+    if isinstance(observed, VersionRejected):
+        return observed
+    if type(observed) is not type(identity) or observed.version != identity.version:
+        return PureEngineDefect(
+            PureEngineDefectCategory.UNEXPECTED_TARGET_VERSION,
+            stage,
+            identity.version,
+            identity.version
+            if stage is not PureExecutionStage.SOURCE_VALIDATION
+            else None,
+        )
+    try:
+        detached = _detach_json_object(document)
+    except _JsonDetachmentError:
+        return PureEngineFailure(
+            PureEngineFailureCategory.JSON_DETACHMENT_FAILURE,
+            stage,
+            identity.version,
+            identity.version
+            if stage is not PureExecutionStage.SOURCE_VALIDATION
+            else None,
+        )
+    if registry.is_empty:
+        if isinstance(identity, ImplicitLegacyV0):
+            return ValidationAccepted()
+        return VersionRejected(
+            VersionRejectionCategory.UNSUPPORTED_NEWER,
+            identity.version,
+        )
+    oldest = cast(int, registry.oldest_supported_version)
+    current = cast(int, registry.current_version)
+    if identity.version < oldest:
+        return VersionRejected(
+            VersionRejectionCategory.UNSUPPORTED_OLDER,
+            identity.version,
+        )
+    if identity.version > current:
+        return VersionRejected(
+            VersionRejectionCategory.UNSUPPORTED_NEWER,
+            identity.version,
+        )
+    problem = _run_validator(
+        detached,
+        registry._validators,
+        version=identity.version,
+        stage=stage,
+        source_version=identity.version,
+        target_version=(
+            identity.version
+            if stage is not PureExecutionStage.SOURCE_VALIDATION
+            else None
+        ),
+        step_name=None,
+    )
+    return problem if problem is not None else ValidationAccepted()
+
+
+def serialize_deterministically(
+    document: Mapping[str, JsonValue],
+) -> SerializationResult:
+    """Serialize strict JSON as UTF-8, LF-only bytes with no trailing newline."""
+
+    try:
+        detached = _detach_json_object(document)
+        text = json.dumps(
+            detached,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        serialized = text.encode("utf-8")
+    except (_JsonDetachmentError, TypeError, ValueError, OverflowError, UnicodeError):
+        return PureEngineFailure(
+            PureEngineFailureCategory.SERIALIZATION_FAILURE,
+            PureExecutionStage.SERIALIZATION,
+        )
+    if len(serialized) > MAX_CONFIG_BYTES:
+        return PureEngineFailure(
+            PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED,
+            PureExecutionStage.SERIALIZATION,
+        )
+    return SerializedDocument(serialized, len(serialized))
+
+
+def execute_prepared_migration(prepared: PreparedMigration) -> ExecutionResult:
+    """Run each detached consecutive step once, validate, and serialize."""
+
+    try:
+        candidate = _detach_json_object(prepared._source_document)
+    except _JsonDetachmentError:
+        return PureEngineFailure(
+            PureEngineFailureCategory.JSON_DETACHMENT_FAILURE,
+            PureExecutionStage.STEP,
+            prepared.source_version,
+            prepared.target_version,
+        )
+
+    for step in prepared._steps:
+        try:
+            step_input = _detach_json_object(candidate)
+        except _JsonDetachmentError:
+            return PureEngineFailure(
+                PureEngineFailureCategory.JSON_DETACHMENT_FAILURE,
+                PureExecutionStage.STEP,
+                step.source_version,
+                step.target_version,
+                step.name,
+            )
+        try:
+            decision: object = step.transform(step_input)
+        except Exception:
+            return PureEngineDefect(
+                PureEngineDefectCategory.CALLBACK_EXCEPTION,
+                PureExecutionStage.STEP,
+                step.source_version,
+                step.target_version,
+                step.name,
+            )
+        if isinstance(decision, StepRejected):
+            return PureExecutionRejected(
+                PureExecutionRejectionCategory.STEP_REJECTION,
+                PureExecutionStage.STEP,
+                step.source_version,
+                step.target_version,
+                step.name,
+            )
+        if not isinstance(decision, StepApplied):
+            return PureEngineDefect(
+                PureEngineDefectCategory.INVALID_CALLBACK_RESULT,
+                PureExecutionStage.STEP,
+                step.source_version,
+                step.target_version,
+                step.name,
+            )
+        try:
+            candidate = _detach_json_object(decision.document)
+        except _JsonDetachmentError:
+            return PureEngineDefect(
+                PureEngineDefectCategory.INVALID_STEP_OUTPUT,
+                PureExecutionStage.STEP,
+                step.source_version,
+                step.target_version,
+                step.name,
+            )
+
+        candidate_version = candidate.get("schema_version")
+        if (
+            not _is_version_int(candidate_version)
+            or candidate_version != step.target_version
+        ):
+            return PureEngineDefect(
+                PureEngineDefectCategory.UNEXPECTED_TARGET_VERSION,
+                PureExecutionStage.STEP,
+                step.source_version,
+                step.target_version,
+                step.name,
+            )
+
+        validation_stage = (
+            PureExecutionStage.TARGET_VALIDATION
+            if step.target_version == prepared.target_version
+            else PureExecutionStage.INTERMEDIATE_VALIDATION
+        )
+        validation = _run_validator(
+            candidate,
+            prepared._validators,
+            version=step.target_version,
+            stage=validation_stage,
+            source_version=step.source_version,
+            target_version=step.target_version,
+            step_name=step.name,
+        )
+        if validation is not None:
+            return validation
+
+    serialized = serialize_deterministically(candidate)
+    if isinstance(serialized, PureEngineFailure):
+        return PureEngineFailure(
+            serialized.category,
+            serialized.stage,
+            prepared.source_version,
+            prepared.target_version,
+        )
+    return SerializedMigration(
+        prepared.source_version,
+        prepared.target_version,
+        prepared.step_count,
+        candidate,
+        serialized.data,
+        serialized.byte_count,
+    )
+
+
+class ConfigurationAuthority(StrEnum):
+    """Best proven owner of the live configuration path at transaction exit."""
+
+    ORIGINAL = "original"
+    CANDIDATE = "candidate"
+    RESTORED_ORIGINAL = "restored_original"
+    EXTERNAL_CURRENT = "external_current"
+    UNKNOWN = "unknown"
+
+
+class TransactionFailureCategory(StrEnum):
+    """Curated filesystem transaction failures with explicit precedence."""
+
+    PRESERVATION_FAILURE = "preservation_failure"
+    SOURCE_CHANGED = "source_changed"
+    ORIGINAL_REVERIFICATION_FAILURE = "original_reverification_failure"
+    CANDIDATE_WRITE_FAILURE = "candidate_write_failure"
+    POST_WRITE_SOURCE_CHANGED = "post_write_source_changed"
+    POST_WRITE_VALIDATION_FAILURE = "post_write_validation_failure"
+    CANDIDATE_RETENTION_FAILURE = "candidate_retention_failure"
+    ROLLBACK_SOURCE_CHANGED = "rollback_source_changed"
+    ROLLBACK_ARTIFACT_FAILURE = "rollback_artifact_failure"
+    ROLLBACK_WRITE_FAILURE = "rollback_write_failure"
+    ROLLBACK_VERIFICATION_FAILURE = "rollback_verification_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationCommitted:
+    """A deterministic candidate was written, reloaded, and validated."""
+
+    target_version: int
+    byte_count: int
+    document: JsonObject = field(repr=False)
+    authority: ConfigurationAuthority = ConfigurationAuthority.CANDIDATE
+    recovery_copy_count: int = 1
+    failed_candidate_copy_count: int = 0
+    rollback_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationAbortedAfterPreservation:
+    """Pure execution stopped after the verified original was preserved."""
+
+    problem: PureProblem
+    authority: ConfigurationAuthority = ConfigurationAuthority.ORIGINAL
+    recovery_copy_count: int = 1
+    failed_candidate_copy_count: int = 0
+    rollback_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationRolledBack:
+    """A rejected post-write candidate was retained when possible and removed."""
+
+    category: TransactionFailureCategory
+    verification_problem: VersionRejected | PureProblem
+    candidate_retention_category: CandidateRetentionFailureCategory | None = None
+    authority: ConfigurationAuthority = ConfigurationAuthority.RESTORED_ORIGINAL
+    recovery_copy_count: int = 1
+    failed_candidate_copy_count: int = 0
+    rollback_count: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationTransactionFailed:
+    """The coordinator failed closed with category-only filesystem details."""
+
+    category: TransactionFailureCategory
+    authority: ConfigurationAuthority
+    recovery_copy_count: int
+    failed_candidate_copy_count: int = 0
+    rollback_count: int = 0
+    recovery_category: RecoveryFailureCategory | None = None
+    candidate_retention_category: CandidateRetentionFailureCategory | None = None
+
+
+MigrationTransactionResult: TypeAlias = (
+    MigrationCommitted
+    | MigrationAbortedAfterPreservation
+    | MigrationRolledBack
+    | MigrationTransactionFailed
+)
+TransactionProblem: TypeAlias = (
+    MigrationAbortedAfterPreservation | MigrationRolledBack | MigrationTransactionFailed
+)
+
+
+class _GuardRefused(Exception):
+    """Internal category-only refusal raised from an atomic-writer guard."""
+
+    def __init__(
+        self,
+        category: TransactionFailureCategory,
+        recovery_category: RecoveryFailureCategory | None = None,
+    ) -> None:
+        self.category = category
+        self.recovery_category = recovery_category
+        super().__init__(category.value)
+
+
+def _pre_write_guard_category(
+    category: RecoveryFailureCategory,
+) -> TransactionFailureCategory:
+    if category in (
+        RecoveryFailureCategory.SOURCE_UNAVAILABLE,
+        RecoveryFailureCategory.SOURCE_CHANGED,
+    ):
+        return TransactionFailureCategory.SOURCE_CHANGED
+    return TransactionFailureCategory.ORIGINAL_REVERIFICATION_FAILURE
+
+
+def _post_write_authority(result: object) -> ConfigurationAuthority:
+    if isinstance(result, RawConfigLoaded):
+        return ConfigurationAuthority.EXTERNAL_CURRENT
+    return ConfigurationAuthority.UNKNOWN
+
+
+def _coordinate_prepared_migration(
+    config_path: Path,
+    loaded: RawConfigLoaded,
+    prepared: PreparedMigration,
+    registry: ValidatedMigrationRegistry,
+) -> MigrationTransactionResult:
+    preservation = preserve_source(config_path, loaded.snapshot)
+    if isinstance(preservation, SourcePreservationFailed):
+        source_changed = preservation.category is RecoveryFailureCategory.SOURCE_CHANGED
+        return MigrationTransactionFailed(
+            category=(
+                TransactionFailureCategory.SOURCE_CHANGED
+                if source_changed
+                else TransactionFailureCategory.PRESERVATION_FAILURE
+            ),
+            authority=(
+                ConfigurationAuthority.UNKNOWN
+                if source_changed
+                else ConfigurationAuthority.ORIGINAL
+            ),
+            recovery_copy_count=preservation.recovery_copy_count,
+            recovery_category=preservation.category,
+        )
+    preserved = preservation.source
+
+    execution = execute_prepared_migration(prepared)
+    if not isinstance(execution, SerializedMigration):
+        original_check = reverify_preserved_source(preserved)
+        if isinstance(original_check, RecoveryVerificationFailed):
+            category = _pre_write_guard_category(original_check.category)
+            return MigrationTransactionFailed(
+                category=category,
+                authority=(
+                    ConfigurationAuthority.UNKNOWN
+                    if category is TransactionFailureCategory.SOURCE_CHANGED
+                    else ConfigurationAuthority.ORIGINAL
+                ),
+                recovery_copy_count=1,
+                recovery_category=original_check.category,
+            )
+        return MigrationAbortedAfterPreservation(execution)
+
+    candidate_bytes = execution.serialized
+    if len(candidate_bytes) > MAX_CONFIG_BYTES:
+        return MigrationAbortedAfterPreservation(
+            PureEngineFailure(
+                PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED,
+                PureExecutionStage.SERIALIZATION,
+                prepared.source_version,
+                prepared.target_version,
+            )
+        )
+
+    def before_candidate_replace() -> None:
+        verification = reverify_preserved_source(preserved)
+        if isinstance(verification, RecoveryVerificationFailed):
+            raise _GuardRefused(
+                _pre_write_guard_category(verification.category),
+                verification.category,
+            )
+
+    try:
+        atomic_write_bytes(
+            config_path,
+            candidate_bytes,
+            before_replace=before_candidate_replace,
+        )
+    except _GuardRefused as refusal:
+        return MigrationTransactionFailed(
+            category=refusal.category,
+            authority=(
+                ConfigurationAuthority.UNKNOWN
+                if refusal.category is TransactionFailureCategory.SOURCE_CHANGED
+                else ConfigurationAuthority.ORIGINAL
+            ),
+            recovery_copy_count=1,
+            recovery_category=refusal.recovery_category,
+        )
+    except OSError:
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.CANDIDATE_WRITE_FAILURE,
+            authority=ConfigurationAuthority.ORIGINAL,
+            recovery_copy_count=1,
+        )
+
+    post_write = load_raw_config(config_path)
+    if (
+        not isinstance(post_write, RawConfigLoaded)
+        or post_write.snapshot.source_is_redirected
+        or post_write.source_bytes != candidate_bytes
+    ):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.POST_WRITE_SOURCE_CHANGED,
+            authority=_post_write_authority(post_write),
+            recovery_copy_count=1,
+        )
+
+    post_write_validation = validate_document(
+        cast(Mapping[str, JsonValue], post_write.mapping),
+        ExplicitVersion(prepared.target_version),
+        registry,
+        stage=PureExecutionStage.TARGET_VALIDATION,
+    )
+    if isinstance(post_write_validation, ValidationAccepted):
+        final_candidate_check = reverify_source_bytes(
+            config_path,
+            post_write.snapshot,
+            candidate_bytes,
+        )
+        if isinstance(final_candidate_check, RecoveryVerificationFailed):
+            return MigrationTransactionFailed(
+                category=TransactionFailureCategory.POST_WRITE_SOURCE_CHANGED,
+                authority=ConfigurationAuthority.UNKNOWN,
+                recovery_copy_count=1,
+                recovery_category=final_candidate_check.category,
+            )
+        return MigrationCommitted(
+            target_version=prepared.target_version,
+            byte_count=len(candidate_bytes),
+            document=execution.document,
+        )
+
+    retention = retain_failed_candidate(
+        config_path,
+        post_write.snapshot,
+        candidate_bytes,
+    )
+    candidate_copy_count: int
+    retention_category: CandidateRetentionFailureCategory | None
+    if isinstance(retention, CandidateRetained):
+        candidate_copy_count = retention.failed_candidate_copy_count
+        retention_category = None
+    else:
+        candidate_copy_count = retention.failed_candidate_copy_count
+        retention_category = retention.category
+
+    candidate_verification = reverify_source_bytes(
+        config_path,
+        post_write.snapshot,
+        candidate_bytes,
+    )
+    if isinstance(candidate_verification, RecoveryVerificationFailed):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+            authority=ConfigurationAuthority.UNKNOWN,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            candidate_retention_category=retention_category,
+        )
+
+    artifact_verification = verify_preserved_artifact(preserved)
+    if isinstance(artifact_verification, RecoveryVerificationFailed):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_ARTIFACT_FAILURE,
+            authority=ConfigurationAuthority.CANDIDATE,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            recovery_category=artifact_verification.category,
+            candidate_retention_category=retention_category,
+        )
+    rollback_bytes = read_preserved_bytes(preserved)
+    if not isinstance(rollback_bytes, PreservedBytesRead):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_ARTIFACT_FAILURE,
+            authority=ConfigurationAuthority.CANDIDATE,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            recovery_category=rollback_bytes.category,
+            candidate_retention_category=retention_category,
+        )
+
+    def before_rollback_replace() -> None:
+        candidate_check = reverify_source_bytes(
+            config_path,
+            post_write.snapshot,
+            candidate_bytes,
+        )
+        if isinstance(candidate_check, RecoveryVerificationFailed):
+            raise _GuardRefused(
+                TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+                candidate_check.category,
+            )
+        artifact_check = verify_preserved_artifact(preserved)
+        if isinstance(artifact_check, RecoveryVerificationFailed):
+            raise _GuardRefused(
+                TransactionFailureCategory.ROLLBACK_ARTIFACT_FAILURE,
+                artifact_check.category,
+            )
+
+    try:
+        atomic_write_bytes(
+            config_path,
+            rollback_bytes.data,
+            before_replace=before_rollback_replace,
+        )
+    except _GuardRefused as refusal:
+        authority = (
+            ConfigurationAuthority.UNKNOWN
+            if refusal.category is TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED
+            else ConfigurationAuthority.CANDIDATE
+        )
+        return MigrationTransactionFailed(
+            category=refusal.category,
+            authority=authority,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            recovery_category=refusal.recovery_category,
+            candidate_retention_category=retention_category,
+        )
+    except OSError:
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_WRITE_FAILURE,
+            authority=ConfigurationAuthority.CANDIDATE,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            candidate_retention_category=retention_category,
+        )
+
+    restored = load_raw_config(config_path)
+    restored_is_exact = (
+        isinstance(restored, RawConfigLoaded)
+        and not restored.snapshot.source_is_redirected
+        and restored.source_bytes == rollback_bytes.data
+    )
+    if not restored_is_exact:
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_VERIFICATION_FAILURE,
+            authority=_post_write_authority(restored),
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            rollback_count=1,
+            candidate_retention_category=retention_category,
+        )
+
+    restored_loaded = cast(RawConfigLoaded, restored)
+    restored_identity = identify_version(
+        cast(Mapping[str, JsonValue], restored_loaded.mapping)
+    )
+    if isinstance(restored_identity, VersionRejected):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_VERIFICATION_FAILURE,
+            authority=ConfigurationAuthority.RESTORED_ORIGINAL,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            rollback_count=1,
+            candidate_retention_category=retention_category,
+        )
+    restored_validation = validate_document(
+        cast(Mapping[str, JsonValue], restored_loaded.mapping),
+        restored_identity,
+        registry,
+    )
+    final_source_check = reverify_source_bytes(
+        config_path,
+        restored_loaded.snapshot,
+        rollback_bytes.data,
+    )
+    if isinstance(final_source_check, RecoveryVerificationFailed):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+            authority=ConfigurationAuthority.UNKNOWN,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            rollback_count=1,
+            recovery_category=final_source_check.category,
+            candidate_retention_category=retention_category,
+        )
+    final_artifact_check = verify_preserved_artifact(preserved)
+    if not isinstance(restored_validation, ValidationAccepted) or isinstance(
+        final_artifact_check, RecoveryVerificationFailed
+    ):
+        return MigrationTransactionFailed(
+            category=TransactionFailureCategory.ROLLBACK_VERIFICATION_FAILURE,
+            authority=ConfigurationAuthority.RESTORED_ORIGINAL,
+            recovery_copy_count=1,
+            failed_candidate_copy_count=candidate_copy_count,
+            rollback_count=1,
+            recovery_category=(
+                final_artifact_check.category
+                if isinstance(final_artifact_check, RecoveryVerificationFailed)
+                else None
+            ),
+            candidate_retention_category=retention_category,
+        )
+
+    rollback_category = (
+        TransactionFailureCategory.CANDIDATE_RETENTION_FAILURE
+        if isinstance(retention, CandidateRetentionFailed)
+        else TransactionFailureCategory.POST_WRITE_VALIDATION_FAILURE
+    )
+    return MigrationRolledBack(
+        category=rollback_category,
+        verification_problem=post_write_validation,
+        candidate_retention_category=retention_category,
+        failed_candidate_copy_count=candidate_copy_count,
+    )
+
+
+LoadedMigrationResult: TypeAlias = (
+    LegacyV0Current
+    | VersionedCurrent
+    | VersionRejected
+    | PureProblem
+    | MigrationTransactionResult
+)
+
+
+def coordinate_migration(
+    config_path: Path,
+    loaded: RawConfigLoaded,
+    registry: ValidatedMigrationRegistry,
+) -> LoadedMigrationResult:
+    """Classify and source-validate before preserving only step-bearing inputs."""
+
+    preparation = prepare_migration(
+        cast(Mapping[str, JsonValue], loaded.mapping),
+        registry,
+    )
+    if isinstance(preparation, PreparedMigration):
+        return _coordinate_prepared_migration(
+            config_path,
+            loaded,
+            preparation,
+            registry,
+        )
+    return preparation
+
+
+@dataclass(frozen=True, slots=True)
+class ImplicitLegacyLoaded(Generic[T]):
+    """One legacy value plus the raw evidence needed for its guarded save."""
+
+    value: T = field(repr=False)
+    raw: RawConfigLoaded = field(repr=False)
+
+
+StartupConfigurationResult: TypeAlias = (
+    ConfigMissing
+    | ConfigRecoveryRequired
+    | ImplicitLegacyLoaded[T]
+    | VersionedCurrent
+    | VersionRejected
+    | PureProblem
+    | MigrationTransactionResult
+)
+
+
+def load_startup_configuration(
+    config_path: Path,
+    legacy_constructor: Callable[[dict[str, object]], T],
+    registry: ValidatedMigrationRegistry,
+) -> StartupConfigurationResult[T]:
+    """Perform exactly one initial bounded load before all classification."""
+
+    loaded = load_raw_config(config_path)
+    if not isinstance(loaded, RawConfigLoaded):
+        return loaded
+
+    identity = identify_version(cast(Mapping[str, JsonValue], loaded.mapping))
+    if registry.is_empty and isinstance(identity, ImplicitLegacyV0):
+        try:
+            value = legacy_constructor(loaded.mapping)
+        except LegacyConstructionFailure:
+            return ConfigRecoveryRequired(
+                ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE,
+                loaded.snapshot,
+            )
+        return ImplicitLegacyLoaded(value, loaded)
+
+    migration_result = coordinate_migration(config_path, loaded, registry)
+    if not isinstance(migration_result, LegacyV0Current):
+        return migration_result
+
+    try:
+        value = legacy_constructor(loaded.mapping)
+    except LegacyConstructionFailure:
+        return ConfigRecoveryRequired(
+            ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE,
+            loaded.snapshot,
+        )
+    return ImplicitLegacyLoaded(value, loaded)
+
+
+class LegacyNormalizationSaveFailureCategory(StrEnum):
+    """Fixed guarded-save failures for already-classified implicit v0."""
+
+    SOURCE_CHANGED = "source_changed"
+    PERSISTENCE_FAILURE = "persistence_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyNormalizationSaved:
+    """The existing canonical implicit-v0 save replaced its unchanged source."""
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyNormalizationSaveFailed:
+    """A guarded legacy normalization save aborted without retry or recovery."""
+
+    category: LegacyNormalizationSaveFailureCategory
+
+
+LegacyNormalizationSaveResult: TypeAlias = (
+    LegacyNormalizationSaved | LegacyNormalizationSaveFailed
+)
+
+
+def guarded_legacy_normalization_save(
+    config_path: Path,
+    loaded: RawConfigLoaded,
+    replacement_text: str,
+) -> LegacyNormalizationSaveResult:
+    """Save canonical legacy text only while the classified bytes remain current."""
+
+    def before_replace() -> None:
+        verification = reverify_source_bytes(
+            config_path,
+            loaded.snapshot,
+            loaded.source_bytes,
+        )
+        if isinstance(verification, RecoveryVerificationFailed):
+            raise _GuardRefused(TransactionFailureCategory.SOURCE_CHANGED)
+
+    try:
+        atomic_write_text(
+            config_path,
+            replacement_text,
+            before_replace=before_replace,
+        )
+    except _GuardRefused:
+        return LegacyNormalizationSaveFailed(
+            LegacyNormalizationSaveFailureCategory.SOURCE_CHANGED
+        )
+    except OSError:
+        return LegacyNormalizationSaveFailed(
+            LegacyNormalizationSaveFailureCategory.PERSISTENCE_FAILURE
+        )
+    return LegacyNormalizationSaved()
+
+
+class StartupFailureRoute(StrEnum):
+    """Pure startup routing that keeps Q3 recovery separate from Q4 failures."""
+
+    Q3_RECOVERY = "q3_recovery"
+    EXIT_ONLY = "exit_only"
+
+
+class StartupNoticeCategory(StrEnum):
+    """Fixed inputs for the Exit-only startup message."""
+
+    MALFORMED_VERSION = "malformed_version"
+    UNSUPPORTED_VERSION = "unsupported_version"
+    MIGRATION_FAILED = "migration_failed"
+    CONFIG_CHANGED = "config_changed"
+
+
+ExitOnlyFailure: TypeAlias = (
+    VersionRejected
+    | PureProblem
+    | MigrationAbortedAfterPreservation
+    | MigrationRolledBack
+    | MigrationTransactionFailed
+    | LegacyNormalizationSaveFailed
+)
+StartupFailureOutcome: TypeAlias = ConfigRecoveryRequired | ExitOnlyFailure
+
+
+def startup_failure_route(outcome: StartupFailureOutcome) -> StartupFailureRoute:
+    """Return the only startup prompt family permitted for an outcome."""
+
+    if isinstance(outcome, ConfigRecoveryRequired):
+        return StartupFailureRoute.Q3_RECOVERY
+    return StartupFailureRoute.EXIT_ONLY
+
+
+def startup_notice_category(outcome: ExitOnlyFailure) -> StartupNoticeCategory:
+    """Reduce an Exit-only failure to one fixed, non-sensitive message input."""
+
+    if isinstance(outcome, VersionRejected):
+        if outcome.category is VersionRejectionCategory.MALFORMED_VERSION:
+            return StartupNoticeCategory.MALFORMED_VERSION
+        return StartupNoticeCategory.UNSUPPORTED_VERSION
+    if isinstance(outcome, LegacyNormalizationSaveFailed):
+        if outcome.category is LegacyNormalizationSaveFailureCategory.SOURCE_CHANGED:
+            return StartupNoticeCategory.CONFIG_CHANGED
+        return StartupNoticeCategory.MIGRATION_FAILED
+    if isinstance(outcome, MigrationTransactionFailed) and outcome.category in (
+        TransactionFailureCategory.SOURCE_CHANGED,
+        TransactionFailureCategory.POST_WRITE_SOURCE_CHANGED,
+        TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+    ):
+        return StartupNoticeCategory.CONFIG_CHANGED
+    return StartupNoticeCategory.MIGRATION_FAILED
+
+
+_STARTUP_NOTICE_MESSAGES: Final[dict[StartupNoticeCategory, str]] = {
+    StartupNoticeCategory.MALFORMED_VERSION: (
+        "The saved configuration has an invalid schema version. "
+        "It was left unchanged and the application will exit."
+    ),
+    StartupNoticeCategory.UNSUPPORTED_VERSION: (
+        "The saved configuration uses an unsupported schema version. "
+        "It was left unchanged and the application will exit."
+    ),
+    StartupNoticeCategory.MIGRATION_FAILED: (
+        "The saved configuration could not be migrated safely. "
+        "The application will exit."
+    ),
+    StartupNoticeCategory.CONFIG_CHANGED: (
+        "The saved configuration changed while it was being processed. "
+        "No further overwrite was attempted and the application will exit."
+    ),
+}
+
+
+def startup_notice_message(category: StartupNoticeCategory) -> str:
+    """Return fixed UI text that cannot contain configuration or exception data."""
+
+    return _STARTUP_NOTICE_MESSAGES[category]
+
+
+DiagnosticOutcome: TypeAlias = (
+    RegistryRejected
+    | VersionRejected
+    | PureExecutionRejected
+    | PureEngineFailure
+    | PureEngineDefect
+)
+
+
+def migration_diagnostics(result: DiagnosticOutcome) -> dict[str, DiagnosticValue]:
+    """Render only curated categories, versions, stages, and safe step names."""
+
+    diagnostics: dict[str, DiagnosticValue] = {"failure_count": 1}
+    if isinstance(result, RegistryRejected):
+        diagnostics["failure_kind"] = "registry_rejection"
+        diagnostics["failure_category"] = result.category.value
+        return diagnostics
+    if isinstance(result, VersionRejected):
+        diagnostics["failure_kind"] = "version_rejection"
+        diagnostics["failure_category"] = result.category.value
+        if result.version is not None:
+            diagnostics["source_version"] = result.version
+        return diagnostics
+
+    if isinstance(result, PureExecutionRejected):
+        diagnostics["failure_kind"] = "execution_rejection"
+    elif isinstance(result, PureEngineFailure):
+        diagnostics["failure_kind"] = "engine_failure"
+    else:
+        diagnostics["failure_kind"] = "engine_defect"
+    diagnostics["failure_category"] = result.category.value
+    diagnostics["failure_stage"] = result.stage.value
+    if result.source_version is not None:
+        diagnostics["source_version"] = result.source_version
+    if result.target_version is not None:
+        diagnostics["target_version"] = result.target_version
+    if result.step_name is not None:
+        diagnostics["step_name"] = result.step_name
+    return diagnostics
+
+
+def transaction_diagnostics(
+    result: TransactionProblem,
+) -> dict[str, DiagnosticValue]:
+    """Render transaction state using only categories, counts, and authority."""
+
+    diagnostics: dict[str, DiagnosticValue]
+    if isinstance(result, MigrationAbortedAfterPreservation):
+        diagnostics = migration_diagnostics(result.problem)
+        diagnostics["transaction_state"] = "aborted_after_preservation"
+    else:
+        diagnostics = {
+            "failure_count": 1,
+            "failure_kind": "transaction_failure",
+            "failure_category": result.category.value,
+        }
+    diagnostics["configuration_authority"] = result.authority.value
+    diagnostics["recovery_copy_count"] = result.recovery_copy_count
+    diagnostics["failed_candidate_copy_count"] = result.failed_candidate_copy_count
+    diagnostics["rollback_count"] = result.rollback_count
+    if isinstance(result, MigrationRolledBack):
+        if result.candidate_retention_category is not None:
+            diagnostics["candidate_retention_category"] = (
+                result.candidate_retention_category.value
+            )
+    elif isinstance(result, MigrationTransactionFailed):
+        if result.recovery_category is not None:
+            diagnostics["recovery_category"] = result.recovery_category.value
+        if result.candidate_retention_category is not None:
+            diagnostics["candidate_retention_category"] = (
+                result.candidate_retention_category.value
+            )
+    return diagnostics
+
+
+def startup_failure_diagnostics(
+    outcome: ExitOnlyFailure,
+) -> dict[str, DiagnosticValue]:
+    """Return the only breadcrumb fields exposed by Exit-only startup failures."""
+
+    if isinstance(
+        outcome,
+        (
+            VersionRejected,
+            PureExecutionRejected,
+            PureEngineFailure,
+            PureEngineDefect,
+        ),
+    ):
+        return migration_diagnostics(outcome)
+    if isinstance(
+        outcome,
+        (
+            MigrationAbortedAfterPreservation,
+            MigrationRolledBack,
+            MigrationTransactionFailed,
+        ),
+    ):
+        return transaction_diagnostics(outcome)
+    return {
+        "failure_count": 1,
+        "failure_kind": "legacy_normalization_save",
+        "failure_category": outcome.category.value,
+    }
+
+
+class ConfigurationMigrationError(Exception):
+    """Safe exception boundary for direct ``LauncherConfig.load`` callers."""
+
+    def __init__(
+        self,
+        notice_category: StartupNoticeCategory,
+        diagnostics: Mapping[str, DiagnosticValue],
+    ) -> None:
+        self.notice_category = notice_category
+        self.diagnostics: dict[str, DiagnosticValue] = dict(diagnostics)
+        super().__init__(notice_category.value)
+
+    @classmethod
+    def from_outcome(
+        cls,
+        outcome: ExitOnlyFailure,
+    ) -> ConfigurationMigrationError:
+        """Create a sanitized exception after callback exception scopes have ended."""
+
+        return cls(
+            startup_notice_category(outcome),
+            startup_failure_diagnostics(outcome),
+        )
+
+    @classmethod
+    def unexpected_success(cls) -> ConfigurationMigrationError:
+        """Fail safely if the dormant registry returns an unsupported app result."""
+
+        return cls(
+            StartupNoticeCategory.MIGRATION_FAILED,
+            {
+                "failure_count": 1,
+                "failure_kind": "unexpected_migration_success",
+            },
+        )
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(notice_category={self.notice_category.value!r})"
+
+    def __str__(self) -> str:
+        return self.notice_category.value
+
+
+StartupResult: TypeAlias = PreparationResult | ExecutionResult | RegistryRejected
+
+
+def migration_startup_route(result: StartupResult) -> MigrationStartupRoute:
+    """Map pure outcomes without exposing any UI or Q3 recovery implementation."""
+
+    if isinstance(result, LegacyV0Current):
+        return MigrationStartupRoute.LEGACY
+    if isinstance(result, VersionedCurrent):
+        return MigrationStartupRoute.CURRENT
+    if isinstance(result, PreparedMigration):
+        return MigrationStartupRoute.MIGRATION_REQUIRED
+    if isinstance(result, SerializedMigration):
+        return MigrationStartupRoute.MIGRATED
+    return MigrationStartupRoute.EXIT_ONLY
+
+
+PRODUCTION_REGISTRY_SPEC: Final = RegistrySpec(None, None, (), ())
+_production_registry_result = validate_registry(PRODUCTION_REGISTRY_SPEC)
+if not isinstance(_production_registry_result, RegistryReady):
+    raise RuntimeError("invalid production migration registry")
+PRODUCTION_REGISTRY: Final = _production_registry_result.registry
+
+
+__all__ = [
+    "ConfigurationAuthority",
+    "ConfigurationMigrationError",
+    "DiagnosticOutcome",
+    "DiagnosticValue",
+    "DocumentValidationResult",
+    "ExecutionResult",
+    "ExitOnlyFailure",
+    "ExplicitVersion",
+    "ImplicitLegacyLoaded",
+    "ImplicitLegacyV0",
+    "JsonObject",
+    "JsonScalar",
+    "JsonValue",
+    "LegacyNormalizationSaveFailed",
+    "LegacyNormalizationSaveFailureCategory",
+    "LegacyNormalizationSaveResult",
+    "LegacyNormalizationSaved",
+    "LegacyV0Current",
+    "LoadedMigrationResult",
+    "MigrationAbortedAfterPreservation",
+    "MigrationCommitted",
+    "MigrationRolledBack",
+    "MigrationStartupRoute",
+    "MigrationStep",
+    "MigrationTransactionFailed",
+    "MigrationTransactionResult",
+    "PRODUCTION_REGISTRY",
+    "PRODUCTION_REGISTRY_SPEC",
+    "PreparationResult",
+    "PreparedMigration",
+    "PureEngineDefect",
+    "PureEngineDefectCategory",
+    "PureEngineFailure",
+    "PureEngineFailureCategory",
+    "PureExecutionRejected",
+    "PureExecutionRejectionCategory",
+    "PureExecutionStage",
+    "PureProblem",
+    "RegistryBuildResult",
+    "RegistryReady",
+    "RegistryRejected",
+    "RegistryRejectionCategory",
+    "RegistrySpec",
+    "SerializedDocument",
+    "SerializedMigration",
+    "SerializationResult",
+    "StartupResult",
+    "StartupConfigurationResult",
+    "StartupFailureOutcome",
+    "StartupFailureRoute",
+    "StartupNoticeCategory",
+    "StepApplied",
+    "StepDecision",
+    "StepRejected",
+    "StepTransform",
+    "ValidatedMigrationRegistry",
+    "ValidationAccepted",
+    "ValidationDecision",
+    "ValidationRejected",
+    "Validator",
+    "VersionIdentification",
+    "VersionRejected",
+    "VersionRejectionCategory",
+    "VersionValidator",
+    "VersionedCurrent",
+    "TransactionFailureCategory",
+    "TransactionProblem",
+    "coordinate_migration",
+    "execute_prepared_migration",
+    "guarded_legacy_normalization_save",
+    "identify_version",
+    "load_startup_configuration",
+    "migration_diagnostics",
+    "migration_startup_route",
+    "prepare_migration",
+    "serialize_deterministically",
+    "startup_failure_diagnostics",
+    "startup_failure_route",
+    "startup_notice_category",
+    "startup_notice_message",
+    "transaction_diagnostics",
+    "validate_document",
+    "validate_registry",
+]

--- a/config_persistence.py
+++ b/config_persistence.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 import os
 import tempfile
 from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, TypeVar, cast
 
 
 class _SyncableTextStream(Protocol):
+    name: str
+
     def write(self, text: str, /) -> int: ...
 
     def flush(self) -> None: ...
@@ -16,10 +19,56 @@ class _SyncableTextStream(Protocol):
     def fileno(self) -> int: ...
 
 
+class _SyncableBinaryStream(Protocol):
+    name: str
+
+    def write(self, data: bytes, /) -> int: ...
+
+    def flush(self) -> None: ...
+
+    def fileno(self) -> int: ...
+
+
+_StreamT = TypeVar("_StreamT", _SyncableTextStream, _SyncableBinaryStream)
+
+
 def _write_and_sync(stream: _SyncableTextStream, text: str) -> None:
     stream.write(text)
     stream.flush()
     os.fsync(stream.fileno())
+
+
+def _write_bytes_and_sync(stream: _SyncableBinaryStream, data: bytes) -> None:
+    if stream.write(data) != len(data):
+        raise OSError("short atomic byte write")
+    stream.flush()
+    os.fsync(stream.fileno())
+
+
+def _atomic_write(
+    path: Path,
+    temporary: AbstractContextManager[_StreamT],
+    write_and_sync: Callable[[_StreamT], None],
+    *,
+    before_replace: Callable[[], None] | None = None,
+) -> None:
+    temporary_path: Path | None = None
+    try:
+        with temporary as stream:
+            temporary_path = Path(stream.name)
+            write_and_sync(stream)
+
+        if before_replace is not None:
+            before_replace()
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                # Preserve the original write or replace error if cleanup also fails.
+                pass
 
 
 def atomic_write_text(
@@ -34,27 +83,43 @@ def atomic_write_text(
     immediately before ``os.replace``. If the guard raises, this writer leaves
     the destination unreplaced and cleans up only its own temporary file.
     """
-    temporary_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
+    temporary = cast(
+        AbstractContextManager[_SyncableTextStream],
+        tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
             dir=path.parent,
             prefix=f".{path.name}.",
             suffix=".tmp",
             delete=False,
-        ) as temporary:
-            temporary_path = Path(temporary.name)
-            _write_and_sync(temporary, text)
+        ),
+    )
 
-        if before_replace is not None:
-            before_replace()
-        os.replace(temporary_path, path)
-        temporary_path = None
-    finally:
-        if temporary_path is not None:
-            try:
-                temporary_path.unlink()
-            except OSError:
-                # Preserve the original write or replace error if cleanup also fails.
-                pass
+    def write_and_sync(stream: _SyncableTextStream) -> None:
+        _write_and_sync(stream, text)
+
+    _atomic_write(path, temporary, write_and_sync, before_replace=before_replace)
+
+
+def atomic_write_bytes(
+    path: Path,
+    data: bytes,
+    *,
+    before_replace: Callable[[], None] | None = None,
+) -> None:
+    """Replace *path* with exact bytes synced in a guarded sibling file."""
+    temporary = cast(
+        AbstractContextManager[_SyncableBinaryStream],
+        tempfile.NamedTemporaryFile(
+            mode="w+b",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ),
+    )
+
+    def write_and_sync(stream: _SyncableBinaryStream) -> None:
+        _write_bytes_and_sync(stream, data)
+
+    _atomic_write(path, temporary, write_and_sync, before_replace=before_replace)

--- a/config_recovery.py
+++ b/config_recovery.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Final, Generic, Protocol, TypeAlias, TypeVar, cast
+from typing import Final, Generic, Literal, Protocol, TypeAlias, TypeVar, cast
 
 from config_persistence import atomic_write_text
 
@@ -65,6 +65,15 @@ class RecoveryFailureCategory(StrEnum):
     RECOVERY_COPY_FAILURE = "recovery_copy_failure"
     RECOVERY_VERIFICATION_FAILURE = "recovery_verification_failure"
     RESET_FAILURE = "reset_failure"
+
+
+class CandidateRetentionFailureCategory(StrEnum):
+    """Privacy-safe reasons an owned failed candidate could not be retained."""
+
+    SOURCE_CHANGED = "source_changed"
+    RECOVERY_DIRECTORY_FAILURE = "recovery_directory_failure"
+    CANDIDATE_COPY_FAILURE = "candidate_copy_failure"
+    CANDIDATE_VERIFICATION_FAILURE = "candidate_verification_failure"
 
 
 class LegacyConstructionFailure(Exception):
@@ -150,7 +159,7 @@ class _FileFingerprint:
 
 @dataclass(frozen=True, slots=True, repr=False)
 class SourceSnapshot:
-    """Private evidence identifying the bytes rejected during bounded loading."""
+    """Private evidence recorded by a successful or rejected bounded raw load."""
 
     path_fingerprint: _FileFingerprint = field(repr=False)
     target_fingerprint: _FileFingerprint = field(repr=False)
@@ -159,6 +168,15 @@ class SourceSnapshot:
     evidence_sha256: bytes = field(repr=False)
     evidence_is_complete: bool
     source_is_redirected: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RawConfigLoaded:
+    """A bounded JSON object and the exact source evidence used to parse it."""
+
+    mapping: dict[str, object] = field(repr=False)
+    source_bytes: bytes = field(repr=False)
+    snapshot: SourceSnapshot = field(repr=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -182,6 +200,9 @@ class ConfigRecoveryRequired:
 
 
 ConfigLoadResult: TypeAlias = ConfigMissing | ConfigLoaded[T] | ConfigRecoveryRequired
+RawConfigLoadResult: TypeAlias = (
+    ConfigMissing | RawConfigLoaded | ConfigRecoveryRequired
+)
 
 
 class ConfigurationLoadError(Exception):
@@ -234,6 +255,91 @@ class _VerifiedCopy:
     path: Path = field(repr=False)
     byte_count: int
     sha256: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True, repr=False, init=False)
+class PreservedSource:
+    """Opaque authority for one independently verified original recovery copy."""
+
+    _source_path: Path = field(repr=False)
+    _source_snapshot: SourceSnapshot = field(repr=False)
+    _artifact_path: Path = field(repr=False)
+    _artifact_fingerprint: _FileFingerprint = field(repr=False)
+    _byte_count: int = field(repr=False)
+    _sha256: bytes = field(repr=False)
+
+    def __new__(cls) -> PreservedSource:
+        raise TypeError("PreservedSource handles are created by preserve_source")
+
+
+def _new_preserved_source(
+    source_path: Path,
+    source_snapshot: SourceSnapshot,
+    artifact_path: Path,
+    artifact_fingerprint: _FileFingerprint,
+    byte_count: int,
+    sha256: bytes,
+) -> PreservedSource:
+    preserved = object.__new__(PreservedSource)
+    object.__setattr__(preserved, "_source_path", source_path)
+    object.__setattr__(preserved, "_source_snapshot", source_snapshot)
+    object.__setattr__(preserved, "_artifact_path", artifact_path)
+    object.__setattr__(preserved, "_artifact_fingerprint", artifact_fingerprint)
+    object.__setattr__(preserved, "_byte_count", byte_count)
+    object.__setattr__(preserved, "_sha256", sha256)
+    return preserved
+
+
+@dataclass(frozen=True, slots=True)
+class SourcePreserved:
+    source: PreservedSource = field(repr=False)
+    recovery_copy_count: Literal[1] = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SourcePreservationFailed:
+    category: RecoveryFailureCategory
+    recovery_copy_count: Literal[0, 1] = 0
+
+
+PreserveSourceResult: TypeAlias = SourcePreserved | SourcePreservationFailed
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryVerificationSucceeded:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryVerificationFailed:
+    category: RecoveryFailureCategory
+
+
+RecoveryVerificationResult: TypeAlias = (
+    RecoveryVerificationSucceeded | RecoveryVerificationFailed
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreservedBytesRead:
+    data: bytes = field(repr=False)
+
+
+PreservedBytesResult: TypeAlias = PreservedBytesRead | RecoveryVerificationFailed
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateRetained:
+    failed_candidate_copy_count: Literal[1] = 1
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateRetentionFailed:
+    category: CandidateRetentionFailureCategory
+    failed_candidate_copy_count: Literal[0, 1] = 0
+
+
+CandidateRetentionResult: TypeAlias = CandidateRetained | CandidateRetentionFailed
 
 
 class _FileSafetyFailure(Exception):
@@ -368,13 +474,12 @@ def _source_still_matches(path: Path, opened: _OpenedSource) -> bool:
         return False
 
 
-def load_config(
+def load_raw_config(
     path: Path,
-    constructor: Callable[[dict[str, object]], T],
     *,
     max_bytes: int = MAX_CONFIG_BYTES,
-) -> ConfigLoadResult[T]:
-    """Read and construct an existing configuration without modifying it."""
+) -> RawConfigLoadResult:
+    """Read one bounded JSON object and retain its exact source evidence."""
 
     if not 0 < max_bytes <= MAX_CONFIG_BYTES:
         raise ValueError(f"max_bytes must be between 1 and {MAX_CONFIG_BYTES}")
@@ -432,20 +537,40 @@ def load_config(
             ConfigLoadFailureCategory.NON_OBJECT_ROOT, snapshot
         )
 
+    return RawConfigLoaded(cast(dict[str, object], parsed), raw, snapshot)
+
+
+def load_config(
+    path: Path,
+    constructor: Callable[[dict[str, object]], T],
+    *,
+    max_bytes: int = MAX_CONFIG_BYTES,
+) -> ConfigLoadResult[T]:
+    """Read and construct an existing configuration without modifying it."""
+
+    raw_result = load_raw_config(path, max_bytes=max_bytes)
+    if not isinstance(raw_result, RawConfigLoaded):
+        return raw_result
+
     try:
-        value = constructor(cast(dict[str, object], parsed))
+        value = constructor(raw_result.mapping)
     except LegacyConstructionFailure:
         return ConfigRecoveryRequired(
             ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE,
-            snapshot,
+            raw_result.snapshot,
         )
     return ConfigLoaded(value)
 
 
-def _snapshot_matches_opened(snapshot: SourceSnapshot, opened: _OpenedSource) -> bool:
+def _snapshot_matches_opened(
+    snapshot: SourceSnapshot,
+    opened: _OpenedSource,
+    *,
+    allow_redirected: bool,
+) -> bool:
     return (
-        not snapshot.source_is_redirected
-        and not opened.redirected
+        snapshot.source_is_redirected == opened.redirected
+        and (allow_redirected or not opened.redirected)
         and opened.path_fingerprint == snapshot.path_fingerprint
         and opened.target_fingerprint == snapshot.target_fingerprint
         and opened.content_fingerprint == snapshot.content_fingerprint
@@ -465,10 +590,19 @@ def _read_evidence(descriptor: int, byte_count: int) -> bytes:
     return bytes(evidence)
 
 
-def _open_matching_source(path: Path, snapshot: SourceSnapshot) -> _OpenedSource:
+def _open_matching_source(
+    path: Path,
+    snapshot: SourceSnapshot,
+    *,
+    allow_redirected: bool = False,
+) -> _OpenedSource:
     opened = _open_source(path)
     try:
-        if not _snapshot_matches_opened(snapshot, opened):
+        if not _snapshot_matches_opened(
+            snapshot,
+            opened,
+            allow_redirected=allow_redirected,
+        ):
             raise _SourceChanged
         evidence = _read_evidence(opened.descriptor, snapshot.evidence_byte_count)
         if len(evidence) != snapshot.evidence_byte_count:
@@ -619,9 +753,11 @@ def _publish_verified_copy(
     recovery_directory: Path,
     expected_count: int,
     expected_digest: bytes,
+    *,
+    final_suffix: Literal["recovery", "failed-candidate"] = "recovery",
 ) -> _VerifiedCopy:
     for _attempt in range(_MAX_NAME_ATTEMPTS):
-        final_path = recovery_directory / f"config-{_safe_token()}.recovery"
+        final_path = recovery_directory / f"config-{_safe_token()}.{final_suffix}"
         if final_path.parent != recovery_directory:
             raise _FileSafetyFailure
         try:
@@ -641,7 +777,7 @@ def _verify_source_and_copy(
     config_path: Path,
     snapshot: SourceSnapshot,
     verified: _VerifiedCopy,
-) -> None:
+) -> _FileFingerprint:
     try:
         opened = _open_matching_source(config_path, snapshot)
         try:
@@ -666,7 +802,7 @@ def _verify_source_and_copy(
         raise _GuardFailure(RecoveryFailureCategory.SOURCE_CHANGED) from None
 
     try:
-        _copy_fingerprint, copy_count, copy_digest = _hash_stable_path(verified.path)
+        copy_fingerprint, copy_count, copy_digest = _hash_stable_path(verified.path)
         if copy_count != verified.byte_count or copy_digest != verified.sha256:
             raise _GuardFailure(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
     except _GuardFailure:
@@ -675,33 +811,31 @@ def _verify_source_and_copy(
         raise _GuardFailure(
             RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
         ) from None
+    return copy_fingerprint
 
 
-def preserve_and_reset(
+def _preserve_source_with_suffix(
     config_path: Path,
-    snapshot: SourceSnapshot | None,
-    replacement_text: str,
-) -> RecoveryResult:
-    """Preserve the detected source, verify it, then atomically install reset text."""
-
-    if snapshot is None or snapshot.source_is_redirected:
-        return RecoveryFailed(RecoveryFailureCategory.SOURCE_UNAVAILABLE)
-
+    snapshot: SourceSnapshot,
+    *,
+    final_suffix: Literal["recovery", "failed-candidate"],
+) -> PreserveSourceResult:
     try:
         source = _open_matching_source(config_path, snapshot)
     except (OSError, _FileSafetyFailure, _SourceChanged):
-        return RecoveryFailed(RecoveryFailureCategory.SOURCE_CHANGED)
+        return SourcePreservationFailed(RecoveryFailureCategory.SOURCE_CHANGED)
 
     staging_path: Path | None = None
     try:
-        copy_outcome: tuple[Path, Path, int, bytes] | RecoveryFailed = RecoveryFailed(
-            RecoveryFailureCategory.RECOVERY_COPY_FAILURE
+        copy_outcome: tuple[Path, Path, int, bytes] | SourcePreservationFailed
+        copy_outcome = SourcePreservationFailed(
+            RecoveryFailureCategory.RECOVERY_COPY_FAILURE,
         )
         try:
             try:
                 recovery_directory = _resolved_recovery_directory(config_path)
             except (OSError, RuntimeError, _FileSafetyFailure):
-                copy_outcome = RecoveryFailed(
+                copy_outcome = SourcePreservationFailed(
                     RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE
                 )
             else:
@@ -715,11 +849,11 @@ def preserve_and_reset(
                         destination_descriptor,
                     )
                 except _SourceChanged:
-                    copy_outcome = RecoveryFailed(
+                    copy_outcome = SourcePreservationFailed(
                         RecoveryFailureCategory.SOURCE_CHANGED
                     )
                 except (OSError, _FileSafetyFailure):
-                    copy_outcome = RecoveryFailed(
+                    copy_outcome = SourcePreservationFailed(
                         RecoveryFailureCategory.RECOVERY_COPY_FAILURE
                     )
                 else:
@@ -734,11 +868,11 @@ def preserve_and_reset(
                 os.close(source.descriptor)
             except OSError:
                 if isinstance(copy_outcome, tuple):
-                    copy_outcome = RecoveryFailed(
+                    copy_outcome = SourcePreservationFailed(
                         RecoveryFailureCategory.RECOVERY_COPY_FAILURE
                     )
 
-        if isinstance(copy_outcome, RecoveryFailed):
+        if isinstance(copy_outcome, SourcePreservationFailed):
             return copy_outcome
         staged_path, recovery_directory, byte_count, digest = copy_outcome
 
@@ -747,9 +881,13 @@ def preserve_and_reset(
                 staged_path
             )
         except (OSError, _FileSafetyFailure, _SourceChanged):
-            return RecoveryFailed(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
+            return SourcePreservationFailed(
+                RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+            )
         if verified_count != byte_count or verified_digest != digest:
-            return RecoveryFailed(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
+            return SourcePreservationFailed(
+                RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+            )
 
         try:
             verified = _publish_verified_copy(
@@ -757,28 +895,249 @@ def preserve_and_reset(
                 recovery_directory,
                 byte_count,
                 digest,
+                final_suffix=final_suffix,
             )
         except (OSError, _FileSafetyFailure, _SourceChanged):
-            return RecoveryFailed(RecoveryFailureCategory.RECOVERY_COPY_FAILURE)
+            return SourcePreservationFailed(
+                RecoveryFailureCategory.RECOVERY_COPY_FAILURE
+            )
 
         _cleanup_staging(staged_path)
         staging_path = None
 
-        def guard() -> None:
-            _verify_source_and_copy(config_path, snapshot, verified)
-
         try:
-            atomic_write_text(config_path, replacement_text, before_replace=guard)
+            artifact_fingerprint = _verify_source_and_copy(
+                config_path,
+                snapshot,
+                verified,
+            )
         except _GuardFailure as failure:
-            return RecoveryFailed(
+            return SourcePreservationFailed(
                 failure.category,
                 recovery_copy_count=1,
             )
-        except OSError:
-            return RecoveryFailed(
-                RecoveryFailureCategory.RESET_FAILURE,
-                recovery_copy_count=1,
-            )
-        return RecoverySucceeded()
+
+        preserved = _new_preserved_source(
+            config_path,
+            snapshot,
+            verified.path,
+            artifact_fingerprint,
+            verified.byte_count,
+            verified.sha256,
+        )
+        return SourcePreserved(preserved)
     finally:
         _cleanup_staging(staging_path)
+
+
+def preserve_source(
+    config_path: Path,
+    snapshot: SourceSnapshot | None,
+) -> PreserveSourceResult:
+    """Publish and independently verify one permanent copy of an original source."""
+
+    if snapshot is None or snapshot.source_is_redirected:
+        return SourcePreservationFailed(RecoveryFailureCategory.SOURCE_UNAVAILABLE)
+    return _preserve_source_with_suffix(
+        config_path,
+        snapshot,
+        final_suffix="recovery",
+    )
+
+
+def _verified_copy(preserved: PreservedSource) -> _VerifiedCopy:
+    return _VerifiedCopy(
+        preserved._artifact_path,
+        preserved._byte_count,
+        preserved._sha256,
+    )
+
+
+def reverify_preserved_source(
+    preserved: PreservedSource,
+) -> RecoveryVerificationResult:
+    """Reverify the original live source first, then its permanent recovery copy."""
+
+    try:
+        artifact_fingerprint = _verify_source_and_copy(
+            preserved._source_path,
+            preserved._source_snapshot,
+            _verified_copy(preserved),
+        )
+        if artifact_fingerprint != preserved._artifact_fingerprint:
+            raise _GuardFailure(RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE)
+    except _GuardFailure as failure:
+        return RecoveryVerificationFailed(failure.category)
+    return RecoveryVerificationSucceeded()
+
+
+def verify_preserved_artifact(
+    preserved: PreservedSource,
+) -> RecoveryVerificationResult:
+    """Reverify a permanent recovery artifact without consulting the replaced source."""
+
+    try:
+        fingerprint, byte_count, digest = _hash_stable_path(preserved._artifact_path)
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        return RecoveryVerificationFailed(
+            RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+        )
+    if (
+        fingerprint != preserved._artifact_fingerprint
+        or byte_count != preserved._byte_count
+        or digest != preserved._sha256
+    ):
+        return RecoveryVerificationFailed(
+            RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+        )
+    return RecoveryVerificationSucceeded()
+
+
+def read_preserved_bytes(preserved: PreservedSource) -> PreservedBytesResult:
+    """Read exact rollback bytes from a stable, independently verified artifact."""
+
+    if preserved._byte_count > MAX_CONFIG_BYTES:
+        return RecoveryVerificationFailed(
+            RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+        )
+
+    try:
+        opened = _open_source(preserved._artifact_path)
+        try:
+            if (
+                opened.redirected
+                or opened.content_fingerprint != preserved._artifact_fingerprint
+            ):
+                raise _SourceChanged
+            data = _read_evidence(opened.descriptor, preserved._byte_count)
+            if len(data) != preserved._byte_count or os.read(opened.descriptor, 1):
+                raise _SourceChanged
+            if not _source_still_matches(preserved._artifact_path, opened):
+                raise _SourceChanged
+        finally:
+            os.close(opened.descriptor)
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        return RecoveryVerificationFailed(
+            RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+        )
+
+    if hashlib.sha256(data).digest() != preserved._sha256:
+        return RecoveryVerificationFailed(
+            RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+        )
+    return PreservedBytesRead(data)
+
+
+def reverify_source_bytes(
+    path: Path,
+    snapshot: SourceSnapshot,
+    expected_bytes: bytes,
+) -> RecoveryVerificationResult:
+    """Prove that a path still contains the complete bytes represented by a snapshot.
+
+    Unchanged redirected sources are accepted for guarded legacy normalization writes.
+    Preservation itself continues to reject every redirected source.
+    """
+
+    if (
+        not snapshot.evidence_is_complete
+        or len(expected_bytes) != snapshot.evidence_byte_count
+        or hashlib.sha256(expected_bytes).digest() != snapshot.evidence_sha256
+    ):
+        return RecoveryVerificationFailed(RecoveryFailureCategory.SOURCE_CHANGED)
+
+    try:
+        opened = _open_matching_source(path, snapshot, allow_redirected=True)
+        try:
+            actual = _read_evidence(opened.descriptor, len(expected_bytes))
+            if actual != expected_bytes or os.read(opened.descriptor, 1):
+                raise _SourceChanged
+            if not _source_still_matches(path, opened):
+                raise _SourceChanged
+        finally:
+            os.close(opened.descriptor)
+    except (OSError, _FileSafetyFailure, _SourceChanged):
+        return RecoveryVerificationFailed(RecoveryFailureCategory.SOURCE_CHANGED)
+    return RecoveryVerificationSucceeded()
+
+
+def _candidate_failure_category(
+    category: RecoveryFailureCategory,
+) -> CandidateRetentionFailureCategory:
+    if category in (
+        RecoveryFailureCategory.SOURCE_UNAVAILABLE,
+        RecoveryFailureCategory.SOURCE_CHANGED,
+    ):
+        return CandidateRetentionFailureCategory.SOURCE_CHANGED
+    if category is RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE:
+        return CandidateRetentionFailureCategory.RECOVERY_DIRECTORY_FAILURE
+    if category is RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE:
+        return CandidateRetentionFailureCategory.CANDIDATE_VERIFICATION_FAILURE
+    return CandidateRetentionFailureCategory.CANDIDATE_COPY_FAILURE
+
+
+def retain_failed_candidate(
+    config_path: Path,
+    candidate_snapshot: SourceSnapshot,
+    expected_candidate_bytes: bytes,
+) -> CandidateRetentionResult:
+    """Retain only the exact failed candidate proven to belong to this transaction."""
+
+    if candidate_snapshot.source_is_redirected or isinstance(
+        reverify_source_bytes(
+            config_path,
+            candidate_snapshot,
+            expected_candidate_bytes,
+        ),
+        RecoveryVerificationFailed,
+    ):
+        return CandidateRetentionFailed(
+            CandidateRetentionFailureCategory.SOURCE_CHANGED
+        )
+
+    retained = _preserve_source_with_suffix(
+        config_path,
+        candidate_snapshot,
+        final_suffix="failed-candidate",
+    )
+    if isinstance(retained, SourcePreservationFailed):
+        return CandidateRetentionFailed(
+            _candidate_failure_category(retained.category),
+            failed_candidate_copy_count=retained.recovery_copy_count,
+        )
+    return CandidateRetained()
+
+
+def preserve_and_reset(
+    config_path: Path,
+    snapshot: SourceSnapshot | None,
+    replacement_text: str,
+) -> RecoveryResult:
+    """Preserve the detected source, verify it, then atomically install reset text."""
+
+    preservation = preserve_source(config_path, snapshot)
+    if isinstance(preservation, SourcePreservationFailed):
+        return RecoveryFailed(
+            preservation.category,
+            recovery_copy_count=preservation.recovery_copy_count,
+        )
+    preserved = preservation.source
+
+    def guard() -> None:
+        verification = reverify_preserved_source(preserved)
+        if isinstance(verification, RecoveryVerificationFailed):
+            raise _GuardFailure(verification.category)
+
+    try:
+        atomic_write_text(config_path, replacement_text, before_replace=guard)
+    except _GuardFailure as failure:
+        return RecoveryFailed(
+            failure.category,
+            recovery_copy_count=1,
+        )
+    except OSError:
+        return RecoveryFailed(
+            RecoveryFailureCategory.RESET_FAILURE,
+            recovery_copy_count=1,
+        )
+    return RecoverySucceeded()

--- a/tests/unit/test_config_migration.py
+++ b/tests/unit/test_config_migration.py
@@ -1,0 +1,2047 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import config_migration as migration
+import config_recovery
+from config_recovery import MAX_CONFIG_BYTES
+
+pytestmark = pytest.mark.unit
+
+
+def _accept(
+    _document: Mapping[str, migration.JsonValue],
+) -> migration.ValidationDecision:
+    return migration.ValidationAccepted()
+
+
+def _validated(spec: migration.RegistrySpec) -> migration.ValidatedMigrationRegistry:
+    result = migration.validate_registry(spec)
+    assert isinstance(result, migration.RegistryReady)  # nosec B101
+    return result.registry
+
+
+def _single_step_registry(
+    transform: migration.StepTransform,
+    *,
+    target_validator: migration.Validator = _accept,
+) -> migration.ValidatedMigrationRegistry:
+    return _validated(
+        migration.RegistrySpec(
+            0,
+            1,
+            (migration.MigrationStep(0, 1, "legacy_to_v1", transform),),
+            (
+                migration.VersionValidator(0, _accept),
+                migration.VersionValidator(1, target_validator),
+            ),
+        )
+    )
+
+
+def _prepared_single_step(
+    transform: migration.StepTransform,
+    *,
+    target_validator: migration.Validator = _accept,
+) -> migration.PreparedMigration:
+    result = migration.prepare_migration(
+        {"title": "Legacy", "unknown": {"items": ["kept"]}},
+        _single_step_registry(transform, target_validator=target_validator),
+    )
+    assert isinstance(result, migration.PreparedMigration)  # nosec B101
+    return result
+
+
+def _recovery_files(config_path: Path) -> list[Path]:
+    return sorted((config_path.parent / "recovery").glob("config-*.recovery"))
+
+
+def _failed_candidate_files(config_path: Path) -> list[Path]:
+    return sorted((config_path.parent / "recovery").glob("config-*.failed-candidate"))
+
+
+def _temporary_residue(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix in (".partial", ".tmp")
+    )
+
+
+def _forbid_legacy_constructor(_mapping: dict[str, object]) -> object:
+    raise AssertionError("migration result must not enter legacy construction")
+
+
+def test_production_empty_registry_keeps_implicit_v0_legacy_only() -> None:
+    source: migration.JsonObject = {
+        "title": "Legacy",
+        "unknown": {"private": "not rendered"},
+    }
+
+    result = migration.prepare_migration(source, migration.PRODUCTION_REGISTRY)
+
+    assert isinstance(result, migration.LegacyV0Current)  # nosec B101
+    assert result.document == source  # nosec B101
+    assert (
+        migration.migration_startup_route(result)
+        is migration.MigrationStartupRoute.LEGACY
+    )
+    assert "private" not in repr(result)  # nosec B101
+
+
+def test_production_implicit_v0_bypasses_pure_detachment_for_legacy_compatibility(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"Legacy","ignored":NaN}'
+    config_path.write_bytes(original)
+
+    def construct_legacy(mapping: dict[str, object]) -> str:
+        ignored = mapping["ignored"]
+        assert isinstance(ignored, float)  # nosec B101
+        assert math.isnan(ignored)  # nosec B101
+        return "legacy"
+
+    result = migration.load_startup_configuration(
+        config_path,
+        construct_legacy,
+        migration.PRODUCTION_REGISTRY,
+    )
+
+    assert isinstance(result, migration.ImplicitLegacyLoaded)  # nosec B101
+    assert result.value == "legacy"  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_category"),
+    [
+        (
+            b'{"schema_version":99,"future":true}',
+            migration.VersionRejectionCategory.UNSUPPORTED_NEWER,
+        ),
+        (
+            b'{"schema_version":0,"title":"invalid"}',
+            migration.VersionRejectionCategory.MALFORMED_VERSION,
+        ),
+    ],
+)
+def test_production_explicit_version_never_constructs_or_writes(
+    tmp_path: Path,
+    source: bytes,
+    expected_category: migration.VersionRejectionCategory,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(source)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+    )
+
+    assert isinstance(result, migration.VersionRejected)  # nosec B101
+    assert result.category is expected_category  # nosec B101
+    assert config_path.read_bytes() == source  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0, -1, True, False, 1.0, "1", None, [], {}],
+)
+def test_invalid_explicit_versions_are_malformed_without_coercion(
+    value: object,
+) -> None:
+    document = cast(migration.JsonObject, {"schema_version": value})
+
+    result = migration.identify_version(document)
+
+    assert isinstance(result, migration.VersionRejected)  # nosec B101
+    assert result.category is migration.VersionRejectionCategory.MALFORMED_VERSION
+    assert (
+        migration.migration_startup_route(result)
+        is migration.MigrationStartupRoute.EXIT_ONLY
+    )
+
+
+@pytest.mark.parametrize("version", [1, 2, 10**30])
+def test_positive_explicit_versions_are_identified_exactly(version: int) -> None:
+    result = migration.identify_version({"schema_version": version})
+
+    assert result == migration.ExplicitVersion(version)  # nosec B101
+
+
+def test_production_rejects_every_positive_explicit_version_as_newer() -> None:
+    result = migration.prepare_migration(
+        {"schema_version": 1}, migration.PRODUCTION_REGISTRY
+    )
+
+    assert isinstance(result, migration.VersionRejected)  # nosec B101
+    assert result.category is migration.VersionRejectionCategory.UNSUPPORTED_NEWER
+    assert result.version == 1  # nosec B101
+
+
+def _step(
+    source: int,
+    target: int,
+    name: str,
+    transform: migration.StepTransform | None = None,
+) -> migration.MigrationStep:
+    return migration.MigrationStep(
+        source,
+        target,
+        name,
+        transform or (lambda document: migration.StepApplied(document)),
+    )
+
+
+def _validator(
+    version: int, callback: migration.Validator = _accept
+) -> migration.VersionValidator:
+    return migration.VersionValidator(version, callback)
+
+
+@pytest.mark.parametrize(
+    ("spec", "category"),
+    [
+        (
+            migration.RegistrySpec(None, 1, (), ()),
+            migration.RegistryRejectionCategory.INVALID_BOUNDS,
+        ),
+        (
+            migration.RegistrySpec(1, 0, (), ()),
+            migration.RegistryRejectionCategory.INVALID_BOUNDS,
+        ),
+        (
+            migration.RegistrySpec(0, 1, (_step(0, 2, "bad_endpoint"),), ()),
+            migration.RegistryRejectionCategory.INVALID_STEP_ENDPOINT,
+        ),
+        (
+            migration.RegistrySpec(
+                0,
+                1,
+                (_step(0, 1, "first"), _step(0, 1, "second")),
+                (),
+            ),
+            migration.RegistryRejectionCategory.DUPLICATE_STEP_SOURCE,
+        ),
+        (
+            migration.RegistrySpec(0, 2, (_step(0, 1, "only_first"),), ()),
+            migration.RegistryRejectionCategory.STEP_GAP,
+        ),
+        (
+            migration.RegistrySpec(0, 1, (_step(0, 1, "Unsafe Name"),), ()),
+            migration.RegistryRejectionCategory.UNSAFE_STEP_NAME,
+        ),
+        (
+            migration.RegistrySpec(
+                0,
+                2,
+                (_step(0, 1, "duplicate"), _step(1, 2, "duplicate")),
+                (),
+            ),
+            migration.RegistryRejectionCategory.DUPLICATE_STEP_NAME,
+        ),
+        (
+            migration.RegistrySpec(
+                0,
+                1,
+                (_step(0, 1, "valid"),),
+                (_validator(0), _validator(2)),
+            ),
+            migration.RegistryRejectionCategory.INVALID_VALIDATOR_VERSION,
+        ),
+        (
+            migration.RegistrySpec(
+                0,
+                1,
+                (_step(0, 1, "valid"),),
+                (_validator(0), _validator(0)),
+            ),
+            migration.RegistryRejectionCategory.DUPLICATE_VALIDATOR_VERSION,
+        ),
+        (
+            migration.RegistrySpec(
+                0,
+                1,
+                (_step(0, 1, "valid"),),
+                (_validator(0),),
+            ),
+            migration.RegistryRejectionCategory.MISSING_VALIDATOR,
+        ),
+    ],
+)
+def test_invalid_registry_shapes_return_curated_categories(
+    spec: migration.RegistrySpec,
+    category: migration.RegistryRejectionCategory,
+) -> None:
+    result = migration.validate_registry(spec)
+
+    assert result == migration.RegistryRejected(category)  # nosec B101
+    assert "lambda" not in repr(result)  # nosec B101
+    assert migration.migration_diagnostics(result) == {  # nosec B101
+        "failure_count": 1,
+        "failure_kind": "registry_rejection",
+        "failure_category": category.value,
+    }
+
+
+@pytest.mark.parametrize("unsafe_name", [b"bytes", 7, None, object()])
+def test_registry_rejects_every_non_string_step_name(unsafe_name: object) -> None:
+    spec = migration.RegistrySpec(
+        0,
+        1,
+        (
+            migration.MigrationStep(
+                0,
+                1,
+                cast(str, unsafe_name),
+                lambda document: migration.StepApplied(document),
+            ),
+        ),
+        (_validator(0), _validator(1)),
+    )
+
+    result = migration.validate_registry(spec)
+
+    assert result == migration.RegistryRejected(  # nosec B101
+        migration.RegistryRejectionCategory.UNSAFE_STEP_NAME
+    )
+
+
+@pytest.mark.parametrize(
+    ("spec", "category"),
+    [
+        (
+            migration.RegistrySpec(0, 10**100, (), ()),
+            migration.RegistryRejectionCategory.STEP_GAP,
+        ),
+        (
+            migration.RegistrySpec(10**100, 10**100, (), ()),
+            migration.RegistryRejectionCategory.MISSING_VALIDATOR,
+        ),
+    ],
+)
+def test_sparse_huge_registry_bounds_return_without_materializing_ranges(
+    spec: migration.RegistrySpec,
+    category: migration.RegistryRejectionCategory,
+) -> None:
+    result = migration.validate_registry(spec)
+
+    assert result == migration.RegistryRejected(category)  # nosec B101
+
+
+def test_current_version_is_validated_without_preparing_steps() -> None:
+    calls: list[migration.JsonObject] = []
+
+    def validate_current(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        calls.append(dict(document))
+        return migration.ValidationAccepted()
+
+    registry = _validated(
+        migration.RegistrySpec(1, 1, (), (_validator(1, validate_current),))
+    )
+    source: migration.JsonObject = {"schema_version": 1, "name": "Current"}
+
+    result = migration.prepare_migration(source, registry)
+
+    assert isinstance(result, migration.VersionedCurrent)  # nosec B101
+    assert result.document == source  # nosec B101
+    assert calls == [source]  # nosec B101
+    assert (
+        migration.migration_startup_route(result)
+        is migration.MigrationStartupRoute.CURRENT
+    )
+
+
+def test_current_version_validator_can_reject_before_any_step() -> None:
+    def reject_current(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        return migration.ValidationRejected()
+
+    registry = _validated(
+        migration.RegistrySpec(1, 1, (), (_validator(1, reject_current),))
+    )
+    source: migration.JsonObject = {"schema_version": 1, "valid_json": True}
+    original = deepcopy(source)
+
+    result = migration.prepare_migration(source, registry)
+
+    assert isinstance(result, migration.PureExecutionRejected)  # nosec B101
+    assert (
+        result.category
+        is migration.PureExecutionRejectionCategory.SOURCE_VALIDATION_FAILURE
+    )
+    assert source == original  # nosec B101
+    assert (
+        migration.migration_startup_route(result)
+        is migration.MigrationStartupRoute.EXIT_ONLY
+    )
+
+
+def _synthetic_run() -> tuple[
+    migration.SerializedMigration,
+    list[str],
+    list[migration.JsonObject],
+    migration.JsonObject,
+]:
+    events: list[str] = []
+    returned_documents: list[migration.JsonObject] = []
+    source: migration.JsonObject = {
+        "title": "Café 東京",
+        "unknown_top_level": {"items": ["preserved"]},
+    }
+    original = deepcopy(source)
+
+    def validator(version: int) -> migration.Validator:
+        def validate(
+            document: Mapping[str, migration.JsonValue],
+        ) -> migration.ValidationDecision:
+            events.append(f"validate_{version}")
+            if version == 0:
+                assert "schema_version" not in document  # nosec B101
+            else:
+                assert document["schema_version"] == version  # nosec B101
+            return migration.ValidationAccepted()
+
+        return validate
+
+    def migrate_0_to_1(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        events.append("step_0_to_1")
+        assert document["unknown_top_level"] == {  # nosec B101
+            "items": ["preserved"]
+        }
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        candidate["history"] = ["v1"]
+        returned_documents.append(candidate)
+        return migration.StepApplied(candidate)
+
+    def migrate_1_to_2(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        events.append("step_1_to_2")
+        candidate = dict(document)
+        candidate["schema_version"] = 2
+        candidate["history"] = ["v1", "v2"]
+        returned_documents.append(candidate)
+        return migration.StepApplied(candidate)
+
+    registry = _validated(
+        migration.RegistrySpec(
+            0,
+            2,
+            (
+                _step(1, 2, "v1_to_v2", migrate_1_to_2),
+                _step(0, 1, "v0_to_v1", migrate_0_to_1),
+            ),
+            (
+                _validator(2, validator(2)),
+                _validator(0, validator(0)),
+                _validator(1, validator(1)),
+            ),
+        )
+    )
+
+    prepared = migration.prepare_migration(source, registry)
+    assert isinstance(prepared, migration.PreparedMigration)  # nosec B101
+    assert prepared.source_version == 0  # nosec B101
+    assert prepared.target_version == 2  # nosec B101
+    assert prepared.step_count == 2  # nosec B101
+    assert source == original  # nosec B101
+
+    executed = migration.execute_prepared_migration(prepared)
+    assert isinstance(executed, migration.SerializedMigration)  # nosec B101
+    assert source == original  # nosec B101
+    return executed, events, returned_documents, source
+
+
+def test_synthetic_v0_to_v1_to_v2_is_consecutive_detached_and_deterministic() -> None:
+    first, first_events, returned_documents, source = _synthetic_run()
+    second, second_events, _, second_source = _synthetic_run()
+
+    assert first_events == [  # nosec B101
+        "validate_0",
+        "step_0_to_1",
+        "validate_1",
+        "step_1_to_2",
+        "validate_2",
+    ]
+    assert second_events == first_events  # nosec B101
+    assert first.serialized == second.serialized  # nosec B101
+    assert first.document == second.document  # nosec B101
+    assert source == second_source  # nosec B101
+    assert first.document["unknown_top_level"] == {  # nosec B101
+        "items": ["preserved"]
+    }
+    assert "workspaces" not in first.document  # nosec B101
+    assert "id" not in first.document  # nosec B101
+    assert first.serialized.decode("utf-8") == json.dumps(  # nosec B101
+        first.document,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    )
+    assert not first.serialized.endswith(b"\n")  # nosec B101
+    assert b"\r\n" not in first.serialized  # nosec B101
+
+    returned_documents[-1]["history"] = ["mutated after return"]
+    assert first.document["history"] == ["v1", "v2"]  # nosec B101
+
+
+def test_intermediate_validator_rejection_stops_before_later_step() -> None:
+    calls: list[str] = []
+
+    def first_step(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        calls.append("first_step")
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        return migration.StepApplied(candidate)
+
+    def reject_intermediate(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        calls.append("reject_intermediate")
+        return migration.ValidationRejected()
+
+    def forbidden_step(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        calls.append("forbidden_step")
+        return migration.StepRejected()
+
+    registry = _validated(
+        migration.RegistrySpec(
+            0,
+            2,
+            (
+                _step(0, 1, "first", first_step),
+                _step(1, 2, "forbidden", forbidden_step),
+            ),
+            (
+                _validator(0),
+                _validator(1, reject_intermediate),
+                _validator(2),
+            ),
+        )
+    )
+    prepared = migration.prepare_migration({"title": "Legacy"}, registry)
+    assert isinstance(prepared, migration.PreparedMigration)  # nosec B101
+
+    result = migration.execute_prepared_migration(prepared)
+
+    assert isinstance(result, migration.PureExecutionRejected)  # nosec B101
+    assert (
+        result.category
+        is migration.PureExecutionRejectionCategory.INTERMEDIATE_VALIDATION_FAILURE
+    )
+    assert result.stage is migration.PureExecutionStage.INTERMEDIATE_VALIDATION
+    assert calls == ["first_step", "reject_intermediate"]  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("transform", "expected_type", "expected_category"),
+    [
+        (
+            lambda _document: migration.StepRejected(),
+            migration.PureExecutionRejected,
+            migration.PureExecutionRejectionCategory.STEP_REJECTION,
+        ),
+        (
+            lambda _document: cast(migration.StepDecision, object()),
+            migration.PureEngineDefect,
+            migration.PureEngineDefectCategory.INVALID_CALLBACK_RESULT,
+        ),
+        (
+            lambda _document: migration.StepApplied(
+                cast(Mapping[str, migration.JsonValue], {"schema_version": {1}})
+            ),
+            migration.PureEngineDefect,
+            migration.PureEngineDefectCategory.INVALID_STEP_OUTPUT,
+        ),
+        (
+            lambda _document: migration.StepApplied({"schema_version": True}),
+            migration.PureEngineDefect,
+            migration.PureEngineDefectCategory.UNEXPECTED_TARGET_VERSION,
+        ),
+        (
+            lambda _document: migration.StepApplied({"schema_version": 2}),
+            migration.PureEngineDefect,
+            migration.PureEngineDefectCategory.UNEXPECTED_TARGET_VERSION,
+        ),
+    ],
+)
+def test_step_contract_outcomes_are_distinct_and_curated(
+    transform: migration.StepTransform,
+    expected_type: type[object],
+    expected_category: object,
+) -> None:
+    result = migration.execute_prepared_migration(_prepared_single_step(transform))
+
+    assert isinstance(result, expected_type)  # nosec B101
+    assert result.category is expected_category  # type: ignore[union-attr]  # nosec B101
+
+
+def test_callback_exception_text_and_captured_source_are_not_exposed() -> None:
+    secret = "https://example.test/?token=do-not-log"
+
+    def explode(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        raise RuntimeError(secret)
+
+    prepared = _prepared_single_step(explode)
+    result = migration.execute_prepared_migration(prepared)
+
+    assert isinstance(result, migration.PureEngineDefect)  # nosec B101
+    assert result.category is migration.PureEngineDefectCategory.CALLBACK_EXCEPTION
+    rendered = repr([prepared, result, migration.migration_diagnostics(result)])
+    assert secret not in rendered  # nosec B101
+    assert "RuntimeError" not in rendered  # nosec B101
+    assert (
+        migration.migration_startup_route(result)
+        is migration.MigrationStartupRoute.EXIT_ONLY
+    )
+
+
+def test_target_validator_rejection_is_distinct_from_step_rejection() -> None:
+    def valid_step(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        return migration.StepApplied(candidate)
+
+    def reject_target(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        return migration.ValidationRejected()
+
+    result = migration.execute_prepared_migration(
+        _prepared_single_step(valid_step, target_validator=reject_target)
+    )
+
+    assert isinstance(result, migration.PureExecutionRejected)  # nosec B101
+    assert (
+        result.category
+        is migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+    )
+    assert result.stage is migration.PureExecutionStage.TARGET_VALIDATION
+
+
+def test_deterministic_serializer_is_unicode_sorted_lf_and_no_final_newline() -> None:
+    result = migration.serialize_deterministically(
+        {"z": 2, "schema_version": 1, "a": "Café 東京"}
+    )
+
+    assert isinstance(result, migration.SerializedDocument)  # nosec B101
+    assert result.data == (  # nosec B101
+        '{\n  "a": "Café 東京",\n  "schema_version": 1,\n  "z": 2\n}'
+    ).encode("utf-8")
+    assert result.byte_count == len(result.data)  # nosec B101
+
+
+def _candidate_with_serialized_size(size: int) -> migration.JsonObject:
+    empty: migration.JsonObject = {"padding": "", "schema_version": 1}
+    baseline = json.dumps(
+        empty,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ).encode("utf-8")
+    assert size >= len(baseline)  # nosec B101
+    return {"padding": "x" * (size - len(baseline)), "schema_version": 1}
+
+
+def test_candidate_exactly_four_mib_is_accepted() -> None:
+    result = migration.serialize_deterministically(
+        _candidate_with_serialized_size(MAX_CONFIG_BYTES)
+    )
+
+    assert isinstance(result, migration.SerializedDocument)  # nosec B101
+    assert result.byte_count == MAX_CONFIG_BYTES  # nosec B101
+
+
+def test_candidate_four_mib_plus_one_is_curated_pre_write_failure() -> None:
+    result = migration.serialize_deterministically(
+        _candidate_with_serialized_size(MAX_CONFIG_BYTES + 1)
+    )
+
+    assert isinstance(result, migration.PureEngineFailure)  # nosec B101
+    assert (
+        result.category
+        is migration.PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED
+    )
+    assert result.stage is migration.PureExecutionStage.SERIALIZATION
+    assert "padding" not in repr(result)  # nosec B101
+
+
+def test_non_finite_candidate_is_rejected_without_rendering_value() -> None:
+    result = migration.serialize_deterministically(
+        {"schema_version": 1, "value": float("nan")}
+    )
+
+    assert isinstance(result, migration.PureEngineFailure)  # nosec B101
+    assert result.category is migration.PureEngineFailureCategory.SERIALIZATION_FAILURE
+    assert "nan" not in repr(result).lower()  # nosec B101
+
+
+def test_real_filesystem_v0_to_v1_to_v2_transaction_is_ordered_and_deterministic(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    source: migration.JsonObject = {
+        "title": "Café 東京",
+        "unknown_top_level": {"items": ["preserved"]},
+    }
+    original = json.dumps(source, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    config_path.write_bytes(original)
+    events: list[str] = []
+
+    def validate_0(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        events.append("validate_0")
+        assert "schema_version" not in document  # nosec B101
+        assert _recovery_files(config_path) == []  # nosec B101
+        return migration.ValidationAccepted()
+
+    def validate_version(
+        version: int,
+    ) -> migration.Validator:
+        def validate(
+            document: Mapping[str, migration.JsonValue],
+        ) -> migration.ValidationDecision:
+            events.append(f"validate_{version}")
+            assert document["schema_version"] == version  # nosec B101
+            return migration.ValidationAccepted()
+
+        return validate
+
+    def migrate_0_to_1(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        events.append("step_0_to_1")
+        recovery_files = _recovery_files(config_path)
+        assert len(recovery_files) == 1  # nosec B101
+        assert recovery_files[0].read_bytes() == original  # nosec B101
+        assert document["unknown_top_level"] == {  # nosec B101
+            "items": ["preserved"]
+        }
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        candidate["history"] = ["v1"]
+        return migration.StepApplied(candidate)
+
+    def migrate_1_to_2(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        events.append("step_1_to_2")
+        candidate = dict(document)
+        candidate["schema_version"] = 2
+        candidate["history"] = ["v1", "v2"]
+        return migration.StepApplied(candidate)
+
+    registry = _validated(
+        migration.RegistrySpec(
+            0,
+            2,
+            (
+                _step(0, 1, "v0_to_v1", migrate_0_to_1),
+                _step(1, 2, "v1_to_v2", migrate_1_to_2),
+            ),
+            (
+                _validator(0, validate_0),
+                _validator(1, validate_version(1)),
+                _validator(2, validate_version(2)),
+            ),
+        )
+    )
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(result, migration.MigrationCommitted)  # nosec B101
+    assert events == [  # nosec B101
+        "validate_0",
+        "step_0_to_1",
+        "validate_1",
+        "step_1_to_2",
+        "validate_2",
+        "validate_2",
+    ]
+    serialized = migration.serialize_deterministically(result.document)
+    assert isinstance(serialized, migration.SerializedDocument)  # nosec B101
+    assert config_path.read_bytes() == serialized.data  # nosec B101
+    assert result.byte_count == len(serialized.data)  # nosec B101
+    assert result.document["unknown_top_level"] == {  # nosec B101
+        "items": ["preserved"]
+    }
+    assert "workspaces" not in result.document  # nosec B101
+    assert "id" not in result.document  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_current_validator_rejection_creates_no_artifact_or_write(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{  "schema_version" : 1, "title" : "unchanged" }'
+    config_path.write_bytes(original)
+
+    def reject_current(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        return migration.ValidationRejected()
+
+    registry = _validated(
+        migration.RegistrySpec(1, 1, (), (_validator(1, reject_current),))
+    )
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(result, migration.PureExecutionRejected)  # nosec B101
+    assert (
+        result.category
+        is migration.PureExecutionRejectionCategory.SOURCE_VALIDATION_FAILURE
+    )
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_step_rejection_after_preservation_keeps_exact_original_and_no_temp(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{\r\n  "title": "Caf\xc3\xa9",\r\n  "unknown": true\r\n}'
+    config_path.write_bytes(original)
+    registry = _single_step_registry(lambda _document: migration.StepRejected())
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(  # nosec B101
+        result, migration.MigrationAbortedAfterPreservation
+    )
+    assert isinstance(result.problem, migration.PureExecutionRejected)  # nosec B101
+    assert (
+        result.problem.category
+        is migration.PureExecutionRejectionCategory.STEP_REJECTION
+    )
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert result.failed_candidate_copy_count == 0  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def _size_candidate_registry(size: int) -> migration.ValidatedMigrationRegistry:
+    candidate = _candidate_with_serialized_size(size)
+
+    def create_sized_candidate(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        return migration.StepApplied(candidate)
+
+    return _single_step_registry(create_sized_candidate)
+
+
+def test_exact_maximum_candidate_commits_through_real_transaction(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    config_path.write_bytes(original)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _size_candidate_registry(MAX_CONFIG_BYTES),
+    )
+
+    assert isinstance(result, migration.MigrationCommitted)  # nosec B101
+    assert result.byte_count == MAX_CONFIG_BYTES  # nosec B101
+    assert len(config_path.read_bytes()) == MAX_CONFIG_BYTES  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_maximum_plus_one_candidate_stops_after_preservation_without_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{ "title": "legacy" }'
+    config_path.write_bytes(original)
+    writer_calls: list[tuple[Path, int]] = []
+
+    def forbidden_writer(
+        path: Path,
+        data: bytes,
+        *,
+        before_replace: object = None,
+    ) -> None:
+        del before_replace
+        writer_calls.append((path, len(data)))
+        raise AssertionError("oversized candidate reached atomic writer")
+
+    monkeypatch.setattr(migration, "atomic_write_bytes", forbidden_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _size_candidate_registry(MAX_CONFIG_BYTES + 1),
+    )
+
+    assert isinstance(  # nosec B101
+        result, migration.MigrationAbortedAfterPreservation
+    )
+    assert isinstance(result.problem, migration.PureEngineFailure)  # nosec B101
+    assert (
+        result.problem.category
+        is migration.PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED
+    )
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert writer_calls == []  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_post_write_target_rejection_retains_candidate_and_rolls_back_exactly(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = (
+        b'{\r\n  "unknown": "Caf\xc3\xa9",\r\n  "title": "Legacy",\r\n'
+        b'  "items": [2, 1]\r\n}'
+    )
+    config_path.write_bytes(original)
+    events: list[str] = []
+    target_validation_count = 0
+
+    def validate_legacy(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        events.append("validate_0")
+        return migration.ValidationAccepted()
+
+    def validate_target(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        nonlocal target_validation_count
+        target_validation_count += 1
+        events.append(f"validate_1_{target_validation_count}")
+        if target_validation_count == 1:
+            return migration.ValidationAccepted()
+        return migration.ValidationRejected()
+
+    def migrate_to_1(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        events.append("step_0_to_1")
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        return migration.StepApplied(candidate)
+
+    registry = _validated(
+        migration.RegistrySpec(
+            0,
+            1,
+            (_step(0, 1, "v0_to_v1", migrate_to_1),),
+            (
+                _validator(0, validate_legacy),
+                _validator(1, validate_target),
+            ),
+        )
+    )
+    candidate_document: migration.JsonObject = cast(
+        migration.JsonObject,
+        json.loads(original.decode("utf-8")),
+    )
+    candidate_document["schema_version"] = 1
+    expected_candidate = migration.serialize_deterministically(candidate_document)
+    assert isinstance(expected_candidate, migration.SerializedDocument)  # nosec B101
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(result, migration.MigrationRolledBack)  # nosec B101
+    assert (
+        result.category
+        is migration.TransactionFailureCategory.POST_WRITE_VALIDATION_FAILURE
+    )
+    assert result.authority is migration.ConfigurationAuthority.RESTORED_ORIGINAL
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert result.failed_candidate_copy_count == 1  # nosec B101
+    assert result.rollback_count == 1  # nosec B101
+    assert events == [  # nosec B101
+        "validate_0",
+        "step_0_to_1",
+        "validate_1_1",
+        "validate_1_2",
+        "validate_0",
+    ]
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert [path.read_bytes() for path in _failed_candidate_files(config_path)] == [
+        expected_candidate.data
+    ]
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+    final_load = config_recovery.load_raw_config(config_path)
+    assert isinstance(final_load, config_recovery.RawConfigLoaded)  # nosec B101
+    assert final_load.source_bytes == original  # nosec B101
+    assert final_load.mapping == json.loads(original.decode("utf-8"))  # nosec B101
+
+
+def test_guarded_legacy_normalization_save_does_not_overwrite_future_race(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(b'{"title":"legacy"}')
+
+    loaded = migration.load_startup_configuration(
+        config_path,
+        lambda mapping: dict(mapping),
+        migration.PRODUCTION_REGISTRY,
+    )
+    assert isinstance(loaded, migration.ImplicitLegacyLoaded)  # nosec B101
+
+    future_bytes = b'{ "schema_version": 99, "future": true }'
+    config_path.write_bytes(future_bytes)
+    result = migration.guarded_legacy_normalization_save(
+        config_path,
+        loaded.raw,
+        '{"title":"normalized legacy"}',
+    )
+
+    assert isinstance(result, migration.LegacyNormalizationSaveFailed)  # nosec B101
+    assert (
+        result.category
+        is migration.LegacyNormalizationSaveFailureCategory.SOURCE_CHANGED
+    )
+    assert config_path.read_bytes() == future_bytes  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_startup_routing_keeps_q3_recovery_separate_from_exit_only() -> None:
+    q3 = config_recovery.ConfigRecoveryRequired(
+        config_recovery.ConfigLoadFailureCategory.MALFORMED_JSON
+    )
+    defect = migration.PureEngineDefect(
+        migration.PureEngineDefectCategory.CALLBACK_EXCEPTION,
+        migration.PureExecutionStage.STEP,
+        0,
+        1,
+        "safe_step",
+    )
+    exit_only: list[migration.ExitOnlyFailure] = [
+        migration.VersionRejected(migration.VersionRejectionCategory.MALFORMED_VERSION),
+        defect,
+        migration.MigrationAbortedAfterPreservation(defect),
+        migration.MigrationRolledBack(
+            migration.TransactionFailureCategory.POST_WRITE_VALIDATION_FAILURE,
+            defect,
+            failed_candidate_copy_count=1,
+        ),
+        migration.MigrationTransactionFailed(
+            migration.TransactionFailureCategory.SOURCE_CHANGED,
+            migration.ConfigurationAuthority.EXTERNAL_CURRENT,
+            1,
+        ),
+        migration.LegacyNormalizationSaveFailed(
+            migration.LegacyNormalizationSaveFailureCategory.SOURCE_CHANGED
+        ),
+    ]
+
+    assert (  # nosec B101
+        migration.startup_failure_route(q3) is migration.StartupFailureRoute.Q3_RECOVERY
+    )
+    assert all(
+        migration.startup_failure_route(outcome)
+        is migration.StartupFailureRoute.EXIT_ONLY
+        for outcome in exit_only
+    )  # nosec B101
+
+
+def test_transaction_callback_failure_is_private_in_every_rendering_layer(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    secret = "https://example.test/?token=never-render-this"
+    config_path.write_text(
+        json.dumps({"title": secret}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    def explode(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        raise RuntimeError(secret)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(explode),
+    )
+    assert isinstance(  # nosec B101
+        result, migration.MigrationAbortedAfterPreservation
+    )
+    assert isinstance(result.problem, migration.PureEngineDefect)  # nosec B101
+
+    transaction_fields = migration.transaction_diagnostics(result)
+    startup_fields = migration.startup_failure_diagnostics(result)
+    notice_category = migration.startup_notice_category(result)
+    notice_message = migration.startup_notice_message(notice_category)
+    error = migration.ConfigurationMigrationError.from_outcome(result)
+    try:
+        raise error
+    except migration.ConfigurationMigrationError as caught:
+        assert caught.__cause__ is None  # nosec B101
+        assert caught.__context__ is None  # nosec B101
+        rendered = repr(
+            [
+                result,
+                result.problem,
+                transaction_fields,
+                startup_fields,
+                notice_category,
+                notice_message,
+                repr(caught),
+                str(caught),
+                caught.diagnostics,
+            ]
+        )
+
+    assert notice_category is migration.StartupNoticeCategory.MIGRATION_FAILED
+    assert notice_message == (  # nosec B101
+        "The saved configuration could not be migrated safely. "
+        "The application will exit."
+    )
+    assert secret not in rendered  # nosec B101
+    assert "RuntimeError" not in rendered  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def _forbidden_candidate_writer(*_args: object, **_kwargs: object) -> None:
+    raise AssertionError("candidate writer must not run")
+
+
+def _file_symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"file symlinks unavailable: {type(error).__name__}")
+
+
+def _post_write_rejection_registry(
+    source_validator: migration.Validator = _accept,
+) -> migration.ValidatedMigrationRegistry:
+    target_validation_count = 0
+
+    def migrate_to_v1(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        return migration.StepApplied(candidate)
+
+    def reject_second_target_validation(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        nonlocal target_validation_count
+        target_validation_count += 1
+        if target_validation_count == 1:
+            return migration.ValidationAccepted()
+        return migration.ValidationRejected()
+
+    return _validated(
+        migration.RegistrySpec(
+            0,
+            1,
+            (_step(0, 1, "legacy_to_v1", migrate_to_v1),),
+            (
+                _validator(0, source_validator),
+                _validator(1, reject_second_target_validation),
+            ),
+        )
+    )
+
+
+def _expected_v1_candidate(original: bytes) -> bytes:
+    document = cast(migration.JsonObject, json.loads(original.decode("utf-8")))
+    document["schema_version"] = 1
+    serialized = migration.serialize_deterministically(document)
+    assert isinstance(serialized, migration.SerializedDocument)  # nosec B101
+    return serialized.data
+
+
+def _assert_transaction_failure(
+    result: object,
+    *,
+    category: migration.TransactionFailureCategory,
+    authority: migration.ConfigurationAuthority,
+    recovery_count: int,
+    candidate_count: int,
+    rollback_count: int,
+) -> migration.MigrationTransactionFailed:
+    assert isinstance(result, migration.MigrationTransactionFailed)  # nosec B101
+    assert result.category is category  # nosec B101
+    assert result.authority is authority  # nosec B101
+    assert result.recovery_copy_count == recovery_count  # nosec B101
+    assert result.failed_candidate_copy_count == candidate_count  # nosec B101
+    assert result.rollback_count == rollback_count  # nosec B101
+    return result
+
+
+def test_unsupported_older_filesystem_config_is_classified_without_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{ "schema_version": 1, "title": "older" }'
+    config_path.write_bytes(original)
+    registry = _validated(migration.RegistrySpec(2, 2, (), (_validator(2),)))
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(result, migration.VersionRejected)  # nosec B101
+    assert result.category is migration.VersionRejectionCategory.UNSUPPORTED_OLDER
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_missing_startup_config_returns_missing_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+    )
+
+    assert isinstance(result, config_recovery.ConfigMissing)  # nosec B101
+    assert list(tmp_path.iterdir()) == []  # nosec B101
+
+
+def test_valid_current_filesystem_config_is_exact_noop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{  "schema_version" : 1, "title" : "current" }'
+    config_path.write_bytes(original)
+    registry = _validated(migration.RegistrySpec(1, 1, (), (_validator(1),)))
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(result, migration.VersionedCurrent)  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("rejected_version", "expected_stage"),
+    [
+        (1, migration.PureExecutionStage.INTERMEDIATE_VALIDATION),
+        (2, migration.PureExecutionStage.TARGET_VALIDATION),
+    ],
+)
+def test_filesystem_validation_rejection_after_preservation_never_writes_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rejected_version: int,
+    expected_stage: migration.PureExecutionStage,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy","unknown":true}'
+    config_path.write_bytes(original)
+
+    def migrate(version: int) -> migration.StepTransform:
+        def transform(
+            document: Mapping[str, migration.JsonValue],
+        ) -> migration.StepDecision:
+            candidate = dict(document)
+            candidate["schema_version"] = version
+            return migration.StepApplied(candidate)
+
+        return transform
+
+    def validate(version: int) -> migration.Validator:
+        def validator(
+            _document: Mapping[str, migration.JsonValue],
+        ) -> migration.ValidationDecision:
+            if version == rejected_version:
+                return migration.ValidationRejected()
+            return migration.ValidationAccepted()
+
+        return validator
+
+    registry = _validated(
+        migration.RegistrySpec(
+            0,
+            2,
+            (
+                _step(0, 1, "legacy_to_v1", migrate(1)),
+                _step(1, 2, "v1_to_v2", migrate(2)),
+            ),
+            (
+                _validator(0),
+                _validator(1, validate(1)),
+                _validator(2, validate(2)),
+            ),
+        )
+    )
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        registry,
+    )
+
+    assert isinstance(result, migration.MigrationAbortedAfterPreservation)  # nosec B101
+    assert isinstance(result.problem, migration.PureExecutionRejected)  # nosec B101
+    assert result.problem.stage is expected_stage  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_redirected_migration_source_fails_before_step_or_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "target.json"
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"redirected legacy"}'
+    target.write_bytes(original)
+    _file_symlink_or_skip(config_path, target)
+    step_calls = 0
+
+    def transform(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        nonlocal step_calls
+        step_calls += 1
+        return migration.StepApplied(document)
+
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(transform),
+    )
+
+    failure = _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.PRESERVATION_FAILURE,
+        authority=migration.ConfigurationAuthority.ORIGINAL,
+        recovery_count=0,
+        candidate_count=0,
+        rollback_count=0,
+    )
+    assert (
+        failure.recovery_category
+        is config_recovery.RecoveryFailureCategory.SOURCE_UNAVAILABLE
+    )
+    assert step_calls == 0  # nosec B101
+    assert target.read_bytes() == original  # nosec B101
+    assert config_path.is_symlink()  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_guarded_legacy_normalization_succeeds_for_unchanged_regular_source(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(b'{"title":"legacy"}')
+    loaded = migration.load_startup_configuration(
+        config_path,
+        lambda mapping: dict(mapping),
+        migration.PRODUCTION_REGISTRY,
+    )
+    assert isinstance(loaded, migration.ImplicitLegacyLoaded)  # nosec B101
+
+    result = migration.guarded_legacy_normalization_save(
+        config_path,
+        loaded.raw,
+        '{"title":"normalized"}',
+    )
+
+    assert isinstance(result, migration.LegacyNormalizationSaved)  # nosec B101
+    assert config_path.read_bytes() == b'{"title":"normalized"}'  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_guarded_legacy_normalization_accepts_unchanged_redirected_source(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target.json"
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"redirected legacy"}'
+    target.write_bytes(original)
+    _file_symlink_or_skip(config_path, target)
+    loaded = migration.load_startup_configuration(
+        config_path,
+        lambda mapping: dict(mapping),
+        migration.PRODUCTION_REGISTRY,
+    )
+    assert isinstance(loaded, migration.ImplicitLegacyLoaded)  # nosec B101
+
+    result = migration.guarded_legacy_normalization_save(
+        config_path,
+        loaded.raw,
+        '{"title":"normalized"}',
+    )
+
+    assert isinstance(result, migration.LegacyNormalizationSaved)  # nosec B101
+    assert config_path.read_bytes() == b'{"title":"normalized"}'  # nosec B101
+    assert not config_path.is_symlink()  # nosec B101
+    assert target.read_bytes() == original  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_unsafe_recovery_location_blocks_step_and_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    config_path.write_bytes(original)
+    (tmp_path / "recovery").write_bytes(b"obstruction")
+    step_calls = 0
+
+    def transform(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        nonlocal step_calls
+        step_calls += 1
+        return migration.StepApplied(document)
+
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(transform),
+    )
+
+    failure = _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.PRESERVATION_FAILURE,
+        authority=migration.ConfigurationAuthority.ORIGINAL,
+        recovery_count=0,
+        candidate_count=0,
+        rollback_count=0,
+    )
+    assert (
+        failure.recovery_category
+        is config_recovery.RecoveryFailureCategory.RECOVERY_DIRECTORY_FAILURE
+    )
+    assert step_calls == 0  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_step_source_replacement_is_caught_by_candidate_guard(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    external = b'{"schema_version":99,"external":true}'
+    config_path.write_bytes(original)
+
+    def replace_source(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        config_path.write_bytes(external)
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        return migration.StepApplied(candidate)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(replace_source),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.SOURCE_CHANGED,
+        authority=migration.ConfigurationAuthority.UNKNOWN,
+        recovery_count=1,
+        candidate_count=0,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == external  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_step_recovery_artifact_mutation_blocks_candidate_installation(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    config_path.write_bytes(original)
+
+    def corrupt_recovery(
+        document: Mapping[str, migration.JsonValue],
+    ) -> migration.StepDecision:
+        _recovery_files(config_path)[0].write_bytes(b"corrupt recovery")
+        candidate = dict(document)
+        candidate["schema_version"] = 1
+        return migration.StepApplied(candidate)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(corrupt_recovery),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.ORIGINAL_REVERIFICATION_FAILURE,
+        authority=migration.ConfigurationAuthority.ORIGINAL,
+        recovery_count=1,
+        candidate_count=0,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path)[0].read_bytes() == b"corrupt recovery"
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_candidate_writer_failure_preserves_original_and_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    config_path.write_bytes(original)
+
+    def fail_writer(*_args: object, **_kwargs: object) -> None:
+        raise OSError("synthetic candidate writer failure")
+
+    monkeypatch.setattr(migration, "atomic_write_bytes", fail_writer)
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(
+            lambda document: migration.StepApplied({**document, "schema_version": 1})
+        ),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.CANDIDATE_WRITE_FAILURE,
+        authority=migration.ConfigurationAuthority.ORIGINAL,
+        recovery_count=1,
+        candidate_count=0,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("fault_mode", "expected_authority"),
+    [
+        ("reload_failure", migration.ConfigurationAuthority.UNKNOWN),
+        ("byte_mismatch", migration.ConfigurationAuthority.EXTERNAL_CURRENT),
+    ],
+)
+def test_unproven_post_write_candidate_is_never_retained_or_rolled_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault_mode: str,
+    expected_authority: migration.ConfigurationAuthority,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    external = b'{"schema_version":77,"external":true}'
+    config_path.write_bytes(original)
+    real_load = migration.load_raw_config
+    load_count = 0
+
+    def load_with_fault(path: Path) -> config_recovery.RawConfigLoadResult:
+        nonlocal load_count
+        load_count += 1
+        if load_count == 2:
+            path.write_bytes(external)
+            if fault_mode == "reload_failure":
+                return config_recovery.ConfigRecoveryRequired(
+                    config_recovery.ConfigLoadFailureCategory.FILE_READ_FAILURE
+                )
+        return real_load(path)
+
+    monkeypatch.setattr(migration, "load_raw_config", load_with_fault)
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _single_step_registry(
+            lambda document: migration.StepApplied({**document, "schema_version": 1})
+        ),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.POST_WRITE_SOURCE_CHANGED,
+        authority=expected_authority,
+        recovery_count=1,
+        candidate_count=0,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == external  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_candidate_change_after_retention_blocks_rollback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    external = b'{"schema_version":88,"external":true}'
+    config_path.write_bytes(original)
+    real_retain = migration.retain_failed_candidate
+
+    def retain_then_replace(
+        path: Path,
+        snapshot: config_recovery.SourceSnapshot,
+        candidate: bytes,
+    ) -> config_recovery.CandidateRetentionResult:
+        retained = real_retain(path, snapshot, candidate)
+        path.write_bytes(external)
+        return retained
+
+    monkeypatch.setattr(migration, "retain_failed_candidate", retain_then_replace)
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _post_write_rejection_registry(),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+        authority=migration.ConfigurationAuthority.UNKNOWN,
+        recovery_count=1,
+        candidate_count=1,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == external  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert len(_failed_candidate_files(config_path)) == 1  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+@pytest.mark.parametrize("fault_mode", ["artifact_verification", "artifact_read"])
+def test_unverified_original_artifact_never_drives_rollback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault_mode: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    expected_candidate = _expected_v1_candidate(original)
+    config_path.write_bytes(original)
+    failure = config_recovery.RecoveryVerificationFailed(
+        config_recovery.RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+    )
+    if fault_mode == "artifact_verification":
+        monkeypatch.setattr(
+            migration, "verify_preserved_artifact", lambda _source: failure
+        )
+    else:
+        monkeypatch.setattr(migration, "read_preserved_bytes", lambda _source: failure)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _post_write_rejection_registry(),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.ROLLBACK_ARTIFACT_FAILURE,
+        authority=migration.ConfigurationAuthority.CANDIDATE,
+        recovery_count=1,
+        candidate_count=1,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == expected_candidate  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert len(_failed_candidate_files(config_path)) == 1  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_candidate_retention_failure_precedes_trigger_after_successful_rollback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    config_path.write_bytes(original)
+    monkeypatch.setattr(
+        migration,
+        "retain_failed_candidate",
+        lambda *_args: config_recovery.CandidateRetentionFailed(
+            config_recovery.CandidateRetentionFailureCategory.CANDIDATE_COPY_FAILURE
+        ),
+    )
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _post_write_rejection_registry(),
+    )
+
+    assert isinstance(result, migration.MigrationRolledBack)  # nosec B101
+    assert (
+        result.category
+        is migration.TransactionFailureCategory.CANDIDATE_RETENTION_FAILURE
+    )
+    assert result.authority is migration.ConfigurationAuthority.RESTORED_ORIGINAL
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert result.failed_candidate_copy_count == 0  # nosec B101
+    assert result.rollback_count == 1  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_rollback_writer_failure_is_distinct_and_never_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    expected_candidate = _expected_v1_candidate(original)
+    config_path.write_bytes(original)
+    real_writer = migration.atomic_write_bytes
+    writer_count = 0
+
+    def fail_second_writer(
+        path: Path,
+        data: bytes,
+        *,
+        before_replace: Callable[[], None] | None = None,
+    ) -> None:
+        nonlocal writer_count
+        writer_count += 1
+        if writer_count == 2:
+            raise OSError("synthetic rollback writer failure")
+        real_writer(path, data, before_replace=before_replace)
+
+    monkeypatch.setattr(migration, "atomic_write_bytes", fail_second_writer)
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _post_write_rejection_registry(),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.ROLLBACK_WRITE_FAILURE,
+        authority=migration.ConfigurationAuthority.CANDIDATE,
+        recovery_count=1,
+        candidate_count=1,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == expected_candidate  # nosec B101
+    assert len(_failed_candidate_files(config_path)) == 1  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("fault_mode", "expected_authority"),
+    [
+        ("reload", migration.ConfigurationAuthority.UNKNOWN),
+        ("validation", migration.ConfigurationAuthority.RESTORED_ORIGINAL),
+        ("artifact", migration.ConfigurationAuthority.RESTORED_ORIGINAL),
+    ],
+)
+def test_final_rollback_failures_are_distinct_and_never_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault_mode: str,
+    expected_authority: migration.ConfigurationAuthority,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    config_path.write_bytes(original)
+    source_validation_count = 0
+
+    def source_validator(
+        _document: Mapping[str, migration.JsonValue],
+    ) -> migration.ValidationDecision:
+        nonlocal source_validation_count
+        source_validation_count += 1
+        if fault_mode == "validation" and source_validation_count == 2:
+            return migration.ValidationRejected()
+        return migration.ValidationAccepted()
+
+    if fault_mode == "reload":
+        real_load = migration.load_raw_config
+        load_count = 0
+
+        def fail_rollback_reload(path: Path) -> config_recovery.RawConfigLoadResult:
+            nonlocal load_count
+            load_count += 1
+            if load_count == 3:
+                return config_recovery.ConfigRecoveryRequired(
+                    config_recovery.ConfigLoadFailureCategory.FILE_READ_FAILURE
+                )
+            return real_load(path)
+
+        monkeypatch.setattr(migration, "load_raw_config", fail_rollback_reload)
+    elif fault_mode == "artifact":
+        real_verify = migration.verify_preserved_artifact
+        verification_count = 0
+
+        def fail_final_artifact(
+            source: config_recovery.PreservedSource,
+        ) -> config_recovery.RecoveryVerificationResult:
+            nonlocal verification_count
+            verification_count += 1
+            if verification_count == 3:
+                return config_recovery.RecoveryVerificationFailed(
+                    config_recovery.RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+                )
+            return real_verify(source)
+
+        monkeypatch.setattr(migration, "verify_preserved_artifact", fail_final_artifact)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _post_write_rejection_registry(source_validator),
+    )
+
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.ROLLBACK_VERIFICATION_FAILURE,
+        authority=expected_authority,
+        recovery_count=1,
+        candidate_count=1,
+        rollback_count=1,
+    )
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert len(_failed_candidate_files(config_path)) == 1  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_failure_diagnostics_follow_a_compact_privacy_allowlist() -> None:
+    defect = migration.PureEngineDefect(
+        migration.PureEngineDefectCategory.CALLBACK_EXCEPTION,
+        migration.PureExecutionStage.STEP,
+        0,
+        1,
+        "safe_step",
+    )
+    outcomes: list[migration.ExitOnlyFailure] = [
+        migration.VersionRejected(
+            migration.VersionRejectionCategory.UNSUPPORTED_NEWER,
+            99,
+        ),
+        migration.PureExecutionRejected(
+            migration.PureExecutionRejectionCategory.STEP_REJECTION,
+            migration.PureExecutionStage.STEP,
+            0,
+            1,
+            "safe_step",
+        ),
+        defect,
+        migration.MigrationRolledBack(
+            migration.TransactionFailureCategory.CANDIDATE_RETENTION_FAILURE,
+            defect,
+            config_recovery.CandidateRetentionFailureCategory.CANDIDATE_COPY_FAILURE,
+            failed_candidate_copy_count=0,
+        ),
+        migration.MigrationTransactionFailed(
+            migration.TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+            migration.ConfigurationAuthority.UNKNOWN,
+            1,
+            failed_candidate_copy_count=1,
+            candidate_retention_category=(
+                config_recovery.CandidateRetentionFailureCategory.SOURCE_CHANGED
+            ),
+        ),
+        migration.LegacyNormalizationSaveFailed(
+            migration.LegacyNormalizationSaveFailureCategory.SOURCE_CHANGED
+        ),
+    ]
+    allowed_keys = {
+        "failure_count",
+        "failure_kind",
+        "failure_category",
+        "failure_stage",
+        "source_version",
+        "target_version",
+        "step_name",
+        "transaction_state",
+        "configuration_authority",
+        "recovery_copy_count",
+        "failed_candidate_copy_count",
+        "rollback_count",
+        "candidate_retention_category",
+        "recovery_category",
+    }
+    forbidden_fragments = (
+        "https://",
+        "private title",
+        "C:\\private\\config.json",
+        "RuntimeError",
+        "sha256",
+        ".recovery",
+        ".failed-candidate",
+    )
+
+    rendered_parts: list[str] = []
+    for outcome in outcomes:
+        diagnostics = migration.startup_failure_diagnostics(outcome)
+        assert set(diagnostics) <= allowed_keys  # nosec B101
+        assert all(  # nosec B101
+            isinstance(value, (str, int)) and not isinstance(value, bool)
+            for value in diagnostics.values()
+        )
+        notice = migration.startup_notice_message(
+            migration.startup_notice_category(outcome)
+        )
+        rendered_parts.extend((repr(outcome), repr(diagnostics), notice))
+
+    candidate_retention = config_recovery.CandidateRetentionFailed(
+        config_recovery.CandidateRetentionFailureCategory.CANDIDATE_COPY_FAILURE
+    )
+    rendered_parts.append(repr(candidate_retention))
+    rendered = " ".join(rendered_parts)
+    assert all(fragment not in rendered for fragment in forbidden_fragments)  # nosec B101
+
+
+def test_rollback_writer_final_guard_rejects_late_candidate_ownership_loss(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"legacy"}'
+    external = b'{"schema_version":73,"external":"late replacement"}'
+    expected_candidate = _expected_v1_candidate(original)
+    config_path.write_bytes(original)
+    real_writer = migration.atomic_write_bytes
+    atomic_writer_calls = 0
+
+    def replace_before_final_rollback_guard(
+        path: Path,
+        data: bytes,
+        *,
+        before_replace: Callable[[], None] | None = None,
+    ) -> None:
+        nonlocal atomic_writer_calls
+        atomic_writer_calls += 1
+        if atomic_writer_calls == 2:
+            external_path = tmp_path / "external.json"
+            external_path.write_bytes(external)
+            external_path.replace(config_path)
+        real_writer(path, data, before_replace=before_replace)
+
+    monkeypatch.setattr(
+        migration,
+        "atomic_write_bytes",
+        replace_before_final_rollback_guard,
+    )
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        _post_write_rejection_registry(),
+    )
+
+    assert atomic_writer_calls == 2  # nosec B101
+    _assert_transaction_failure(
+        result,
+        category=migration.TransactionFailureCategory.ROLLBACK_SOURCE_CHANGED,
+        authority=migration.ConfigurationAuthority.UNKNOWN,
+        recovery_count=1,
+        candidate_count=1,
+        rollback_count=0,
+    )
+    assert config_path.read_bytes() == external  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert [path.read_bytes() for path in _failed_candidate_files(config_path)] == [
+        expected_candidate
+    ]
+    assert _temporary_residue(tmp_path) == []  # nosec B101

--- a/tests/unit/test_config_persistence.py
+++ b/tests/unit/test_config_persistence.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import config_persistence
-from config_persistence import atomic_write_text
+from config_persistence import atomic_write_bytes, atomic_write_text
 
 
 pytestmark = pytest.mark.unit
@@ -132,5 +133,202 @@ def test_before_replace_failure_preserves_original_and_removes_temporary_file(
             before_replace=reject_replace,
         )
 
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_write_bytes_preserves_exact_mixed_newline_and_unicode_bytes(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    payload = '{\n  "title": "Café 東京",\r\n  "value": 1\n}'.encode()
+
+    atomic_write_bytes(config_path, payload)
+
+    assert config_path.read_bytes() == payload  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_byte_write_failure_preserves_original_and_cleans_temporary_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"original bytes"
+    config_path.write_bytes(original)
+
+    def fail_during_write(_stream: object, _data: bytes) -> None:
+        raise OSError("synthetic binary write failure")
+
+    monkeypatch.setattr(config_persistence, "_write_bytes_and_sync", fail_during_write)
+
+    with pytest.raises(OSError, match="synthetic binary write failure"):
+        atomic_write_bytes(config_path, b"replacement")
+
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_byte_guard_runs_after_sync_and_before_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(b"original")
+    events: list[str] = []
+    real_write = config_persistence._write_bytes_and_sync
+    real_replace = config_persistence.os.replace
+
+    def tracked_write(
+        stream: config_persistence._SyncableBinaryStream,
+        data: bytes,
+    ) -> None:
+        events.append("write_and_sync")
+        real_write(stream, data)
+
+    def guard() -> None:
+        events.append("guard")
+        assert config_path.read_bytes() == b"original"  # nosec B101
+
+    def tracked_replace(source: Path, destination: Path) -> None:
+        events.append("replace")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(config_persistence, "_write_bytes_and_sync", tracked_write)
+    monkeypatch.setattr(config_persistence.os, "replace", tracked_replace)
+
+    atomic_write_bytes(config_path, b"replacement", before_replace=guard)
+
+    assert events == ["write_and_sync", "guard", "replace"]  # nosec B101
+    assert config_path.read_bytes() == b"replacement"  # nosec B101
+
+
+def test_atomic_byte_guard_failure_preserves_original_and_only_removes_owned_temp(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"original bytes"
+    config_path.write_bytes(original)
+    unrelated_temp = tmp_path / ".config.json.pre-existing.tmp"
+    unrelated_payload = b"not owned by the writer"
+    unrelated_temp.write_bytes(unrelated_payload)
+    owned_temp_paths: list[Path] = []
+
+    def reject_replace() -> None:
+        owned_temp_paths.extend(
+            path
+            for path in tmp_path.iterdir()
+            if path not in {config_path, unrelated_temp}
+        )
+        raise RuntimeError("synthetic binary guard rejection")
+
+    with pytest.raises(RuntimeError, match="synthetic binary guard rejection"):
+        atomic_write_bytes(
+            config_path,
+            b"replacement bytes",
+            before_replace=reject_replace,
+        )
+
+    assert len(owned_temp_paths) == 1  # nosec B101
+    assert not owned_temp_paths[0].exists()  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert unrelated_temp.read_bytes() == unrelated_payload  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path, unrelated_temp}  # nosec B101
+
+
+def test_atomic_byte_short_write_is_rejected_and_owned_temp_is_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"original bytes"
+    config_path.write_bytes(original)
+    real_named_temporary_file = config_persistence.tempfile.NamedTemporaryFile
+
+    class ShortWriteTemporary:
+        def __init__(self, stream: Any) -> None:
+            self._stream = stream
+
+        @property
+        def name(self) -> str:
+            return str(self._stream.name)
+
+        def __enter__(self) -> ShortWriteTemporary:
+            self._stream.__enter__()
+            return self
+
+        def __exit__(self, *args: object) -> object:
+            return self._stream.__exit__(*args)
+
+        def write(self, data: bytes) -> int:
+            written = self._stream.write(data[:-1])
+            return int(written)
+
+        def flush(self) -> None:
+            self._stream.flush()
+
+        def fileno(self) -> int:
+            return int(self._stream.fileno())
+
+    def short_write_temporary(*args: object, **kwargs: object) -> object:
+        return ShortWriteTemporary(real_named_temporary_file(*args, **kwargs))
+
+    monkeypatch.setattr(
+        config_persistence.tempfile,
+        "NamedTemporaryFile",
+        short_write_temporary,
+    )
+
+    with pytest.raises(OSError, match="short atomic byte write"):
+        atomic_write_bytes(config_path, b"replacement bytes")
+
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_byte_fsync_failure_preserves_original_and_removes_owned_temp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"original bytes"
+    config_path.write_bytes(original)
+
+    def fail_fsync(_descriptor: int) -> None:
+        raise OSError("synthetic fsync failure")
+
+    monkeypatch.setattr(config_persistence.os, "fsync", fail_fsync)
+
+    with pytest.raises(OSError, match="synthetic fsync failure"):
+        atomic_write_bytes(config_path, b"replacement bytes")
+
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_byte_replace_failure_preserves_original_and_removes_owned_temp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"original bytes"
+    replacement = b"replacement bytes"
+    config_path.write_bytes(original)
+    observed_temporary_paths: list[Path] = []
+
+    def fail_replace(source: Path, destination: Path) -> None:
+        source_path = Path(source)
+        observed_temporary_paths.append(source_path)
+        assert Path(destination) == config_path  # nosec B101
+        assert source_path.read_bytes() == replacement  # nosec B101
+        raise OSError("synthetic byte replace failure")
+
+    monkeypatch.setattr(config_persistence.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="synthetic byte replace failure"):
+        atomic_write_bytes(config_path, replacement)
+
+    assert len(observed_temporary_paths) == 1  # nosec B101
+    assert not observed_temporary_paths[0].exists()  # nosec B101
     assert config_path.read_bytes() == original  # nosec B101
     assert set(tmp_path.iterdir()) == {config_path}  # nosec B101

--- a/tests/unit/test_config_recovery.py
+++ b/tests/unit/test_config_recovery.py
@@ -13,21 +13,37 @@ import pytest
 import config_recovery
 from config_recovery import (
     MAX_CONFIG_BYTES,
+    CandidateRetained,
+    CandidateRetentionFailed,
+    CandidateRetentionFailureCategory,
     ConfigLoaded,
     ConfigLoadFailureCategory,
     ConfigMissing,
     ConfigRecoveryRequired,
     ConfigurationLoadError,
     LegacyConstructionFailure,
+    PreservedBytesRead,
+    RawConfigLoaded,
     RecoveryFailed,
     RecoveryFailureCategory,
     RecoverySucceeded,
+    RecoveryVerificationFailed,
+    RecoveryVerificationSucceeded,
+    SourcePreservationFailed,
+    SourcePreserved,
     load_config,
+    load_raw_config,
     preserve_and_reset,
+    preserve_source,
+    read_preserved_bytes,
     recovery_exit_diagnostics,
     recovery_required_diagnostics,
     recovery_result_diagnostics,
+    retain_failed_candidate,
+    reverify_preserved_source,
+    reverify_source_bytes,
     validate_legacy_mapping,
+    verify_preserved_artifact,
 )
 
 pytestmark = pytest.mark.unit
@@ -55,6 +71,13 @@ def _recovery_files(config_path: Path) -> list[Path]:
     if not recovery_directory.exists():
         return []
     return sorted(recovery_directory.glob("config-*.recovery"))
+
+
+def _failed_candidate_files(config_path: Path) -> list[Path]:
+    recovery_directory = config_path.parent / "recovery"
+    if not recovery_directory.exists():
+        return []
+    return sorted(recovery_directory.glob("config-*.failed-candidate"))
 
 
 def _fail_source_close_after_real_close(
@@ -1034,3 +1057,221 @@ def test_diagnostics_contain_only_curated_categories_and_counts() -> None:
     rendered = repr(diagnostics)
     for forbidden in ("example.test", "token", "password", "config.json", "sha256"):
         assert forbidden not in rendered  # nosec B101
+
+
+def test_raw_load_exposes_exact_bytes_mapping_and_private_snapshot(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = (
+        b'{\r\n  "title": "Caf\xc3\xa9 \xe6\x9d\xb1\xe4\xba\xac",\r\n  "tiles": []\r\n}'
+    )
+    config_path.write_bytes(original)
+
+    result = load_raw_config(config_path)
+
+    assert isinstance(result, RawConfigLoaded)  # nosec B101
+    assert result.mapping == {"title": "Café 東京", "tiles": []}  # nosec B101
+    assert result.source_bytes == original  # nosec B101
+    assert result.snapshot.evidence_is_complete  # nosec B101
+    assert result.snapshot.evidence_byte_count == len(original)  # nosec B101
+    rendered = f"{result!r} {result.snapshot!r}"
+    assert "Café" not in rendered  # nosec B101
+    assert str(config_path) not in rendered  # nosec B101
+    verification = reverify_source_bytes(
+        config_path,
+        result.snapshot,
+        result.source_bytes,
+    )
+    assert isinstance(verification, RecoveryVerificationSucceeded)  # nosec B101
+
+
+def test_unchanged_redirect_can_be_guarded_but_not_preserved(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"title":"Redirected"}'
+    target.write_bytes(original)
+    config_path = tmp_path / "config.json"
+    try:
+        config_path.symlink_to(target)
+    except OSError:
+        pytest.skip("file symlinks are unavailable in this environment")
+
+    loaded = load_raw_config(config_path)
+    assert isinstance(loaded, RawConfigLoaded)  # nosec B101
+    verification = reverify_source_bytes(config_path, loaded.snapshot, original)
+    assert isinstance(verification, RecoveryVerificationSucceeded)  # nosec B101
+
+    preservation = preserve_source(config_path, loaded.snapshot)
+    assert isinstance(preservation, SourcePreservationFailed)  # nosec B101
+    assert preservation.category is RecoveryFailureCategory.SOURCE_UNAVAILABLE  # nosec B101
+    assert preservation.recovery_copy_count == 0  # nosec B101
+
+    target.write_bytes(b'{"title":"Changed"}')
+    changed = reverify_source_bytes(config_path, loaded.snapshot, original)
+    assert isinstance(changed, RecoveryVerificationFailed)  # nosec B101
+    assert changed.category is RecoveryFailureCategory.SOURCE_CHANGED  # nosec B101
+
+
+def test_public_preservation_handle_reads_and_reverifies_exact_private_bytes(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = "{\r\n  private: 'Café 東京'\r\n".encode()
+    config_path.write_bytes(original)
+    rejected = _rejected(config_path)
+
+    result = preserve_source(config_path, rejected.snapshot)
+
+    assert isinstance(result, SourcePreserved)  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert isinstance(  # nosec B101
+        reverify_preserved_source(result.source),
+        RecoveryVerificationSucceeded,
+    )
+    assert isinstance(  # nosec B101
+        verify_preserved_artifact(result.source),
+        RecoveryVerificationSucceeded,
+    )
+    recovered = read_preserved_bytes(result.source)
+    assert isinstance(recovered, PreservedBytesRead)  # nosec B101
+    assert recovered.data == original  # nosec B101
+    rendered = f"{result!r} {result.source!r} {recovered!r}"
+    assert "Café" not in rendered  # nosec B101
+    assert str(config_path) not in rendered  # nosec B101
+
+
+def test_preserved_source_cannot_be_constructed_without_successful_preservation(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(TypeError, match="created by preserve_source"):
+        config_recovery.PreservedSource()
+
+    config_path = tmp_path / "config.json"
+    original = b'{"private":"preserved only after verification"'
+    config_path.write_bytes(original)
+    rejected = _rejected(config_path)
+
+    result = preserve_source(config_path, rejected.snapshot)
+
+    assert isinstance(result, SourcePreserved)  # nosec B101
+    source_verification = reverify_preserved_source(result.source)
+    artifact_verification = verify_preserved_artifact(result.source)
+    recovered = read_preserved_bytes(result.source)
+    assert isinstance(  # nosec B101
+        source_verification,
+        RecoveryVerificationSucceeded,
+    )
+    assert isinstance(  # nosec B101
+        artifact_verification,
+        RecoveryVerificationSucceeded,
+    )
+    assert isinstance(recovered, PreservedBytesRead)  # nosec B101
+    assert recovered.data == original  # nosec B101
+
+
+def test_public_reverification_keeps_source_changed_precedence(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    preserved = preserve_source(config_path, rejected.snapshot)
+    assert isinstance(preserved, SourcePreserved)  # nosec B101
+    recovery_file = _recovery_files(config_path)[0]
+    config_path.write_bytes(b"externally changed source")
+    recovery_file.write_bytes(b"externally changed recovery")
+
+    result = reverify_preserved_source(preserved.source)
+
+    assert isinstance(result, RecoveryVerificationFailed)  # nosec B101
+    assert result.category is RecoveryFailureCategory.SOURCE_CHANGED  # nosec B101
+    artifact = verify_preserved_artifact(preserved.source)
+    assert isinstance(artifact, RecoveryVerificationFailed)  # nosec B101
+    assert (  # nosec B101
+        artifact.category is RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+    )
+
+
+def test_preserve_source_counts_a_published_copy_when_final_verification_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(_CORRUPT_BYTES)
+    rejected = _rejected(config_path)
+    real_hash = config_recovery._hash_stable_path
+    calls = 0
+
+    def fail_final_copy(
+        path: Path,
+        *,
+        allow_redirected: bool = False,
+    ) -> tuple[config_recovery._FileFingerprint, int, bytes]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise PermissionError("synthetic final-copy access failure")
+        return real_hash(path, allow_redirected=allow_redirected)
+
+    monkeypatch.setattr(config_recovery, "_hash_stable_path", fail_final_copy)
+
+    result = preserve_source(config_path, rejected.snapshot)
+
+    assert isinstance(result, SourcePreservationFailed)  # nosec B101
+    assert (  # nosec B101
+        result.category is RecoveryFailureCategory.RECOVERY_VERIFICATION_FAILURE
+    )
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert len(_recovery_files(config_path)) == 1  # nosec B101
+
+
+def test_failed_candidate_retention_requires_and_keeps_exact_owned_bytes(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    candidate = b'{"schema_version":1,"title":"Caf\xc3\xa9"}'
+    config_path.write_bytes(candidate)
+    loaded = load_raw_config(config_path)
+    assert isinstance(loaded, RawConfigLoaded)  # nosec B101
+
+    rejected = retain_failed_candidate(
+        config_path,
+        loaded.snapshot,
+        candidate + b" ",
+    )
+    assert isinstance(rejected, CandidateRetentionFailed)  # nosec B101
+    assert rejected.category is CandidateRetentionFailureCategory.SOURCE_CHANGED  # nosec B101
+    assert rejected.failed_candidate_copy_count == 0  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+
+    retained = retain_failed_candidate(config_path, loaded.snapshot, candidate)
+    assert isinstance(retained, CandidateRetained)  # nosec B101
+    assert retained.failed_candidate_copy_count == 1  # nosec B101
+    candidate_files = _failed_candidate_files(config_path)
+    assert len(candidate_files) == 1  # nosec B101
+    assert candidate_files[0].read_bytes() == candidate  # nosec B101
+
+
+def test_failed_candidate_final_name_collision_never_overwrites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    candidate = b'{"schema_version":1}'
+    config_path.write_bytes(candidate)
+    loaded = load_raw_config(config_path)
+    assert isinstance(loaded, RawConfigLoaded)  # nosec B101
+    recovery_directory = tmp_path / "recovery"
+    recovery_directory.mkdir()
+    stage_token = "a" * 32
+    collision_token = "b" * 32
+    final_token = "c" * 32
+    sentinel = recovery_directory / f"config-{collision_token}.failed-candidate"
+    sentinel.write_bytes(b"sentinel")
+    tokens = iter([stage_token, collision_token, final_token])
+    monkeypatch.setattr(config_recovery, "_new_token", lambda: next(tokens))
+
+    result = retain_failed_candidate(config_path, loaded.snapshot, candidate)
+
+    assert isinstance(result, CandidateRetained)  # nosec B101
+    assert sentinel.read_bytes() == b"sentinel"  # nosec B101
+    retained = recovery_directory / f"config-{final_token}.failed-candidate"
+    assert retained.read_bytes() == candidate  # nosec B101

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -75,15 +75,28 @@ from PySide6.QtWidgets import (
 )
 
 import debug_scaffold
+from config_migration import (
+    ConfigurationMigrationError,
+    ImplicitLegacyLoaded,
+    LegacyNormalizationSaveFailed,
+    MigrationCommitted,
+    PRODUCTION_REGISTRY,
+    StartupFailureRoute,
+    VersionedCurrent,
+    guarded_legacy_normalization_save,
+    load_startup_configuration,
+    startup_failure_route,
+    startup_notice_message,
+)
 from config_persistence import atomic_write_text
 from config_recovery import (
     ConfigLoadFailureCategory,
-    ConfigLoaded,
     ConfigMissing,
+    ConfigRecoveryRequired,
     ConfigurationLoadError,
+    RawConfigLoaded,
     RecoveryFailed,
     RecoveryFailureCategory,
-    load_config,
     preserve_and_reset,
     recovery_exit_diagnostics,
     recovery_required_diagnostics,
@@ -365,15 +378,35 @@ class LauncherConfig:
         return cfg
 
     @staticmethod
-    def load() -> "LauncherConfig":
-        result = load_config(CFG_PATH, _construct_legacy_configuration)
+    def load(
+        *,
+        on_existing_legacy: (
+            Callable[["LauncherConfig", RawConfigLoaded], None] | None
+        ) = None,
+    ) -> "LauncherConfig":
+        result = load_startup_configuration(
+            CFG_PATH,
+            _construct_legacy_configuration,
+            PRODUCTION_REGISTRY,
+        )
         if isinstance(result, ConfigMissing):
             cfg = LauncherConfig.first_run()
             cfg.save()
             return cfg
-        if isinstance(result, ConfigLoaded):
-            return result.value
-        raise ConfigurationLoadError(result.category, result.snapshot)
+        if isinstance(result, ConfigRecoveryRequired):
+            if startup_failure_route(result) is StartupFailureRoute.Q3_RECOVERY:
+                raise ConfigurationLoadError(result.category, result.snapshot)
+            raise ConfigurationMigrationError.unexpected_success()
+        if isinstance(result, ImplicitLegacyLoaded):
+            cfg = result.value
+            if on_existing_legacy is not None:
+                on_existing_legacy(cfg, result.raw)
+            return cfg
+        if isinstance(result, (VersionedCurrent, MigrationCommitted)):
+            raise ConfigurationMigrationError.unexpected_success()
+        if startup_failure_route(result) is StartupFailureRoute.EXIT_ONLY:
+            raise ConfigurationMigrationError.from_outcome(result)
+        raise ConfigurationMigrationError.unexpected_success()
 
     def serialize(self) -> str:
         """Serialize using the existing unversioned schema and formatting."""
@@ -407,6 +440,19 @@ class LauncherConfig:
 def _construct_legacy_configuration(data: dict[str, object]) -> LauncherConfig:
     validate_legacy_mapping(data)
     return LauncherConfig.from_legacy_mapping(data)
+
+
+def _guarded_existing_legacy_save(
+    config: LauncherConfig,
+    loaded: RawConfigLoaded,
+) -> None:
+    result = guarded_legacy_normalization_save(
+        CFG_PATH,
+        loaded,
+        config.serialize(),
+    )
+    if isinstance(result, LegacyNormalizationSaveFailed):
+        raise ConfigurationMigrationError.from_outcome(result)
 
 
 def _tab_order_state(cfg: LauncherConfig) -> TabOrderState:
@@ -2840,30 +2886,49 @@ def _show_recovery_failure(category: RecoveryFailureCategory) -> None:
     )
 
 
+def _show_migration_failure(error: ConfigurationMigrationError) -> None:
+    box = QMessageBox()
+    box.setIcon(QMessageBox.Icon.Critical)
+    box.setWindowTitle("DesktopTileLauncher")
+    box.setText(startup_notice_message(error.notice_category))
+    exit_button = box.addButton(
+        "Exit",
+        QMessageBox.ButtonRole.RejectRole,
+    )
+    box.setDefaultButton(exit_button)
+    box.setEscapeButton(exit_button)
+    exit_button.setFocus()
+    box.exec()
+
+
 def _resolve_startup_configuration() -> _StartupReady | _StartupExit:
-    result = load_config(CFG_PATH, _construct_legacy_configuration)
-    if isinstance(result, ConfigMissing):
-        config = LauncherConfig.first_run()
-        config.save()
-        return _StartupReady(config)
-    if isinstance(result, ConfigLoaded):
-        config = result.value
-        config.save()
+    try:
+        config = LauncherConfig.load(
+            on_existing_legacy=_guarded_existing_legacy_save,
+        )
+    except ConfigurationMigrationError as error:
+        record_breadcrumb("config_migration_exit", **error.diagnostics)
+        _show_migration_failure(error)
+        return _StartupExit(1)
+    except ConfigurationLoadError as error:
+        category = error.category
+        snapshot = error.snapshot
+    else:
         return _StartupReady(config)
 
     record_breadcrumb(
         "config_recovery_required",
-        **recovery_required_diagnostics(result.category),
+        **recovery_required_diagnostics(category),
     )
-    if _prompt_config_recovery(result.category) is _RecoveryChoice.EXIT:
+    if _prompt_config_recovery(category) is _RecoveryChoice.EXIT:
         record_breadcrumb(
             "config_recovery_exit",
-            **recovery_exit_diagnostics(result.category),
+            **recovery_exit_diagnostics(category),
         )
         return _StartupExit(0)
 
     config = LauncherConfig.first_run()
-    recovery = preserve_and_reset(CFG_PATH, result.snapshot, config.serialize())
+    recovery = preserve_and_reset(CFG_PATH, snapshot, config.serialize())
     if isinstance(recovery, RecoveryFailed):
         record_breadcrumb(
             "config_recovery_failed",


### PR DESCRIPTION
Closes #110

## Summary

- Add a Qt-free schema registry, strict version classification, pure consecutive migration runner, validation hooks, and deterministic JSON serialization.
- Add guarded candidate persistence, exact source preservation, failed-candidate retention, post-write validation, ownership-aware rollback, and privacy-safe outcomes.
- Integrate single-read startup classification while preserving Q3 corrupt-configuration recovery and guarding legacy normalization against concurrent replacement.
- Keep production on implicit unversioned v0 with an empty registry: no production migration step, no `schema_version: 1` output, and no Q5 identity work.

## Validation

- `make format-check`
- `make lint`
- `make lint_tests`
- `.venv/Scripts/python.exe -m ruff check tests`
- `make typecheck`
- `make test_unit` — 460 passed, 31 deselected
- `git diff --check`
- Manual isolated-Windows validation:
  - friendly missing-config startup;
  - ordinary implicit-v0 startup and normalization;
  - future and invalid versions use Exit-only handling and remain byte-identical;
  - malformed JSON retains the Q3 Exit / Preserve and Reset prompt;
  - no recovery or temporary artifacts and no diagnostic-content leakage.
