### PR TITLE
feat: add stable workspace and tab identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
 ### App Behavior
 - Detect unreadable or corrupt configuration at startup and offer a safe default Exit or an
   explicit preserve-and-reset flow before the launcher mutates configuration state.
-- Add a Qt-free, schema-versioned migration harness while production remains on implicit,
-  unversioned legacy v0 with no registered migration step and no `schema_version` 1 output.
+- Add a Qt-free, schema-versioned migration harness and activate its pure deterministic
+  v0-to-v1 step for the Workspace/Tab identity schema.
+- Persist one `Default Workspace`, stable Workspace and Tab identities, ID-based Tile
+  membership, and an independent `application.title` while retaining flat Tile behavior and
+  existing launcher settings.
+- Construct missing and reset configuration as native version 1, load valid current version 1
+  without a startup write, and reject invalid identity graphs rather than repairing or
+  regenerating IDs.
 - Give malformed, explicit-zero, unsupported, and migration-failure outcomes distinct fixed
   Exit-only handling without changing the existing corrupt-configuration Exit / Preserve and
   Reset flow.
@@ -22,7 +28,7 @@
 ### Security/Privacy
 - Preserve and verify exact corrupt-configuration bytes before reset, keep verified copies in a
   private recovery location, and record only curated failure categories and integer counts.
-- For future registered migrations, preserve and verify the exact source before the first step,
+- For registered migrations, preserve and verify the exact source before the first step,
   guard deterministic candidate replacement, and retain and roll back only after the exact
   installed candidate is proven and post-write target validation then fails.
 - Treat reload failure, exact-byte mismatch, or later ownership loss as fail-closed Exit-only
@@ -38,8 +44,9 @@
   URLs, domains, names, retrieved titles, icon paths, page content, or sensitive exception details.
 
 ### Docs
-- Define the proposed vNext state, identity, ordering, ownership, import, recovery, and
-  migration contract for the Windows Content Triage roadmap.
+- Clarify ADR-0001 so schema version 1 is the Q5 identity-only Workspace/Tab format and the
+  unchanged full Resource/Placement/DeviceBinding graph is schema version 2; the Windows
+  Content Triage “v1” product milestone name remains unchanged.
 
 ## v0.3.5 - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -116,17 +116,19 @@ SPDX-License-Identifier: Apache-2.0
 ### Configuration versions and recovery
 
 DesktopTileLauncher reads at most 4 MiB of `config.json` for normal UTF-8 and
-JSON parsing. Production remains on the existing implicit, unversioned legacy
-v0 format: a configuration without `schema_version` is constructed, normalized,
-and saved using the existing behavior. The production migration registry has no
-registered steps, no v0-to-v1 migration runs, and the application does not emit
-`schema_version` 1.
+JSON parsing. Production persists the explicit identity-only schema version 1:
+one Workspace, stable Workspace and Tab UUIDs, ID-based Tile membership, and the
+existing flat Tile and launcher settings. Legacy configuration without
+`schema_version` is version 0 and migrates transactionally through the registered
+pure v0-to-v1 step. Migration creates exactly one `Default Workspace`; the
+launcher title is preserved independently as `application.title`.
 
 An explicit `schema_version` of 0 is invalid. A malformed version value or any
-positive explicit version, including version 1, receives fixed **Exit**-only
-handling before legacy construction, normalization, or saving. Migration
-failures also use fixed Exit-only handling. These version and migration cases
-never offer Preserve and Reset.
+unsupported newer version, including the deferred full-graph version 2, receives
+fixed **Exit**-only handling before legacy construction, normalization, or
+saving. Invalid current version 1 and migration failures also use fixed
+Exit-only handling. These version and migration cases never offer Preserve and
+Reset.
 
 The existing recovery choices remain unchanged for the established corrupt or
 unreadable configuration categories. Startup offers exactly **Exit** or
@@ -140,16 +142,17 @@ configuration is installed atomically. A reset is not attempted when copying,
 verification, or the final source-change check fails. Verified recovery copies
 are never overwritten or deleted automatically.
 
-The Qt-free migration harness is ready for future consecutive, registered
-schema steps. It validates the source before preservation; a source-validation
-rejection creates no recovery artifact and performs no write. When at least one
-step will run, the harness preserves and independently verifies one exact
-recovery copy before the first step, validates every detached intermediate and
-target document, and writes deterministic UTF-8 JSON through a guarded atomic
-replacement. Candidate JSON preserves non-ASCII text, sorts keys, uses two-space
-indentation and LF line endings, rejects non-finite numbers, and has no trailing
-newline. The harness reverifies both the source and recovery copy immediately
-before replacement, then reloads and validates the installed candidate.
+The Qt-free migration harness runs the pure deterministic v0-to-v1 step and is
+ready for future consecutive registered steps. It validates the source before
+preservation; a source-validation rejection creates no recovery artifact and
+performs no write. When at least one step will run, the harness preserves and
+independently verifies one exact recovery copy before the first step, validates
+every detached intermediate and target document, and writes deterministic
+UTF-8 JSON through a guarded atomic replacement. Candidate JSON preserves
+non-ASCII text, sorts keys, uses two-space indentation and LF line endings,
+rejects non-finite numbers, and has no trailing newline. The harness reverifies
+both the source and recovery copy immediately before replacement, then reloads
+and validates the installed candidate.
 
 After replacement, the harness must successfully reload the exact candidate
 bytes before treating the installed file as transaction-owned. Retention and
@@ -167,11 +170,11 @@ that cannot be completed or verified also fails closed. Published recovery
 copies and failed candidates are private, never overwritten, and never deleted
 automatically.
 
-The normal implicit-v0 startup save has a separate overwrite guard. Immediately
-before installing the normalized legacy text, the application verifies that the
-source still matches the bytes classified at startup. If another process changed
-or replaced the file, the save is cancelled and the application exits without
-overwriting the newer source.
+A valid current version 1 file loads directly without a startup normalization
+write and never passes through repair-oriented legacy normalization. Workspace
+and Tab IDs are not regenerated while loading, saving, or restarting. Actual
+user mutations persist one complete strictly validated version 1 document
+through the shared atomic-write path.
 
 Migration recovery is not journaled. A process interruption after an atomic
 candidate replacement but before post-write verification or rollback can leave

--- a/config_migration.py
+++ b/config_migration.py
@@ -41,6 +41,7 @@ from config_recovery import (
     reverify_source_bytes,
     verify_preserved_artifact,
 )
+from config_schema import migrate_v0_to_v1, validate_v0, validate_v1
 
 JsonScalar: TypeAlias = None | bool | int | float | str
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
@@ -198,7 +199,7 @@ class ValidatedMigrationRegistry:
 
     @property
     def is_empty(self) -> bool:
-        """Return whether this is the production legacy-only registry."""
+        """Return whether the registry declares no supported versions or steps."""
 
         return self.current_version is None
 
@@ -283,7 +284,7 @@ PureProblem: TypeAlias = PureExecutionRejected | PureEngineFailure | PureEngineD
 
 @dataclass(frozen=True, slots=True)
 class LegacyV0Current:
-    """Production legacy input remains on the existing constructor path."""
+    """Implicit v0 accepted by an empty or synthetic registry."""
 
     document: JsonObject = field(repr=False)
 
@@ -1313,6 +1314,8 @@ def load_startup_configuration(
     config_path: Path,
     legacy_constructor: Callable[[dict[str, object]], T],
     registry: ValidatedMigrationRegistry,
+    *,
+    legacy_validator: Callable[[dict[str, object]], None] | None = None,
 ) -> StartupConfigurationResult[T]:
     """Perform exactly one initial bounded load before all classification."""
 
@@ -1321,6 +1324,14 @@ def load_startup_configuration(
         return loaded
 
     identity = identify_version(cast(Mapping[str, JsonValue], loaded.mapping))
+    if isinstance(identity, ImplicitLegacyV0) and legacy_validator is not None:
+        try:
+            legacy_validator(loaded.mapping)
+        except LegacyConstructionFailure:
+            return ConfigRecoveryRequired(
+                ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE,
+                loaded.snapshot,
+            )
     if registry.is_empty and isinstance(identity, ImplicitLegacyV0):
         try:
             value = legacy_constructor(loaded.mapping)
@@ -1649,7 +1660,34 @@ def migration_startup_route(result: StartupResult) -> MigrationStartupRoute:
     return MigrationStartupRoute.EXIT_ONLY
 
 
-PRODUCTION_REGISTRY_SPEC: Final = RegistrySpec(None, None, (), ())
+def _validate_production_v0(
+    document: Mapping[str, JsonValue],
+) -> ValidationDecision:
+    return ValidationAccepted() if validate_v0(document) else ValidationRejected()
+
+
+def _migrate_production_v0_to_v1(
+    document: Mapping[str, JsonValue],
+) -> StepDecision:
+    candidate = migrate_v0_to_v1(document)
+    return StepApplied(candidate) if candidate is not None else StepRejected()
+
+
+def _validate_production_v1(
+    document: Mapping[str, JsonValue],
+) -> ValidationDecision:
+    return ValidationAccepted() if validate_v1(document) else ValidationRejected()
+
+
+PRODUCTION_REGISTRY_SPEC: Final = RegistrySpec(
+    0,
+    1,
+    (MigrationStep(0, 1, "legacy_to_v1", _migrate_production_v0_to_v1),),
+    (
+        VersionValidator(0, _validate_production_v0),
+        VersionValidator(1, _validate_production_v1),
+    ),
+)
 _production_registry_result = validate_registry(PRODUCTION_REGISTRY_SPEC)
 if not isinstance(_production_registry_result, RegistryReady):
     raise RuntimeError("invalid production migration registry")

--- a/config_schema.py
+++ b/config_schema.py
@@ -1,0 +1,727 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure schema-version 1 validation, construction, and v0 migration.
+
+This module deliberately has no Qt, filesystem, clock, environment, or random
+dependency.  Runtime callers inject UUIDv4 allocation for native documents;
+legacy migration identities are deterministic UUIDv5 values derived only from
+the complete detached v0 mapping.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Callable, Mapping
+from typing import Final, TypeAlias, cast
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from config_recovery import LegacyConstructionFailure, validate_legacy_mapping
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+Uuid4Allocator: TypeAlias = Callable[[], UUID | str]
+Uuid5Factory: TypeAlias = Callable[[UUID, str], UUID | str]
+
+SCHEMA_VERSION: Final = 1
+DEFAULT_WORKSPACE_NAME: Final = "Default Workspace"
+DEFAULT_APPLICATION_TITLE: Final = "My Launcher"
+LEGACY_APPLICATION_TITLE: Final = "Launcher"
+DEFAULT_TAB_NAME: Final = "Main"
+LEGACY_EXTENSION_NAMESPACE: Final = "io.github.108thecitizen.legacy"
+MIGRATION_NAME_ROOT: Final = (
+    "https://github.com/108thecitizen/DesktopTileLauncher/migration/v0"
+)
+NATIVE_ID_ALLOCATION_ATTEMPTS: Final = 32
+
+_ROOT_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "application",
+        "workspaces",
+        "tabs",
+        "tiles",
+        "columns",
+        "auto_fit",
+        "window_x",
+        "window_y",
+        "window_w",
+        "window_h",
+        "extensions",
+    }
+)
+_APPLICATION_FIELDS: Final = frozenset({"title", "default_workspace_id", "extensions"})
+_WORKSPACE_FIELDS: Final = frozenset({"id", "name", "tab_order", "extensions"})
+_TAB_FIELDS: Final = frozenset(
+    {"id", "workspace_id", "name", "visibility", "extensions"}
+)
+_TILE_FIELDS: Final = frozenset(
+    {
+        "name",
+        "url",
+        "tab_id",
+        "icon",
+        "bg",
+        "browser",
+        "chrome_profile",
+        "open_target",
+    }
+)
+_RECOGNIZED_V0_FIELDS: Final = frozenset(
+    {
+        "title",
+        "columns",
+        "tiles",
+        "tabs",
+        "hidden_tabs",
+        "tab_ids",
+        "tab_order",
+        "auto_fit",
+        "window_x",
+        "window_y",
+        "window_w",
+        "window_h",
+    }
+)
+
+
+class NativeV1ConstructionError(ValueError):
+    """A native v1 identity could not be allocated safely."""
+
+    def __init__(self) -> None:
+        super().__init__("native_v1_identity_allocation_failed")
+
+
+def _is_int(value: object) -> bool:
+    return type(value) is int
+
+
+def _is_nullable_int(value: object) -> bool:
+    return value is None or _is_int(value)
+
+
+def _is_nullable_string(value: object) -> bool:
+    return value is None or isinstance(value, str)
+
+
+def _canonical_uuid(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = UUID(value)
+    except (AttributeError, ValueError):
+        return None
+    canonical = str(parsed)
+    return canonical if value == canonical else None
+
+
+def _canonical_legacy_uuid(value: object) -> str | None:
+    """Canonicalize the legacy format, accepting canonical uppercase text."""
+
+    if not isinstance(value, str):
+        return None
+    try:
+        canonical = str(UUID(value))
+    except (AttributeError, ValueError):
+        return None
+    return canonical if value.lower() == canonical else None
+
+
+def _is_utf8_text(value: str) -> bool:
+    try:
+        value.encode("utf-8")
+    except UnicodeError:
+        return False
+    return True
+
+
+def _is_strict_json(value: object, active: set[int]) -> bool:
+    value_type = type(value)
+    if value is None or value_type in (bool, int):
+        return True
+    if value_type is str:
+        return _is_utf8_text(cast(str, value))
+    if value_type is float:
+        return math.isfinite(cast(float, value))
+    if value_type is list:
+        marker = id(value)
+        if marker in active:
+            return False
+        active.add(marker)
+        try:
+            return all(
+                _is_strict_json(item, active) for item in cast(list[object], value)
+            )
+        finally:
+            active.remove(marker)
+    if value_type is dict:
+        marker = id(value)
+        if marker in active:
+            return False
+        active.add(marker)
+        try:
+            mapping = cast(dict[object, object], value)
+            return all(
+                isinstance(key, str)
+                and _is_utf8_text(key)
+                and _is_strict_json(item, active)
+                for key, item in mapping.items()
+            )
+        finally:
+            active.remove(marker)
+    return False
+
+
+def _valid_extensions(value: object) -> bool:
+    if type(value) is not dict:
+        return False
+    extensions = cast(dict[str, object], value)
+    if not extensions:
+        return True
+    if set(extensions) != {LEGACY_EXTENSION_NAMESPACE}:
+        return False
+    legacy = extensions[LEGACY_EXTENSION_NAMESPACE]
+    return type(legacy) is dict and _is_strict_json(legacy, set())
+
+
+def _valid_application(value: object) -> tuple[str, str] | None:
+    if type(value) is not dict:
+        return None
+    application = cast(dict[str, object], value)
+    if set(application) != _APPLICATION_FIELDS:
+        return None
+    title = application["title"]
+    workspace_id = application["default_workspace_id"]
+    if (
+        not isinstance(title, str)
+        or _canonical_uuid(workspace_id) is None
+        or application["extensions"] != {}
+        or type(application["extensions"]) is not dict
+    ):
+        return None
+    return title, cast(str, workspace_id)
+
+
+def _valid_workspace(value: object) -> tuple[str, list[str]] | None:
+    if type(value) is not dict:
+        return None
+    workspace = cast(dict[str, object], value)
+    if set(workspace) != _WORKSPACE_FIELDS:
+        return None
+    workspace_id = workspace["id"]
+    name = workspace["name"]
+    raw_order = workspace["tab_order"]
+    if (
+        _canonical_uuid(workspace_id) is None
+        or not isinstance(name, str)
+        or not name
+        or type(raw_order) is not list
+        or workspace["extensions"] != {}
+        or type(workspace["extensions"]) is not dict
+    ):
+        return None
+    order = cast(list[object], raw_order)
+    if any(_canonical_uuid(tab_id) is None for tab_id in order):
+        return None
+    return cast(str, workspace_id), cast(list[str], order)
+
+
+def _valid_tabs(
+    value: object,
+    workspace_id: str,
+) -> tuple[set[str], set[str]] | None:
+    if type(value) is not list or not value:
+        return None
+    tab_ids: set[str] = set()
+    tab_names: set[str] = set()
+    visible_count = 0
+    for raw_tab in cast(list[object], value):
+        if type(raw_tab) is not dict:
+            return None
+        tab = cast(dict[str, object], raw_tab)
+        if set(tab) != _TAB_FIELDS:
+            return None
+        tab_id = tab["id"]
+        name = tab["name"]
+        visibility = tab["visibility"]
+        if (
+            _canonical_uuid(tab_id) is None
+            or tab["workspace_id"] != workspace_id
+            or not isinstance(name, str)
+            or not name
+            or name in tab_names
+            or visibility not in ("visible", "hidden")
+            or tab["extensions"] != {}
+            or type(tab["extensions"]) is not dict
+        ):
+            return None
+        canonical_tab_id = cast(str, tab_id)
+        if canonical_tab_id in tab_ids or canonical_tab_id == workspace_id:
+            return None
+        tab_ids.add(canonical_tab_id)
+        tab_names.add(name)
+        if visibility == "visible":
+            visible_count += 1
+    return (tab_ids, tab_names) if visible_count else None
+
+
+def _valid_tile(value: object, tab_ids: set[str]) -> bool:
+    if type(value) is not dict:
+        return False
+    tile = cast(dict[str, object], value)
+    if set(tile) != _TILE_FIELDS:
+        return False
+    tab_id = tile["tab_id"]
+    return (
+        isinstance(tile["name"], str)
+        and isinstance(tile["url"], str)
+        and isinstance(tab_id, str)
+        and tab_id in tab_ids
+        and _is_nullable_string(tile["icon"])
+        and isinstance(tile["bg"], str)
+        and _is_nullable_string(tile["browser"])
+        and _is_nullable_string(tile["chrome_profile"])
+        and tile["open_target"] in ("tab", "window")
+    )
+
+
+def validate_v1(document: Mapping[str, JsonValue]) -> bool:
+    """Return whether ``document`` is the exact strict identity-only v1 shape."""
+
+    try:
+        strict_json = _is_strict_json(dict(document), set())
+    except RecursionError:
+        return False
+    if not strict_json:
+        return False
+    if set(document) != _ROOT_FIELDS:
+        return False
+    if document["schema_version"] != SCHEMA_VERSION or not _is_int(
+        document["schema_version"]
+    ):
+        return False
+
+    application = _valid_application(document["application"])
+    raw_workspaces = document["workspaces"]
+    if application is None or type(raw_workspaces) is not list:
+        return False
+    workspaces = cast(list[object], raw_workspaces)
+    if len(workspaces) != 1:
+        return False
+    workspace = _valid_workspace(workspaces[0])
+    if workspace is None:
+        return False
+    _, default_workspace_id = application
+    workspace_id, tab_order = workspace
+    if default_workspace_id != workspace_id:
+        return False
+
+    tabs = _valid_tabs(document["tabs"], workspace_id)
+    if tabs is None:
+        return False
+    tab_ids, _ = tabs
+    if len(tab_order) != len(tab_ids) or set(tab_order) != tab_ids:
+        return False
+
+    raw_tiles = document["tiles"]
+    if type(raw_tiles) is not list or not all(
+        _valid_tile(tile, tab_ids) for tile in cast(list[object], raw_tiles)
+    ):
+        return False
+    if not _is_int(document["columns"]):
+        return False
+    if type(document["auto_fit"]) is not bool:
+        return False
+    if not all(
+        _is_nullable_int(document[field])
+        for field in ("window_x", "window_y", "window_w", "window_h")
+    ):
+        return False
+    return _valid_extensions(document["extensions"])
+
+
+def validate_v0(document: Mapping[str, JsonValue]) -> bool:
+    """Apply the completed shallow legacy validation contract to implicit v0."""
+
+    if "schema_version" in document:
+        return False
+    try:
+        validate_legacy_mapping(cast(dict[str, object], dict(document)))
+    except LegacyConstructionFailure:
+        return False
+    return True
+
+
+def _canonical_v0(
+    document: Mapping[str, JsonValue],
+) -> tuple[JsonObject, bytes] | None:
+    try:
+        serialized = json.dumps(
+            dict(document),
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        ).encode("utf-8")
+        detached: object = json.loads(serialized)
+    except (TypeError, ValueError, OverflowError, UnicodeError):
+        return None
+    if type(detached) is not dict:
+        return None
+    return cast(JsonObject, detached), serialized
+
+
+def _discover_tab_names(source: JsonObject) -> list[str]:
+    names: list[str] = []
+    seen_names: set[str] = set()
+    raw_tabs = source.get("tabs")
+    if type(raw_tabs) is list:
+        for item in raw_tabs:
+            if isinstance(item, str) and item not in seen_names:
+                names.append(item)
+                seen_names.add(item)
+
+    raw_tiles = source.get("tiles")
+    if type(raw_tiles) is list:
+        for raw_tile in raw_tiles:
+            tile = cast(dict[str, JsonValue], raw_tile)
+            tab_name = cast(str, tile.get("tab", DEFAULT_TAB_NAME))
+            if tab_name not in seen_names:
+                names.append(tab_name)
+                seen_names.add(tab_name)
+    if not names:
+        names.append(DEFAULT_TAB_NAME)
+    return names
+
+
+def _reserved_legacy_ids(source: JsonObject) -> set[str]:
+    reserved: set[str] = set()
+    raw_tab_ids = source.get("tab_ids")
+    if type(raw_tab_ids) is dict:
+        for value in raw_tab_ids.values():
+            candidate = _canonical_legacy_uuid(value)
+            if candidate is not None:
+                reserved.add(candidate)
+    raw_tab_order = source.get("tab_order")
+    if type(raw_tab_order) is list:
+        for value in raw_tab_order:
+            candidate = _canonical_legacy_uuid(value)
+            if candidate is not None:
+                reserved.add(candidate)
+    return reserved
+
+
+def _retained_tab_ids(source: JsonObject, names: list[str]) -> dict[str, str]:
+    raw_tab_ids = source.get("tab_ids")
+    saved_ids = raw_tab_ids if type(raw_tab_ids) is dict else {}
+    retained: dict[str, str] = {}
+    used: set[str] = set()
+    for name in names:
+        candidate = _canonical_legacy_uuid(saved_ids.get(name))
+        if candidate is not None and candidate not in used:
+            retained[name] = candidate
+            used.add(candidate)
+    return retained
+
+
+def _ordered_tab_names(
+    source: JsonObject,
+    discovered: list[str],
+    retained: Mapping[str, str],
+) -> list[str]:
+    title_by_id = {tab_id: title for title, tab_id in retained.items()}
+    ordered: list[str] = []
+    seen_titles: set[str] = set()
+    raw_order = source.get("tab_order")
+    if type(raw_order) is list:
+        for raw_id in raw_order:
+            tab_id = _canonical_legacy_uuid(raw_id)
+            title = title_by_id.get(tab_id) if tab_id is not None else None
+            if title is not None and title not in seen_titles:
+                ordered.append(title)
+                seen_titles.add(title)
+    for title in discovered:
+        if title not in seen_titles:
+            ordered.append(title)
+            seen_titles.add(title)
+    return ordered
+
+
+def _derived_uuid(
+    name: str,
+    uuid5_factory: Uuid5Factory,
+) -> str | None:
+    result = uuid5_factory(NAMESPACE_URL, name)
+    if isinstance(result, UUID):
+        return str(result) if result.version == 5 else None
+    canonical = _canonical_uuid(result)
+    if canonical is None or UUID(canonical).version != 5:
+        return None
+    return canonical
+
+
+def _allocate_migration_ids(
+    source: JsonObject,
+    canonical_bytes: bytes,
+    ordered_names: list[str],
+    retained: Mapping[str, str],
+    uuid5_factory: Uuid5Factory,
+) -> tuple[str, dict[str, str]] | None:
+    digest = hashlib.sha256(canonical_bytes).hexdigest()
+    reserved = _reserved_legacy_ids(source)
+    workspace_id = _derived_uuid(
+        f"{MIGRATION_NAME_ROOT}/{digest}/workspace/0",
+        uuid5_factory,
+    )
+    if workspace_id is None or workspace_id in reserved:
+        return None
+
+    used = {workspace_id}
+    tab_ids: dict[str, str] = {}
+    for ordinal, name in enumerate(ordered_names):
+        tab_id = retained.get(name)
+        if tab_id is None:
+            tab_id = _derived_uuid(
+                f"{MIGRATION_NAME_ROOT}/{digest}/tab/{ordinal}",
+                uuid5_factory,
+            )
+            if tab_id is None or tab_id in reserved or tab_id in used:
+                return None
+        elif tab_id in used:
+            return None
+        tab_ids[name] = tab_id
+        used.add(tab_id)
+    return workspace_id, tab_ids
+
+
+def _migrated_tiles(source: JsonObject, tab_ids: Mapping[str, str]) -> list[JsonValue]:
+    migrated: list[JsonValue] = []
+    raw_tiles = source.get("tiles")
+    if type(raw_tiles) is not list:
+        return migrated
+    for raw_tile in raw_tiles:
+        tile = cast(dict[str, JsonValue], raw_tile)
+        tab_name = cast(str, tile.get("tab", DEFAULT_TAB_NAME))
+        migrated.append(
+            {
+                "name": cast(str, tile["name"]),
+                "url": cast(str, tile["url"]),
+                "tab_id": tab_ids[tab_name],
+                "icon": tile.get("icon"),
+                "bg": tile.get("bg", "#F5F6FA"),
+                "browser": tile.get("browser"),
+                "chrome_profile": tile.get("chrome_profile"),
+                "open_target": tile.get("open_target", "tab"),
+            }
+        )
+    return migrated
+
+
+def migrate_v0_to_v1(
+    document: Mapping[str, JsonValue],
+    *,
+    uuid5_factory: Uuid5Factory = uuid5,
+) -> JsonObject | None:
+    """Return the exact deterministic identity-v1 candidate, or reject v0."""
+
+    if not validate_v0(document):
+        return None
+    canonical = _canonical_v0(document)
+    if canonical is None:
+        return None
+    source, canonical_bytes = canonical
+    discovered = _discover_tab_names(source)
+    if any(name == "" for name in discovered):
+        return None
+    retained = _retained_tab_ids(source, discovered)
+    ordered_names = _ordered_tab_names(source, discovered, retained)
+    allocated = _allocate_migration_ids(
+        source,
+        canonical_bytes,
+        ordered_names,
+        retained,
+        uuid5_factory,
+    )
+    if allocated is None:
+        return None
+    workspace_id, tab_ids = allocated
+
+    hidden_names: list[str] = []
+    seen_hidden_names: set[str] = set()
+    raw_hidden = source.get("hidden_tabs")
+    if type(raw_hidden) is list:
+        for name in raw_hidden:
+            if (
+                isinstance(name, str)
+                and name in tab_ids
+                and name not in seen_hidden_names
+            ):
+                hidden_names.append(name)
+                seen_hidden_names.add(name)
+    if len(hidden_names) == len(ordered_names):
+        hidden_names.remove(ordered_names[0])
+    hidden = set(hidden_names)
+
+    unknown = {
+        key: value for key, value in source.items() if key not in _RECOGNIZED_V0_FIELDS
+    }
+    extensions: JsonObject = {LEGACY_EXTENSION_NAMESPACE: unknown} if unknown else {}
+    candidate: JsonObject = {
+        "schema_version": SCHEMA_VERSION,
+        "application": {
+            "title": source.get("title", LEGACY_APPLICATION_TITLE),
+            "default_workspace_id": workspace_id,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": workspace_id,
+                "name": DEFAULT_WORKSPACE_NAME,
+                "tab_order": [tab_ids[name] for name in ordered_names],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": tab_ids[name],
+                "workspace_id": workspace_id,
+                "name": name,
+                "visibility": "hidden" if name in hidden else "visible",
+                "extensions": {},
+            }
+            for name in ordered_names
+        ],
+        "tiles": _migrated_tiles(source, tab_ids),
+        "columns": source.get("columns", 5),
+        "auto_fit": source.get("auto_fit", True),
+        "window_x": source.get("window_x"),
+        "window_y": source.get("window_y"),
+        "window_w": source.get("window_w"),
+        "window_h": source.get("window_h"),
+        "extensions": extensions,
+    }
+    return candidate
+
+
+def _allocator_uuid4(value: object) -> str | None:
+    if isinstance(value, UUID):
+        parsed = value
+    elif isinstance(value, str):
+        canonical = _canonical_uuid(value)
+        if canonical is None:
+            return None
+        parsed = UUID(canonical)
+    else:
+        return None
+    return str(parsed) if parsed.version == 4 else None
+
+
+def _allocate_native_id(
+    allocator: Uuid4Allocator,
+    blocked: set[str],
+) -> str:
+    for _ in range(NATIVE_ID_ALLOCATION_ATTEMPTS):
+        try:
+            candidate = _allocator_uuid4(allocator())
+        except Exception:
+            raise NativeV1ConstructionError from None
+        if candidate is not None and candidate not in blocked:
+            return candidate
+    raise NativeV1ConstructionError
+
+
+def build_native_v1(id_allocator: Uuid4Allocator) -> JsonObject:
+    """Build the friendly native v1 document with two injected UUIDv4 IDs."""
+
+    workspace_id = _allocate_native_id(id_allocator, set())
+    tab_id = _allocate_native_id(id_allocator, {workspace_id})
+    candidate: JsonObject = {
+        "schema_version": SCHEMA_VERSION,
+        "application": {
+            "title": DEFAULT_APPLICATION_TITLE,
+            "default_workspace_id": workspace_id,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": workspace_id,
+                "name": DEFAULT_WORKSPACE_NAME,
+                "tab_order": [tab_id],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": tab_id,
+                "workspace_id": workspace_id,
+                "name": DEFAULT_TAB_NAME,
+                "visibility": "visible",
+                "extensions": {},
+            }
+        ],
+        "tiles": [
+            {
+                "name": "ChatGPT",
+                "url": "https://chat.openai.com",
+                "tab_id": tab_id,
+                "icon": None,
+                "bg": "#F5F6FA",
+                "browser": None,
+                "chrome_profile": None,
+                "open_target": "tab",
+            },
+            {
+                "name": "Gmail",
+                "url": "https://mail.google.com",
+                "tab_id": tab_id,
+                "icon": None,
+                "bg": "#F5F6FA",
+                "browser": None,
+                "chrome_profile": None,
+                "open_target": "tab",
+            },
+            {
+                "name": "Notion",
+                "url": "https://www.notion.so",
+                "tab_id": tab_id,
+                "icon": None,
+                "bg": "#F5F6FA",
+                "browser": None,
+                "chrome_profile": None,
+                "open_target": "tab",
+            },
+        ],
+        "columns": 5,
+        "auto_fit": True,
+        "window_x": None,
+        "window_y": None,
+        "window_w": None,
+        "window_h": None,
+        "extensions": {},
+    }
+    if not validate_v1(candidate):
+        raise NativeV1ConstructionError
+    return candidate
+
+
+__all__ = [
+    "DEFAULT_APPLICATION_TITLE",
+    "DEFAULT_TAB_NAME",
+    "DEFAULT_WORKSPACE_NAME",
+    "JsonObject",
+    "JsonScalar",
+    "JsonValue",
+    "LEGACY_APPLICATION_TITLE",
+    "LEGACY_EXTENSION_NAMESPACE",
+    "MIGRATION_NAME_ROOT",
+    "NATIVE_ID_ALLOCATION_ATTEMPTS",
+    "NativeV1ConstructionError",
+    "SCHEMA_VERSION",
+    "Uuid4Allocator",
+    "Uuid5Factory",
+    "build_native_v1",
+    "migrate_v0_to_v1",
+    "validate_v0",
+    "validate_v1",
+]

--- a/docs/adr/0001-vnext-state-and-migration-contract.md
+++ b/docs/adr/0001-vnext-state-and-migration-contract.md
@@ -2,8 +2,9 @@
 
 - Status: Accepted
 - Date: 2026-07-18
+- Q5 amendment: 2026-07-20
 - Decision owners: DesktopTileLauncher maintainers
-- Tracking issue: #106
+- Tracking issues: #106, #112
 - Planning references: Q2, STAB-03, WORK-01, MODE-05, IMAGE-05, REVIEW-05, PLAT-02
 
 ## Context
@@ -24,15 +25,22 @@ resources, per-tab placements, New/In Use/Archived workflow state, Display and K
 modes, safe managed copies, deterministic ordering, staged imports, and platform seams.
 The state contract must be agreed before recovery and migration code is introduced.
 
-This ADR defines the target contract. It does not change the runtime schema or behavior.
+This ADR defines the target contract. The Q5 amendment stages the persisted contract without
+changing the accepted full-graph semantics: schema version 1 is the Workspace/Tab
+identity-only format, and the full Resource/Placement/DeviceBinding graph is schema version 2.
+The ADR remains Accepted, and RD-06 through RD-10 remain approved without semantic changes.
+The Windows Content Triage “v1” product milestone name is also unchanged; milestone names and
+persisted schema-version numbers are distinct.
 
 ## Decision summary
 
-1. A missing `schema_version` is legacy version 0. The first explicit version is 1.
-2. Version 1 separates portable application state from device-specific bindings and
+1. A missing `schema_version` is legacy version 0. Version 1 is the explicit identity-only
+   Workspace/Tab schema. Version 2 is the full graph previously described as version 1.
+2. Version 2 separates portable application state from device-specific bindings and
    short-lived, recoverable import staging stored outside committed configuration.
-3. Workspace, Tab, Resource, Placement, DeviceBinding, and ImportBatch use immutable,
-   canonical UUID strings.
+3. Workspace and Tab use immutable, canonical UUID strings in version 1. Version 2 retains
+   those identities and adds immutable Resource, Placement, DeviceBinding, and ImportBatch
+   identities.
 4. A Resource owns the underlying target, managed content, intrinsic metadata, and default
    label and icon. A Placement owns tab membership, workflow status, its positions in the
    Tab's Display and Kanban orders, color, and optional label and icon overrides. A
@@ -41,9 +49,9 @@ This ADR defines the target contract. It does not change the runtime schema or b
    Visible, Hidden, and Archived from those values. Archiving preserves visibility and
    restoring returns the tab to that prior visible/hidden state. Tile workflow status is
    separate from all tab state.
-6. Each Tab has an independent Display order and per-status Kanban column orders. Reordering
-   one does not change the other. Ordered exports use Display order initially; version 1 has
-   no separate export order.
+6. In version 2, each Tab has an independent Display order and per-status Kanban column
+   orders. Reordering one does not change the other. Ordered exports use Display order
+   initially; version 2 has no separate export order.
 7. Discard removes only a Placement. It never deletes an original file or a managed copy.
 8. ImportBatch is a durable, recoverable staging manifest outside the committed
    configuration. Pre-commit batches can be resumed or abandoned after interruption. Commit
@@ -51,9 +59,12 @@ This ADR defines the target contract. It does not change the runtime schema or b
    committed state never references an unavailable staged asset.
 9. Recovery precedes migration. Migration validates a complete candidate before atomic
    replacement and never overwrites the last good configuration on failure.
-10. Legacy migration always names the single created Workspace `Default Workspace`. The
-    existing launcher title remains `application.title` only and is not reused as the
-    Workspace name.
+10. Version 0 to version 1 migration always names the single created Workspace
+    `Default Workspace`. The existing launcher title remains `application.title` only and
+    is not reused as the Workspace name.
+11. Q5 implements only version 0 to version 1. A later focused slice will implement version
+    1 to version 2. Until then, explicit version 2 is unsupported newer and is never opened
+    or rewritten.
 
 ## Version envelope
 
@@ -64,6 +75,8 @@ This ADR defines the target contract. It does not change the runtime schema or b
 - Boolean, floating-point, string, negative, and otherwise malformed version values are
   invalid; they are not coerced.
 - The application migrates only through consecutive registered steps.
+- Q5 supports versions 0 through 1 and registers only the version 0 to version 1 step.
+  Explicit version 2 remains unsupported newer until the later version 1 to version 2 slice.
 - A document whose version is greater than the newest supported version is not opened or
   rewritten. The user receives an unsupported-newer-version recovery message.
 - A document whose version is lower than the oldest supported input version is preserved
@@ -74,22 +87,111 @@ This ADR defines the target contract. It does not change the runtime schema or b
 - Versioned documents are validated against the fields defined for that version.
 - Unknown fields outside an `extensions` object are validation errors. They are never
   silently dropped and the source is never overwritten.
-- Each versioned entity may carry an `extensions` object. Extension keys must be
-  reverse-domain or repository-qualified names. Values are opaque JSON and round-trip
+- In version 1, the application, Workspace, and Tab `extensions` objects must be empty. The
+  root `extensions` object is either empty or contains exactly the fixed
+  `io.github.108thecitizen.legacy` object described below. Version 1 introduces no general
+  extension-key grammar.
+- In version 2, each versioned entity may carry an `extensions` object. Extension keys must
+  be reverse-domain or repository-qualified names. Values are opaque JSON and round-trip
   unchanged.
 - Legacy version 0 fields that are not recognized are copied into
   `extensions["io.github.108thecitizen.legacy"]` during migration so a successful migration
   does not silently discard them.
 
-### Root state
+### Version 1 identity-only root state
 
-Version 1 has this logical shape. Arrays are shown for readability; each `id` must be
-unique within the complete document. The empty arrays identify top-level collections and do
-not by themselves form a valid graph.
+Version 1 has exactly this logical shape. The UUIDs are illustrative, and object-key order is
+not semantic.
 
 ```json
 {
   "schema_version": 1,
+  "application": {
+    "title": "My Launcher",
+    "default_workspace_id": "11111111-1111-4111-8111-111111111111",
+    "extensions": {}
+  },
+  "workspaces": [
+    {
+      "id": "11111111-1111-4111-8111-111111111111",
+      "name": "Default Workspace",
+      "tab_order": [
+        "22222222-2222-4222-8222-222222222222"
+      ],
+      "extensions": {}
+    }
+  ],
+  "tabs": [
+    {
+      "id": "22222222-2222-4222-8222-222222222222",
+      "workspace_id": "11111111-1111-4111-8111-111111111111",
+      "name": "Main",
+      "visibility": "visible",
+      "extensions": {}
+    }
+  ],
+  "tiles": [
+    {
+      "name": "ChatGPT",
+      "url": "https://chat.openai.com",
+      "tab_id": "22222222-2222-4222-8222-222222222222",
+      "icon": null,
+      "bg": "#F5F6FA",
+      "browser": null,
+      "chrome_profile": null,
+      "open_target": "tab"
+    }
+  ],
+  "columns": 5,
+  "auto_fit": true,
+  "window_x": null,
+  "window_y": null,
+  "window_w": null,
+  "window_h": null,
+  "extensions": {}
+}
+```
+
+Every shown field is required. Unknown fields outside the permitted `extensions` objects are
+invalid. `schema_version` is integer `1`, not Boolean. `application` contains exactly a
+string `title`, a resolving canonical lowercase UUID `default_workspace_id`, and empty
+`extensions`; blank and non-ASCII titles are valid. Version 1 contains exactly one Workspace
+with a non-empty name, complete `tab_order`, and empty `extensions`. Its non-empty `tabs`
+have globally unique canonical lowercase IDs, resolve to that Workspace, have unique
+non-empty names, use `visible` or `hidden`, and include at least one visible Tab. Every Tab
+occurs exactly once in the Workspace's `tab_order`.
+
+Root `tiles` retains the existing global Tile order; the order for a Tab is that array's
+subsequence. Every Tile has exactly the shown fields, uses `tab_id` rather than legacy
+title-valued `tab`, and resolves to a Tab. Nullable fields are required and use JSON null
+when absent. `open_target` is `tab` or `window`; `auto_fit` is Boolean; `columns` and window
+values retain their current accepted integer domains, with Booleans rejected as integers.
+Root `extensions` is empty or exactly:
+
+```json
+{
+  "io.github.108thecitizen.legacy": {
+    "unrecognized_legacy_field": "preserved value"
+  }
+}
+```
+
+Retained legacy values must be recursively finite strict JSON. For migration and native
+missing/reset construction, the Workspace name is exactly `Default Workspace`. A valid
+current version 1 document may use another non-empty Workspace name and round-trips it
+unchanged. The launcher title remains independent: a legacy launcher titled `My Launcher`
+retains `application.title: "My Launcher"`, while its migrated Workspace is still named
+`Default Workspace`.
+
+### Version 2 full-graph root state
+
+Version 2 retains the accepted full-graph contract previously numbered version 1. Arrays are
+shown for readability; each `id` must be unique within the complete document. The empty
+arrays identify top-level collections and do not by themselves form a valid graph.
+
+```json
+{
+  "schema_version": 2,
   "application": {
     "title": "My Launcher",
     "default_workspace_id": "0b7c...",
@@ -103,10 +205,6 @@ not by themselves form a valid graph.
   "extensions": {}
 }
 ```
-
-For migration, those two names are deliberately independent. A legacy launcher titled
-`My Launcher` retains `application.title: "My Launcher"`, while the Workspace referenced by
-`default_workspace_id` has `name: "Default Workspace"`.
 
 An ImportBatch is deliberately absent from committed configuration. Its recoverable,
 short-lived staging manifest is defined separately below.
@@ -129,9 +227,13 @@ Migration must be pure and repeatable for the same input bytes.
 
 - Valid existing tab UUIDs are retained.
 - Missing, malformed, or duplicate legacy IDs are replaced deterministically.
-- The migration computes a SHA-256 digest of canonicalized legacy JSON and derives UUIDv5
-  values using the standard URL namespace and names of the form
-  `https://github.com/108thecitizen/DesktopTileLauncher/migration/v0/{digest}/{kind}/{ordinal}`.
+- A migration computes a SHA-256 digest of its canonicalized source JSON and derives UUIDv5
+  values using the standard URL namespace and future names of the form
+  `https://github.com/108thecitizen/DesktopTileLauncher/migration/v{source_version}/{digest}/{kind}/{ordinal}`.
+- Q5 implements only the exact version 0 names
+  `https://github.com/108thecitizen/DesktopTileLauncher/migration/v0/{digest}/workspace/0`
+  and
+  `https://github.com/108thecitizen/DesktopTileLauncher/migration/v0/{digest}/tab/{ordinal}`.
 - Ordinals come from the preserved legacy order, not from a dictionary iteration order.
 - A rerun against identical legacy input therefore produces identical candidate state.
 - New entities created after migration use UUIDv4 and are persisted before another process
@@ -141,6 +243,9 @@ Ephemeral refresh-operation tokens and in-memory object identities are not persi
 and must not be used as Resource, Placement, or ImportBatch identity.
 
 ## Entity contracts
+
+Workspace and the version 1 subset of Tab apply to both schema versions. The additional Tab
+fields and the Resource, Placement, and DeviceBinding contracts apply to version 2.
 
 ### Workspace
 
@@ -155,12 +260,13 @@ Required fields:
 
 Invariants:
 
-- Every Tab belongs to exactly one Workspace in version 1.
+- Every Tab belongs to exactly one Workspace.
 - Every ID in `tab_order` resolves to a Tab owned by the Workspace.
 - Every owned Tab occurs exactly once in `tab_order`.
-- At least one Workspace and one Tab exist.
-- Window geometry is device-specific and is represented by a DeviceBinding, not portable
-  Workspace state.
+- Version 1 has exactly one Workspace and at least one Tab. Version 2 has at least one of
+  each.
+- In version 2, window geometry is device-specific and is represented by a DeviceBinding,
+  not portable Workspace state. Version 1 retains the existing root window fields.
 
 Window ownership, simultaneous windows, restoration, compact palettes, and tab tear-off
 remain later behavior. This ADR does not define a running-window/session model.
@@ -171,8 +277,12 @@ Required fields:
 
 - `id`: immutable UUID.
 - `workspace_id`: owning Workspace ID.
-- `name`: non-empty user-visible name, unique within its Workspace for version 1.
+- `name`: non-empty user-visible name, unique within its Workspace.
 - `visibility`: `visible` or `hidden`.
+- `extensions`: opaque extension map; it is empty in version 1.
+
+Version 2 adds these required fields without changing their accepted semantics:
+
 - `lifecycle`: `active` or `archived`.
 - `view_mode`: `display` or `kanban`.
 - `display_filter`: a duplicate-free subset of `new`, `in_use`, and `archived`, serialized
@@ -181,7 +291,6 @@ Required fields:
   Display's row-major reading order: top-left is first and bottom-right is last.
 - `kanban_order`: object with `new`, `in_use`, and `archived` arrays. Each array is the
   top-to-bottom order of Placements in that workflow-status column.
-- `extensions`: opaque extension map.
 
 Visibility and lifecycle are independent. The user-facing category is derived as follows:
 
@@ -198,11 +307,12 @@ Hide and Show change only `visibility` and apply to active tabs. Archive changes
 tab returns to Hidden. Archived tabs never appear in the normal tab bar, regardless of the
 remembered visibility value.
 
-The exact archived-tab manager and delete/trash UI remain deferred. Version 1 migration
-sets all existing tabs to `lifecycle: active` and preserves current hidden/visible state.
+The exact archived-tab manager and delete/trash UI remain deferred. Version 1 to version 2
+migration sets all existing tabs to `lifecycle: active` and preserves current hidden/visible
+state.
 
-An empty Display filter is valid and intentionally displays no placements. The migration
-default is `["new", "in_use"]`.
+An empty Display filter is valid and intentionally displays no placements. The version 1 to
+version 2 migration default is `["new", "in_use"]`.
 
 ### Resource
 
@@ -486,6 +596,9 @@ M2 rules:
 
 ## Ordering contract
 
+This section applies to the version 2 full graph. Version 1 has only Workspace `tab_order`
+and the root Tile array, whose per-Tab order is its `tab_id` subsequence.
+
 Display arrangement and Kanban evaluation serve different workflows and therefore persist
 independent orders.
 
@@ -522,7 +635,7 @@ independent orders.
 
 ### Export order
 
-- Version 1 stores no independent export order.
+- Version 2 stores no independent export order.
 - Any future export first determines its included Placement set under that export's own
   scope rules. Within each Tab, it sorts that Tab's included set by `display_order`.
 - Thus, within a Tab, the included tile nearest the Display's top-left exports first and the
@@ -547,61 +660,125 @@ independent orders.
 - Deleting or archiving a Tab is not equivalent to discarding all of its Placements. Tab
   archive/delete/trash semantics require their own later decision.
 
-## Legacy version 0 migration
+## Legacy version 0 to identity version 1 migration
 
-Migration from the current format to version 1 follows this mapping.
+Q5 migrates the current format to version 1 through the Q4 transaction with this mapping.
 
 | Legacy value | Version 1 value |
 |---|---|
-| top-level `title` | `application.title` only, preserved independently from Workspace naming |
+| top-level `title` | `application.title` only; missing materializes `Launcher` |
 | synthetic migrated Workspace | exactly one Workspace named `Default Workspace`; its ID becomes `application.default_workspace_id` and it owns every migrated Tab |
-| `columns`, `auto_fit`, window geometry | local Workspace/window DeviceBinding settings |
-| `tabs` and tile-referenced missing tabs | Tab entities in normalized current order |
-| valid `tab_ids` | retained Tab IDs |
-| missing/invalid/duplicate `tab_ids` | deterministic migration UUIDs |
-| `tab_order` | default Workspace `tab_order`, retaining valid order and appending omitted tabs |
-| `hidden_tabs` | Tab `visibility`; all Tab lifecycles become `active` |
-| each legacy Tile | one distinct URL Resource and one Placement; no URL deduplication during migration |
-| Tile `tab` title | resolved Placement `tab_id` |
-| Tile list position | per-tab `display_order` and `kanban_order.in_use`, in the same preserved order |
+| `tabs` and Tile-referenced missing tabs | Tab entities in normalized current order |
+| valid `tab_ids` | retained canonical Tab IDs |
+| missing, malformed, or duplicate Tab IDs | deterministic migration UUIDs |
+| `tab_order` | ordering hints for the default Workspace `tab_order`; omitted Tabs append in normalized discovery order |
+| `hidden_tabs` | Tab `visibility` |
+| each legacy Tile | one root Tile with every field preserved, replacing only title-valued `tab` with resolving `tab_id` |
+| `columns`, `auto_fit`, and window geometry | same root settings with current defaults materialized when missing |
+| any other unrecognized top-level field | fixed root `extensions["io.github.108thecitizen.legacy"]` object |
+
+The detached source mapping is immutable. Migration continues using the completed shallow
+legacy validation boundary: malformed JSON and incompatible known fields take the Q3
+recovery route, while non-finite unknown values fail closed before preservation or any
+migration step. No migration artifact is created and the source remains unchanged.
+
+Migration preserves current effective legacy behavior before replacing names with IDs:
+
+- Retain string `tabs` entries in encounter order, filter nonstrings, and collapse duplicate
+  names to their first occurrence without trimming or case folding.
+- A Tile with no `tab` uses the existing implicit `Main`. Append Tile-only Tab names in
+  first-seen Tile order. If no Tab remains, create `Main`.
+- An empty Tab name or empty Tile Tab name is an expected migration rejection after exact
+  source preservation; migration never renames, drops, or merges it.
+- Filter hidden names to retained Tabs and deduplicate them. If every final Tab would be
+  hidden, make the first final ordered Tab visible.
+- Preserve global Tile order and each per-Tab subsequence. Preserve every Tile field and
+  launch behavior, changing only `tab` to the resolving `tab_id`.
+- Materialize the existing defaults for every missing field: title `Launcher`, columns `5`,
+  `auto_fit: true`, null window values, and the current Tile defaults.
+- Consume recognized `tabs`, `hidden_tabs`, `tab_ids`, and `tab_order`; do not copy them into
+  extensions. Copy every other unrecognized top-level field into the fixed legacy object.
+- Create exactly one Workspace named `Default Workspace`, assign every Tab to it, and use its
+  ID as `application.default_workspace_id`. Never derive, copy, or fall back from the
+  application title when naming the Workspace.
+
+Canonical valid legacy Tab UUIDs associated with migrated names are retained in lowercase.
+For duplicate IDs, the first Tab in normalized discovery order retains the ID and later Tabs
+receive deterministic replacements. A non-object `tab_ids` or non-list `tab_order` is
+tolerated as absent hints. `tab_order` contributes only known, duplicate-free canonical IDs
+assigned to migrated Tabs; malformed, duplicate, and dangling entries are ignored, and
+omitted Tabs append in normalized discovery order. Canonical UUIDs anywhere in legacy
+`tab_ids` values or `tab_order` remain collision reservations even when dangling, but do not
+create entities or references.
+
+The complete detached version 0 mapping is canonicalized as:
+
+```python
+json.dumps(
+    detached_v0_mapping,
+    ensure_ascii=False,
+    sort_keys=True,
+    indent=2,
+    allow_nan=False,
+).encode("utf-8")
+```
+
+Those canonical bytes and the serialized candidate use LF and no trailing newline. The
+canonical bytes' lowercase SHA-256 digest feeds the exact version 0 UUIDv5 names defined
+above. A Tab ordinal is its zero-based position in the complete final Workspace order, not a
+count of generated IDs. A derived collision with a reserved, retained, or already derived
+UUID rejects migration; there is no retry name or random fallback. The step uses no
+randomness, time, process state, mutable globals, environment, filesystem, network, or Qt.
+Identical canonical input produces identical IDs and candidate bytes.
+
+Migration-specific tests must prove that exactly one Workspace is created, its name is
+exactly `Default Workspace`, its ID is the `default_workspace_id` target, and
+`application.title` equals the preserved legacy launcher title. Custom, blank/default,
+missing, and non-ASCII title cases demonstrate that the two names are independent.
+
+Missing configuration bypasses migration and constructs native version 1 directly with
+`application.title: "My Launcher"`, one `Default Workspace`, one visible `Main` Tab, and the
+existing ChatGPT, Gmail, and Notion Tiles assigned to Main by `tab_id`. It uses distinct,
+collision-checked Workspace and Tab UUIDv4 values from an injectable runtime allocator,
+validates the complete candidate, and atomically persists it before returning usable state.
+Q3 Preserve and Reset installs the same native version 1 only after preserving and verifying
+the corrupt source. Native IDs are never regenerated while loading, normalizing, saving, or
+restarting.
+
+## Version 1 to version 2 migration
+
+A later focused slice will implement version 1 to version 2. It must preserve the version 1
+Workspace, Tab, Tile, application, setting, and extension state while producing the accepted
+full graph. The accepted mapping, previously described as direct version 0 to version 1,
+remains:
+
+| Version 1 value | Version 2 value |
+|---|---|
+| `application.title` | unchanged, independently from Workspace naming |
+| sole Workspace | same identity, name, default reference, ownership, and `tab_order` |
+| root `columns`, `auto_fit`, and window geometry | local Workspace/window DeviceBinding settings |
+| Tabs | same IDs, names, ownership, order, and visibility; lifecycle becomes `active` |
+| each root Tile | one distinct URL Resource and one Placement; no URL deduplication |
+| Tile `tab_id` | resolving Placement `tab_id` |
+| Tile-list per-Tab subsequence | `display_order` and `kanban_order.in_use` in the same order |
 | Tile `name` | Resource `default_label`; Placement `label_override: null` |
 | Tile `icon` | Resource `default_icon`; Placement `icon_override: null` |
 | Tile `bg` | Placement `background_color` |
 | Tile URL | Resource URL target |
 | Tile browser/profile/open target | local Placement/launch DeviceBinding |
-| existing tiles | Placement `workflow_status: in_use` |
-| existing tabs | `view_mode: display`, Display filter `new` + `in_use` |
+| existing Tiles | Placement `workflow_status: in_use` |
+| existing Tabs | `view_mode: display`, Display filter `new` + `in_use` |
 
-Additional rules:
+The later step does not deduplicate Resources, merge Tabs, normalize user-facing labels, drop
+Tiles, or change launch behavior. Each Tile becomes a distinct Resource, so Resource defaults
+and null Placement overrides preserve appearance without introducing sharing between formerly
+independent Tiles. Existing Tiles initialize Display order and the In Use Kanban column from
+the same preserved per-Tab order; New and Archived Kanban arrays start empty. Every current
+Tab, hidden state, stable order, Tile field, launch setting, window value, and permitted
+extension remains accounted for. The complete version 2 candidate must pass all version 2
+invariants before any write.
 
-- The source document is treated as immutable input.
-- Migration creates exactly one Workspace named `Default Workspace`, regardless of whether
-  the legacy launcher title is blank or non-blank. It never derives, copies, or falls back
-  the Workspace name from that title. The original title is preserved in `application.title`
-  under the existing title rules and is not trimmed or normalized merely for Workspace
-  naming.
-- Migration never deduplicates Resources, merges tabs, normalizes user-facing labels, drops
-  tiles, or changes launch behavior.
-- Because migration creates one distinct Resource per legacy Tile, moving each legacy name
-  and icon into Resource defaults while leaving Placement overrides null preserves the
-  current appearance exactly and does not introduce sharing between formerly independent
-  tiles.
-- Existing Tiles initialize both Display order and the In Use Kanban column from the same
-  preserved per-tab legacy order; New and Archived Kanban arrays start empty.
-- Every current tab, hidden state, stable order, tile, icon reference, background color,
-  browser/profile preference, open target, window value, and extension is accounted for.
-- Invalid references are repaired only by the current documented invariants: tile-only tab
-  titles are added, duplicate titles collapse to the first occurrence, and an invalid tile
-  Tab falls back to the first Tab only when no source title can be recovered.
-- The candidate must pass all version 1 invariants before any write.
-
-Migration-specific tests must prove that exactly one Workspace is created, its name is
-exactly `Default Workspace`, its ID is the `default_workspace_id` target, and
-`application.title` equals the preserved legacy launcher title. Cases include a custom
-title, a blank/default title, and a non-ASCII title, demonstrating that the two names are
-independent.
-
-New photo imports after migration create image Resources, New Placements, and, when the batch
+New photo imports after version 2 create image Resources, New Placements, and, when the batch
 creates a Tab, a Kanban Tab with the default Display filter of New plus In Use.
 
 ## Recovery, migration, and rollback boundary
@@ -615,7 +792,8 @@ The startup sequence is normative:
 4. Preserve a byte-for-byte recovery copy before the first migration write.
 5. Apply consecutive pure migration steps in memory. No step uses Qt, the network, a real
    device, wall-clock ordering, or global mutable state.
-6. Validate the complete target graph and managed-path constraints.
+6. Validate the complete target document and its version-specific graph and managed-path
+   constraints.
 7. Serialize deterministically and atomically replace the configuration.
 8. Reload and validate the written file before declaring migration complete.
 
@@ -628,18 +806,32 @@ Failure rules:
 - Recovery copies use collision-safe names, remain outside managed asset cleanup, and are
   never overwritten.
 - Reopening an already valid version 1 document is idempotent and performs no migration write.
+- Loaded version 1 state never passes through repair-oriented legacy normalization and never
+  regenerates identities. Invalid identities or references are rejected before any write.
 - Diagnostics record versions, step names, counts, and sanitized failure categories, not URLs,
   file content, titles, paths, or credentials.
 
 Q3 implements corrupt-input preservation and user recovery. Q4 implements the version
 registry, pure step runner, validation hooks, deterministic tests, and rollback plumbing.
-Q5 implements the version 0 to version 1 Workspace/Tab identity slice. Later focused slices
-add Resource/Placement, workflow, DeviceBinding, and ImportBatch runtime behavior while
-conforming to this contract.
+Q5 implements the version 0 to version 1 Workspace/Tab identity slice. A later focused slice
+implements version 1 to version 2 before subsequent slices add the accepted full-graph
+Resource/Placement, workflow, DeviceBinding, and ImportBatch runtime behavior.
 
 ## Validation invariants
 
-A version 1 candidate is valid only when:
+### Version 1
+
+A version 1 candidate is valid only when its exact required root, application, Workspace,
+Tab, Tile, setting, window, and extension fields have the documented JSON types and values.
+Workspace and Tab IDs are canonical lowercase UUIDs and globally unique within the identity
+graph; the application default, every Tab owner, every `tab_order` member, and every Tile
+`tab_id` resolve. The sole Workspace owns every Tab, its `tab_order` contains every Tab
+exactly once, Tab names are unique and non-empty, and at least one Tab is visible. Root Tile
+order and fields remain complete, and unknown fields or non-finite values are rejected.
+
+### Version 2
+
+A version 2 candidate is valid only when:
 
 - Every required field has the exact documented JSON type and enum value.
 - All IDs are canonical and globally unique across entity types.
@@ -659,10 +851,10 @@ A version 1 candidate is valid only when:
 - DeviceBinding uniqueness and subject rules hold.
 - Extension values are valid JSON and their namespace keys are valid.
 
-Validation is strict. Repair belongs in an explicit migration step, not in general version 1
-loading.
+Validation is strict in both versions. Repair belongs in an explicit migration step, not in
+general versioned loading.
 
-ImportBatch manifests are validated separately from committed version 1 state. Validation
+ImportBatch manifests are validated separately from committed version 2 state. Validation
 requires a supported manifest version and legal state transition; the state-appropriate
 base snapshot/digest and, once constructed, candidate snapshot/digest; unique planned entity
 IDs; complete item outcomes and both order insertions; size and digest agreement for every
@@ -678,9 +870,9 @@ Anything else enters explicit recovery without configuration mutation or automat
   hermetic tests. It does not add feature UI.
 - Q5: create the default Workspace named exactly `Default Workspace`, preserve the existing
   launcher title in `application.title`, and introduce stable Workspace/Tab identity
-  migration while preserving existing valid Tab IDs and behavior.
-- Later Resource/Placement slice: introduce typed targets, placement ownership, status, and
-  independent Display/Kanban orders.
+  migration while preserving existing valid Tab IDs and behavior as schema version 1.
+- Later version 1 to version 2 Resource/Placement slice: introduce typed targets, placement
+  ownership, status, and independent Display/Kanban orders.
 - Later image/import slices: implement the RD-09 recovery journal, managed assets,
   DeviceBindings, crash-boundary tests, and the M2 routing limits.
 - Later Kanban slice: implement independent column queues and their status-transition rules
@@ -779,7 +971,8 @@ This ADR intentionally does not decide:
 
 ## Review checklist
 
-- [x] Version 0 and version 1 boundaries are unambiguous.
+- [x] Version 0 legacy input, identity-only version 1, and full-graph version 2 boundaries are
+  unambiguous.
 - [x] Entity identity, ownership, references, and deletion rules are complete.
 - [x] Resource defaults, Placement overrides, inheritance, refresh, and legacy presentation
   migration follow the approved ownership rules.
@@ -797,4 +990,5 @@ This ADR intentionally does not decide:
 - [x] Manifest/candidate privacy, bounded scanning, path containment, digest verification,
   atomic transitions, partial-failure reporting, and the confirmed M2 limits are covered.
 - [x] Q3, Q4, Q5, and later implementation slices can be issued independently.
-- [x] No runtime or persisted-schema change is included in this ADR PR.
+- [x] The Q5 amendment changes only schema staging; accepted version 2 entity semantics remain
+  unchanged.

--- a/tab_order.py
+++ b/tab_order.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from uuid import UUID, uuid4
 
@@ -59,6 +59,8 @@ def normalize_tab_order(
     raw_tab_ids: object,
     raw_tab_order: object,
     id_factory: TabIdFactory = new_tab_id,
+    *,
+    blocked_ids: Iterable[object] = (),
 ) -> TabOrderState:
     """Normalize persisted tab identity and ordering data without losing tabs.
 
@@ -75,12 +77,17 @@ def normalize_tab_order(
             seen_titles.add(title)
 
     saved_ids = raw_tab_ids if isinstance(raw_tab_ids, dict) else {}
-    reserved_ids = _reserved_saved_ids(raw_tab_ids, raw_tab_order)
+    blocked = {
+        candidate
+        for value in blocked_ids
+        if (candidate := _canonical_tab_id(value)) is not None
+    }
+    reserved_ids = _reserved_saved_ids(raw_tab_ids, raw_tab_order) | blocked
     used_ids: set[str] = set()
     tab_ids: dict[str, str] = {}
     for title in clean_tabs:
         candidate = _canonical_tab_id(saved_ids.get(title))
-        if candidate is None or candidate in used_ids:
+        if candidate is None or candidate in used_ids or candidate in blocked:
             candidate = _new_unique_tab_id(reserved_ids | used_ids, id_factory)
         tab_ids[title] = candidate
         used_ids.add(candidate)
@@ -128,6 +135,8 @@ def add_tab(
     state: TabOrderState,
     title: str,
     id_factory: TabIdFactory = new_tab_id,
+    *,
+    blocked_ids: Iterable[object] = (),
 ) -> TabOrderState:
     """Append a newly identified tab to the canonical full order."""
 
@@ -135,6 +144,11 @@ def add_tab(
         return state
 
     used_ids = set(state.tab_ids.values()) | set(state.tab_order)
+    used_ids.update(
+        candidate
+        for value in blocked_ids
+        if (candidate := _canonical_tab_id(value)) is not None
+    )
     tab_id = _new_unique_tab_id(used_ids, id_factory)
     return TabOrderState(
         [*state.tabs, title],

--- a/tests/unit/test_config_migration.py
+++ b/tests/unit/test_config_migration.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import math
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from pathlib import Path
@@ -12,6 +11,7 @@ import pytest
 
 import config_migration as migration
 import config_recovery
+import config_schema
 from config_recovery import MAX_CONFIG_BYTES
 
 pytestmark = pytest.mark.unit
@@ -27,6 +27,19 @@ def _validated(spec: migration.RegistrySpec) -> migration.ValidatedMigrationRegi
     result = migration.validate_registry(spec)
     assert isinstance(result, migration.RegistryReady)  # nosec B101
     return result.registry
+
+
+_EMPTY_REGISTRY = _validated(migration.RegistrySpec(None, None, (), ()))
+
+
+def _native_v1_document() -> config_schema.JsonObject:
+    identifiers = iter(
+        (
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222",
+        )
+    )
+    return config_schema.build_native_v1(lambda: next(identifiers))
 
 
 def _single_step_registry(
@@ -80,7 +93,7 @@ def _forbid_legacy_constructor(_mapping: dict[str, object]) -> object:
     raise AssertionError("migration result must not enter legacy construction")
 
 
-def test_production_empty_registry_keeps_implicit_v0_legacy_only() -> None:
+def test_production_registry_prepares_exactly_v0_to_v1() -> None:
     source: migration.JsonObject = {
         "title": "Legacy",
         "unknown": {"private": "not rendered"},
@@ -88,38 +101,43 @@ def test_production_empty_registry_keeps_implicit_v0_legacy_only() -> None:
 
     result = migration.prepare_migration(source, migration.PRODUCTION_REGISTRY)
 
-    assert isinstance(result, migration.LegacyV0Current)  # nosec B101
-    assert result.document == source  # nosec B101
+    assert isinstance(result, migration.PreparedMigration)  # nosec B101
+    assert result.source_version == 0  # nosec B101
+    assert result.target_version == 1  # nosec B101
+    assert result.step_count == 1  # nosec B101
     assert (
         migration.migration_startup_route(result)
-        is migration.MigrationStartupRoute.LEGACY
+        is migration.MigrationStartupRoute.MIGRATION_REQUIRED
     )
     assert "private" not in repr(result)  # nosec B101
+    assert source == {  # nosec B101
+        "title": "Legacy",
+        "unknown": {"private": "not rendered"},
+    }
 
 
-def test_production_implicit_v0_bypasses_pure_detachment_for_legacy_compatibility(
+def test_production_nonfinite_unknown_fails_before_preservation_or_step(
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "config.json"
     original = b'{"title":"Legacy","ignored":NaN}'
     config_path.write_bytes(original)
 
-    def construct_legacy(mapping: dict[str, object]) -> str:
-        ignored = mapping["ignored"]
-        assert isinstance(ignored, float)  # nosec B101
-        assert math.isnan(ignored)  # nosec B101
-        return "legacy"
-
     result = migration.load_startup_configuration(
         config_path,
-        construct_legacy,
+        _forbid_legacy_constructor,
         migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
     )
 
-    assert isinstance(result, migration.ImplicitLegacyLoaded)  # nosec B101
-    assert result.value == "legacy"  # nosec B101
+    assert isinstance(result, migration.PureEngineFailure)  # nosec B101
+    assert (  # nosec B101
+        result.category is migration.PureEngineFailureCategory.JSON_DETACHMENT_FAILURE
+    )
+    assert result.stage is migration.PureExecutionStage.SOURCE_VALIDATION  # nosec B101
     assert config_path.read_bytes() == original  # nosec B101
     assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
     assert _temporary_residue(tmp_path) == []  # nosec B101
 
 
@@ -136,7 +154,7 @@ def test_production_implicit_v0_bypasses_pure_detachment_for_legacy_compatibilit
         ),
     ],
 )
-def test_production_explicit_version_never_constructs_or_writes(
+def test_production_unsupported_or_malformed_version_never_constructs_or_writes(
     tmp_path: Path,
     source: bytes,
     expected_category: migration.VersionRejectionCategory,
@@ -183,14 +201,221 @@ def test_positive_explicit_versions_are_identified_exactly(version: int) -> None
     assert result == migration.ExplicitVersion(version)  # nosec B101
 
 
-def test_production_rejects_every_positive_explicit_version_as_newer() -> None:
-    result = migration.prepare_migration(
-        {"schema_version": 1}, migration.PRODUCTION_REGISTRY
+def test_production_accepts_strict_v1_and_rejects_explicit_v2() -> None:
+    current = _native_v1_document()
+
+    accepted = migration.prepare_migration(current, migration.PRODUCTION_REGISTRY)
+    future = deepcopy(current)
+    future["schema_version"] = 2
+    rejected = migration.prepare_migration(future, migration.PRODUCTION_REGISTRY)
+
+    assert isinstance(accepted, migration.VersionedCurrent)  # nosec B101
+    assert accepted.version == 1  # nosec B101
+    assert isinstance(rejected, migration.VersionRejected)  # nosec B101
+    assert rejected.category is migration.VersionRejectionCategory.UNSUPPORTED_NEWER
+    assert rejected.version == 2  # nosec B101
+
+
+def test_production_v0_migrates_transactionally_without_legacy_construction(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = (
+        b'{"title":"Legacy","tabs":["Main"],"tiles":[],"unknown":{"retained":true}}'
+    )
+    config_path.write_bytes(original)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
     )
 
-    assert isinstance(result, migration.VersionRejected)  # nosec B101
-    assert result.category is migration.VersionRejectionCategory.UNSUPPORTED_NEWER
-    assert result.version == 1  # nosec B101
+    assert isinstance(result, migration.MigrationCommitted)  # nosec B101
+    assert result.target_version == 1  # nosec B101
+    assert config_schema.validate_v1(result.document)  # nosec B101
+    extensions = cast(dict[str, object], result.document["extensions"])
+    assert extensions == {  # nosec B101
+        config_schema.LEGACY_EXTENSION_NAMESPACE: {"unknown": {"retained": True}}
+    }
+    serialized = migration.serialize_deterministically(result.document)
+    assert isinstance(serialized, migration.SerializedDocument)  # nosec B101
+    assert config_path.read_bytes() == serialized.data  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_known_incompatible_v0_uses_q3_recovery_without_artifacts(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"columns":true}'
+    config_path.write_bytes(original)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(result, config_recovery.ConfigRecoveryRequired)  # nosec B101
+    assert (  # nosec B101
+        result.category
+        is config_recovery.ConfigLoadFailureCategory.LEGACY_CONSTRUCTION_FAILURE
+    )
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_current_v1_startup_is_exact_no_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    document = _native_v1_document()
+    original = json.dumps(document, ensure_ascii=False, separators=(", ", ": ")).encode(
+        "utf-8"
+    )
+    config_path.write_bytes(original)
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(result, migration.VersionedCurrent)  # nosec B101
+    assert result.document == document  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_current_v1_with_lone_surrogate_is_exit_only_and_no_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    document = _native_v1_document()
+    application = cast(dict[str, migration.JsonValue], document["application"])
+    application["title"] = "\ud800"
+    original = json.dumps(document, ensure_ascii=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    assert b"\\ud800" in original  # nosec B101
+    config_path.write_bytes(original)
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(result, migration.PureExecutionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.category
+        is migration.PureExecutionRejectionCategory.SOURCE_VALIDATION_FAILURE
+    )
+    assert result.stage is migration.PureExecutionStage.SOURCE_VALIDATION  # nosec B101
+    assert (  # nosec B101
+        migration.startup_failure_route(result)
+        is migration.StartupFailureRoute.EXIT_ONLY
+    )
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_empty_legacy_tab_rejects_after_exact_preservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"Legacy","tabs":[""],"tiles":[]}'
+    config_path.write_bytes(original)
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(  # nosec B101
+        result, migration.MigrationAbortedAfterPreservation
+    )
+    assert isinstance(result.problem, migration.PureExecutionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.problem.category
+        is migration.PureExecutionRejectionCategory.STEP_REJECTION
+    )
+    assert result.problem.stage is migration.PureExecutionStage.STEP  # nosec B101
+    assert result.problem.step_name == "legacy_to_v1"  # nosec B101
+    assert result.authority is migration.ConfigurationAuthority.ORIGINAL  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert result.failed_candidate_copy_count == 0  # nosec B101
+    assert result.rollback_count == 0  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_invalid_applied_output_uses_target_validation_after_preservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = b'{"title":"Legacy","tabs":["Main"],"tiles":[]}'
+    config_path.write_bytes(original)
+
+    def invalid_target(
+        _document: Mapping[str, config_schema.JsonValue],
+    ) -> config_schema.JsonObject:
+        return {"schema_version": 1}
+
+    monkeypatch.setattr(migration, "migrate_v0_to_v1", invalid_target)
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(  # nosec B101
+        result, migration.MigrationAbortedAfterPreservation
+    )
+    assert isinstance(result.problem, migration.PureExecutionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.problem.category
+        is migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+    )
+    assert (  # nosec B101
+        result.problem.stage is migration.PureExecutionStage.TARGET_VALIDATION
+    )
+    assert result.problem.step_name == "legacy_to_v1"  # nosec B101
+    assert result.authority is migration.ConfigurationAuthority.ORIGINAL  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
+    assert result.failed_candidate_copy_count == 0  # nosec B101
+    assert result.rollback_count == 0  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
 
 
 def _step(
@@ -1046,7 +1271,7 @@ def test_guarded_legacy_normalization_save_does_not_overwrite_future_race(
     loaded = migration.load_startup_configuration(
         config_path,
         lambda mapping: dict(mapping),
-        migration.PRODUCTION_REGISTRY,
+        _EMPTY_REGISTRY,
     )
     assert isinstance(loaded, migration.ImplicitLegacyLoaded)  # nosec B101
 
@@ -1424,7 +1649,7 @@ def test_guarded_legacy_normalization_succeeds_for_unchanged_regular_source(
     loaded = migration.load_startup_configuration(
         config_path,
         lambda mapping: dict(mapping),
-        migration.PRODUCTION_REGISTRY,
+        _EMPTY_REGISTRY,
     )
     assert isinstance(loaded, migration.ImplicitLegacyLoaded)  # nosec B101
 
@@ -1451,7 +1676,7 @@ def test_guarded_legacy_normalization_accepts_unchanged_redirected_source(
     loaded = migration.load_startup_configuration(
         config_path,
         lambda mapping: dict(mapping),
-        migration.PRODUCTION_REGISTRY,
+        _EMPTY_REGISTRY,
     )
     assert isinstance(loaded, migration.ImplicitLegacyLoaded)  # nosec B101
 

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -1,0 +1,997 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from collections.abc import Callable
+from copy import deepcopy
+from typing import cast
+from uuid import UUID
+
+import pytest
+
+import config_schema as schema
+
+pytestmark = pytest.mark.unit
+
+WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+MAIN_ID = "22222222-2222-4222-8222-222222222222"
+WORK_ID = "33333333-3333-4333-8333-333333333333"
+OTHER_ID = "44444444-4444-4444-8444-444444444444"
+DANGLING_ID = "55555555-5555-4555-8555-555555555555"
+V5_WORKSPACE_ID = "8b66f209-e64d-50d9-b534-144cac41f7bf"
+V5_TAB_ID = "97587f7c-ca79-5cb7-ad4d-c9e4cd08683d"
+NONCANONICAL_IDS: tuple[object, ...] = (
+    V5_TAB_ID.upper(),
+    MAIN_ID.replace("-", ""),
+    "not-a-uuid",
+    "",
+    None,
+)
+
+
+def _valid_v1() -> schema.JsonObject:
+    return {
+        "schema_version": 1,
+        "application": {
+            "title": "My Launcher",
+            "default_workspace_id": WORKSPACE_ID,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": WORKSPACE_ID,
+                "name": "Default Workspace",
+                "tab_order": [MAIN_ID, WORK_ID],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": MAIN_ID,
+                "workspace_id": WORKSPACE_ID,
+                "name": "Main",
+                "visibility": "visible",
+                "extensions": {},
+            },
+            {
+                "id": WORK_ID,
+                "workspace_id": WORKSPACE_ID,
+                "name": "Work",
+                "visibility": "hidden",
+                "extensions": {},
+            },
+        ],
+        "tiles": [
+            {
+                "name": "ChatGPT",
+                "url": "https://chat.openai.com",
+                "tab_id": MAIN_ID,
+                "icon": None,
+                "bg": "#F5F6FA",
+                "browser": None,
+                "chrome_profile": None,
+                "open_target": "tab",
+            }
+        ],
+        "columns": 5,
+        "auto_fit": True,
+        "window_x": None,
+        "window_y": -20,
+        "window_w": 0,
+        "window_h": 900,
+        "extensions": {},
+    }
+
+
+def _application(document: schema.JsonObject) -> dict[str, schema.JsonValue]:
+    value = document["application"]
+    assert isinstance(value, dict)  # nosec B101
+    return value
+
+
+def _workspace(document: schema.JsonObject) -> dict[str, schema.JsonValue]:
+    value = document["workspaces"]
+    assert isinstance(value, list) and value  # nosec B101
+    workspace = value[0]
+    assert isinstance(workspace, dict)  # nosec B101
+    return workspace
+
+
+def _tabs(document: schema.JsonObject) -> list[dict[str, schema.JsonValue]]:
+    value = document["tabs"]
+    assert isinstance(value, list)  # nosec B101
+    assert all(isinstance(tab, dict) for tab in value)  # nosec B101
+    return cast(list[dict[str, schema.JsonValue]], value)
+
+
+def _tiles(document: schema.JsonObject) -> list[dict[str, schema.JsonValue]]:
+    value = document["tiles"]
+    assert isinstance(value, list)  # nosec B101
+    assert all(isinstance(tile, dict) for tile in value)  # nosec B101
+    return cast(list[dict[str, schema.JsonValue]], value)
+
+
+def _replace_workspace_identity(
+    document: schema.JsonObject,
+    replacement: schema.JsonValue,
+) -> None:
+    workspace = _workspace(document)
+    previous_id = workspace["id"]
+    _application(document)["default_workspace_id"] = replacement
+    workspace["id"] = replacement
+    for tab in _tabs(document):
+        assert tab["workspace_id"] == previous_id  # nosec B101
+        tab["workspace_id"] = replacement
+
+
+def _replace_tab_identity(
+    document: schema.JsonObject,
+    tab_index: int,
+    replacement: schema.JsonValue,
+) -> None:
+    tab = _tabs(document)[tab_index]
+    previous_id = tab["id"]
+    tab["id"] = replacement
+
+    workspace = _workspace(document)
+    raw_order = workspace["tab_order"]
+    assert isinstance(raw_order, list)  # nosec B101
+    workspace["tab_order"] = [
+        replacement if tab_id == previous_id else tab_id for tab_id in raw_order
+    ]
+    for tile in _tiles(document):
+        if tile["tab_id"] == previous_id:
+            tile["tab_id"] = replacement
+
+
+def test_validate_v1_accepts_exact_shape_and_name_independence() -> None:
+    document = _valid_v1()
+    _application(document)["title"] = ""
+    _workspace(document)["name"] = "工作区"
+    _tabs(document)[0]["name"] = "主要"
+    document["extensions"] = {
+        schema.LEGACY_EXTENSION_NAMESPACE: {
+            "arbitrary": [None, True, -1, 1.5, "秘密", {"nested": "kept"}]
+        }
+    }
+
+    assert schema.validate_v1(document)  # nosec B101
+
+
+def test_validate_v1_accepts_utf8_unicode_and_preserves_it_unchanged() -> None:
+    emoji = cast(str, json.loads(r'"\ud83d\ude00"'))
+    document = _valid_v1()
+    _application(document)["title"] = f"Café 東京 {emoji}"
+    _workspace(document)["name"] = "默认工作区"
+    _tabs(document)[0]["name"] = "主要"
+    tile = _tiles(document)[0]
+    tile["name"] = "邮件"
+    tile["url"] = "https://例子.test/路径"
+    tile["icon"] = "图标.png"
+    tile["bg"] = "蓝色"
+    tile["browser"] = "浏览器"
+    tile["chrome_profile"] = "个人资料"
+    document["extensions"] = {
+        schema.LEGACY_EXTENSION_NAMESPACE: {
+            "扩展键": {"嵌套": ["秘密", emoji]},
+        }
+    }
+    original = deepcopy(document)
+
+    assert schema.validate_v1(document)  # nosec B101
+    assert document == original  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("location", "field"),
+    [
+        ("application", "title"),
+        ("workspace", "name"),
+        ("tab", "name"),
+        ("tile", "name"),
+        ("tile", "url"),
+        ("tile", "icon"),
+        ("tile", "bg"),
+        ("tile", "browser"),
+        ("tile", "chrome_profile"),
+    ],
+)
+@pytest.mark.parametrize("escaped_surrogate", [r'"\ud800"', r'"\udfff"'])
+def test_validate_v1_rejects_lone_surrogates_in_schema_strings(
+    location: str,
+    field: str,
+    escaped_surrogate: str,
+) -> None:
+    containers: dict[
+        str,
+        Callable[[schema.JsonObject], dict[str, schema.JsonValue]],
+    ] = {
+        "application": _application,
+        "workspace": _workspace,
+        "tab": lambda document: _tabs(document)[0],
+        "tile": lambda document: _tiles(document)[0],
+    }
+    document = _valid_v1()
+    surrogate = cast(str, json.loads(escaped_surrogate))
+    containers[location](document)[field] = surrogate
+
+    assert not schema.validate_v1(document)  # nosec B101
+
+
+@pytest.mark.parametrize("escaped_surrogate", [r'"\ud800"', r'"\udfff"'])
+def test_validate_v1_rejects_lone_surrogates_in_legacy_extension_tree(
+    escaped_surrogate: str,
+) -> None:
+    surrogate = cast(str, json.loads(escaped_surrogate))
+    payloads: tuple[schema.JsonObject, ...] = (
+        {surrogate: "direct key"},
+        {"nested": {surrogate: "nested key"}},
+        {"nested": ["value", surrogate]},
+    )
+
+    for payload in payloads:
+        document = _valid_v1()
+        document["extensions"] = {schema.LEGACY_EXTENSION_NAMESPACE: payload}
+        assert not schema.validate_v1(document)  # nosec B101
+
+
+def test_validate_v1_rejects_overdeep_extension_without_raising() -> None:
+    payload: schema.JsonObject = {}
+    cursor = payload
+    for _ in range(1_500):
+        nested: schema.JsonObject = {}
+        cursor["nested"] = nested
+        cursor = nested
+    document = _valid_v1()
+    document["extensions"] = {schema.LEGACY_EXTENSION_NAMESPACE: payload}
+
+    assert not schema.validate_v1(document)  # nosec B101
+
+
+def test_validate_v1_rejects_missing_and_unknown_fields_at_every_level() -> None:
+    locations = (
+        (lambda doc: doc, "columns"),
+        (_application, "title"),
+        (_workspace, "name"),
+        (lambda doc: _tabs(doc)[0], "visibility"),
+        (lambda doc: _tiles(doc)[0], "chrome_profile"),
+    )
+    for locate, field in locations:
+        missing = _valid_v1()
+        del locate(missing)[field]
+        assert not schema.validate_v1(missing)  # nosec B101
+
+        unknown = _valid_v1()
+        locate(unknown)["unexpected"] = "retained nowhere"
+        assert not schema.validate_v1(unknown)  # nosec B101
+
+
+@pytest.mark.parametrize("marker", [True, False, 0, 2, 1.0, "1", None])
+def test_validate_v1_requires_integer_marker_one(marker: object) -> None:
+    document = _valid_v1()
+    document["schema_version"] = cast(schema.JsonValue, marker)
+
+    assert not schema.validate_v1(document)  # nosec B101
+
+
+def test_validate_v1_requires_exactly_one_resolving_workspace() -> None:
+    missing = _valid_v1()
+    missing["workspaces"] = []
+    assert not schema.validate_v1(missing)  # nosec B101
+
+    multiple = _valid_v1()
+    workspaces = multiple["workspaces"]
+    assert isinstance(workspaces, list)  # nosec B101
+    workspaces.append(deepcopy(workspaces[0]))
+    assert not schema.validate_v1(multiple)  # nosec B101
+
+    unresolved_default = _valid_v1()
+    _application(unresolved_default)["default_workspace_id"] = OTHER_ID
+    assert not schema.validate_v1(unresolved_default)  # nosec B101
+
+    empty_name = _valid_v1()
+    _workspace(empty_name)["name"] = ""
+    assert not schema.validate_v1(empty_name)  # nosec B101
+
+
+@pytest.mark.parametrize("bad_id", NONCANONICAL_IDS)
+def test_application_default_workspace_id_requires_canonical_text(
+    bad_id: object,
+) -> None:
+    application = deepcopy(_application(_valid_v1()))
+    application["default_workspace_id"] = cast(schema.JsonValue, bad_id)
+
+    assert schema._valid_application(application) is None  # nosec B101
+
+
+@pytest.mark.parametrize("bad_id", NONCANONICAL_IDS)
+def test_workspace_id_requires_canonical_text(bad_id: object) -> None:
+    workspace = deepcopy(_workspace(_valid_v1()))
+    workspace["id"] = cast(schema.JsonValue, bad_id)
+
+    assert schema._valid_workspace(workspace) is None  # nosec B101
+
+
+@pytest.mark.parametrize("bad_id", NONCANONICAL_IDS)
+def test_tab_id_requires_canonical_text(bad_id: object) -> None:
+    tabs = deepcopy(_tabs(_valid_v1()))
+    tabs[0]["id"] = cast(schema.JsonValue, bad_id)
+
+    assert schema._valid_tabs(tabs, WORKSPACE_ID) is None  # nosec B101
+
+
+@pytest.mark.parametrize("bad_id", NONCANONICAL_IDS)
+def test_validate_v1_rejects_noncanonical_resolving_workspace_graph(
+    bad_id: object,
+) -> None:
+    document = _valid_v1()
+    replacement = cast(schema.JsonValue, bad_id)
+    _replace_workspace_identity(document, replacement)
+
+    assert _application(document)["default_workspace_id"] == replacement  # nosec B101
+    assert _workspace(document)["id"] == replacement  # nosec B101
+    assert all(  # nosec B101
+        tab["workspace_id"] == replacement for tab in _tabs(document)
+    )
+    assert not schema.validate_v1(document)  # nosec B101
+
+
+@pytest.mark.parametrize("bad_id", NONCANONICAL_IDS)
+def test_validate_v1_rejects_noncanonical_tab_id_with_resolving_references(
+    bad_id: object,
+) -> None:
+    document = _valid_v1()
+    replacement = cast(schema.JsonValue, bad_id)
+    _replace_tab_identity(document, 0, replacement)
+
+    assert _workspace(document)["tab_order"] == [replacement, WORK_ID]  # nosec B101
+    assert _tiles(document)[0]["tab_id"] == replacement  # nosec B101
+
+    assert not schema.validate_v1(document)  # nosec B101
+
+
+def test_validate_v1_rejects_global_identity_collision_and_invalid_ownership() -> None:
+    workspace_collision = _valid_v1()
+    _replace_tab_identity(workspace_collision, 0, WORKSPACE_ID)
+    assert _workspace(workspace_collision)["tab_order"] == [  # nosec B101
+        WORKSPACE_ID,
+        WORK_ID,
+    ]
+    assert _tiles(workspace_collision)[0]["tab_id"] == WORKSPACE_ID  # nosec B101
+    assert not schema.validate_v1(workspace_collision)  # nosec B101
+
+    wrong_owner = _valid_v1()
+    _tabs(wrong_owner)[0]["workspace_id"] = OTHER_ID
+    assert not schema.validate_v1(wrong_owner)  # nosec B101
+
+
+def test_validate_v1_requires_complete_unique_tab_order() -> None:
+    for order in (
+        [MAIN_ID],
+        [MAIN_ID, MAIN_ID],
+        [MAIN_ID, DANGLING_ID],
+        [MAIN_ID, WORK_ID, WORK_ID],
+    ):
+        document = _valid_v1()
+        _workspace(document)["tab_order"] = order
+        assert not schema.validate_v1(document)  # nosec B101
+
+
+def test_validate_v1_requires_nonempty_unique_tabs_and_one_visible() -> None:
+    no_tabs = _valid_v1()
+    no_tabs["tabs"] = []
+    assert not schema.validate_v1(no_tabs)  # nosec B101
+
+    duplicate_name = _valid_v1()
+    _tabs(duplicate_name)[1]["name"] = "Main"
+    assert not schema.validate_v1(duplicate_name)  # nosec B101
+
+    empty_name = _valid_v1()
+    _tabs(empty_name)[0]["name"] = ""
+    assert not schema.validate_v1(empty_name)  # nosec B101
+
+    all_hidden = _valid_v1()
+    _tabs(all_hidden)[0]["visibility"] = "hidden"
+    assert not schema.validate_v1(all_hidden)  # nosec B101
+
+    invalid_visibility = _valid_v1()
+    _tabs(invalid_visibility)[0]["visibility"] = "archived"
+    assert not schema.validate_v1(invalid_visibility)  # nosec B101
+
+
+def test_validate_v1_requires_exact_tile_fields_and_resolving_membership() -> None:
+    legacy_membership = _valid_v1()
+    tile = _tiles(legacy_membership)[0]
+    del tile["tab_id"]
+    tile["tab"] = "Main"
+    assert not schema.validate_v1(legacy_membership)  # nosec B101
+
+    unresolved = _valid_v1()
+    _tiles(unresolved)[0]["tab_id"] = DANGLING_ID
+    assert not schema.validate_v1(unresolved)  # nosec B101
+
+    unhashable_membership = _valid_v1()
+    _tiles(unhashable_membership)[0]["tab_id"] = [MAIN_ID]
+    assert not schema.validate_v1(unhashable_membership)  # nosec B101
+
+    omitted_nullable = _valid_v1()
+    del _tiles(omitted_nullable)[0]["icon"]
+    assert not schema.validate_v1(omitted_nullable)  # nosec B101
+
+    wrong_nullable_type = _valid_v1()
+    _tiles(wrong_nullable_type)[0]["browser"] = False
+    assert not schema.validate_v1(wrong_nullable_type)  # nosec B101
+
+    wrong_target = _valid_v1()
+    _tiles(wrong_target)[0]["open_target"] = "default"
+    assert not schema.validate_v1(wrong_target)  # nosec B101
+
+
+def test_validate_v1_uses_current_integer_and_boolean_domains() -> None:
+    for field in ("columns", "window_x", "window_y", "window_w", "window_h"):
+        document = _valid_v1()
+        document[field] = True
+        assert not schema.validate_v1(document)  # nosec B101
+
+    wrong_auto_fit = _valid_v1()
+    wrong_auto_fit["auto_fit"] = 1
+    assert not schema.validate_v1(wrong_auto_fit)  # nosec B101
+
+    integers = _valid_v1()
+    integers["columns"] = -999
+    integers["window_x"] = 0
+    assert schema.validate_v1(integers)  # nosec B101
+
+
+def test_validate_v1_allows_only_the_fixed_finite_legacy_extension() -> None:
+    wrong_namespace = _valid_v1()
+    wrong_namespace["extensions"] = {"example.other": {}}
+    assert not schema.validate_v1(wrong_namespace)  # nosec B101
+
+    extra_namespace = _valid_v1()
+    extra_namespace["extensions"] = {
+        schema.LEGACY_EXTENSION_NAMESPACE: {},
+        "example.other": {},
+    }
+    assert not schema.validate_v1(extra_namespace)  # nosec B101
+
+    wrong_payload = _valid_v1()
+    wrong_payload["extensions"] = {schema.LEGACY_EXTENSION_NAMESPACE: []}
+    assert not schema.validate_v1(wrong_payload)  # nosec B101
+
+    nonfinite = _valid_v1()
+    nonfinite["extensions"] = {schema.LEGACY_EXTENSION_NAMESPACE: {"bad": float("nan")}}
+    assert not schema.validate_v1(nonfinite)  # nosec B101
+
+    nested_extension = _valid_v1()
+    _application(nested_extension)["extensions"] = {"unexpected": True}
+    assert not schema.validate_v1(nested_extension)  # nosec B101
+
+
+def test_validate_v0_reuses_shallow_legacy_contract() -> None:
+    accepted: schema.JsonObject = {
+        "tabs": ["Main", False, None, ["filtered"]],
+        "hidden_tabs": ["Main", 3],
+        "tab_ids": ["tolerated malformed hint"],
+        "tab_order": {"tolerated": "malformed hint"},
+        "unknown": {"strict": [True, None]},
+    }
+    assert schema.validate_v0(accepted)  # nosec B101
+
+    assert not schema.validate_v0({"columns": True})  # nosec B101
+    assert not schema.validate_v0({"tiles": [{"name": "Missing URL"}]})  # nosec B101
+    assert not schema.validate_v0({"schema_version": 1})  # nosec B101
+
+
+@pytest.mark.parametrize("title", ["Custom", "", "Launcher", "起動器"])
+def test_migration_keeps_application_title_independent_from_workspace(
+    title: str,
+) -> None:
+    candidate = schema.migrate_v0_to_v1({"title": title})
+
+    assert candidate is not None  # nosec B101
+    assert _application(candidate)["title"] == title  # nosec B101
+    assert _workspace(candidate)["name"] == "Default Workspace"  # nosec B101
+
+
+def test_migration_materializes_all_legacy_and_tile_defaults() -> None:
+    candidate = schema.migrate_v0_to_v1(
+        {"tiles": [{"name": "Defaulted", "url": "example.test"}]}
+    )
+
+    assert candidate is not None  # nosec B101
+    assert schema.validate_v1(candidate)  # nosec B101
+    assert _application(candidate)["title"] == "Launcher"  # nosec B101
+    assert candidate["columns"] == 5  # nosec B101
+    assert candidate["auto_fit"] is True  # nosec B101
+    assert all(  # nosec B101
+        candidate[field] is None
+        for field in ("window_x", "window_y", "window_w", "window_h")
+    )
+    tab = _tabs(candidate)[0]
+    tile = _tiles(candidate)[0]
+    assert tab["name"] == "Main"  # nosec B101
+    assert tile == {  # nosec B101
+        "name": "Defaulted",
+        "url": "example.test",
+        "tab_id": tab["id"],
+        "icon": None,
+        "bg": "#F5F6FA",
+        "browser": None,
+        "chrome_profile": None,
+        "open_target": "tab",
+    }
+
+
+def test_migration_missing_tile_tab_appends_main_after_explicit_work() -> None:
+    candidate = schema.migrate_v0_to_v1(
+        {
+            "tabs": ["Work"],
+            "tiles": [{"name": "Implicit", "url": "example.test"}],
+        }
+    )
+
+    assert candidate is not None  # nosec B101
+    tabs = _tabs(candidate)
+    assert [tab["name"] for tab in tabs] == ["Work", "Main"]  # nosec B101
+    assert _workspace(candidate)["tab_order"] == [  # nosec B101
+        tab["id"] for tab in tabs
+    ]
+    assert _tiles(candidate)[0]["tab_id"] == tabs[1]["id"]  # nosec B101
+    assert _tiles(candidate)[0]["tab_id"] != tabs[0]["id"]  # nosec B101
+
+
+def test_migration_preserves_tile_fields_order_membership_and_unknown_fields() -> None:
+    source: schema.JsonObject = {
+        "title": "Legacy",
+        "columns": 8,
+        "auto_fit": False,
+        "window_x": -1,
+        "window_y": 2,
+        "window_w": 3,
+        "window_h": 4,
+        "tabs": ["Main", 7, "Work", "Main"],
+        "hidden_tabs": ["Unknown", "Work", "Work"],
+        "tiles": [
+            {"name": "Implicit", "url": "first.example"},
+            {
+                "name": "Complete",
+                "url": "second.example",
+                "tab": "Work",
+                "icon": "icon.png",
+                "bg": "#123456",
+                "browser": "chrome",
+                "chrome_profile": "Profile 1",
+                "open_target": "window",
+            },
+            {"name": "Tile only", "url": "third.example", "tab": "Personal"},
+        ],
+        "unrecognized": {"nested": ["preserved", 3.5]},
+    }
+    original = deepcopy(source)
+
+    candidate = schema.migrate_v0_to_v1(source)
+
+    assert candidate is not None  # nosec B101
+    assert source == original  # nosec B101
+    assert [tab["name"] for tab in _tabs(candidate)] == [  # nosec B101
+        "Main",
+        "Work",
+        "Personal",
+    ]
+    tab_ids = {str(tab["name"]): tab["id"] for tab in _tabs(candidate)}
+    tiles = _tiles(candidate)
+    assert [tile["name"] for tile in tiles] == [  # nosec B101
+        "Implicit",
+        "Complete",
+        "Tile only",
+    ]
+    assert [tile["tab_id"] for tile in tiles] == [  # nosec B101
+        tab_ids["Main"],
+        tab_ids["Work"],
+        tab_ids["Personal"],
+    ]
+    assert tiles[1] == {  # nosec B101
+        "name": "Complete",
+        "url": "second.example",
+        "tab_id": tab_ids["Work"],
+        "icon": "icon.png",
+        "bg": "#123456",
+        "browser": "chrome",
+        "chrome_profile": "Profile 1",
+        "open_target": "window",
+    }
+    assert candidate["extensions"] == {  # nosec B101
+        schema.LEGACY_EXTENSION_NAMESPACE: {
+            "unrecognized": {"nested": ["preserved", 3.5]}
+        }
+    }
+
+
+def test_migration_retains_canonicalized_ids_and_applies_saved_order() -> None:
+    source: schema.JsonObject = {
+        "tabs": ["Main", "Work", "Personal"],
+        "tab_ids": {
+            "Main": MAIN_ID.upper(),
+            "Work": WORK_ID,
+            "Personal": "malformed",
+            "Removed": DANGLING_ID,
+        },
+        "tab_order": [
+            None,
+            WORK_ID,
+            DANGLING_ID,
+            MAIN_ID.upper(),
+            WORK_ID,
+            "malformed",
+        ],
+    }
+
+    candidate = schema.migrate_v0_to_v1(source)
+
+    assert candidate is not None  # nosec B101
+    tabs = _tabs(candidate)
+    assert [tab["name"] for tab in tabs] == ["Work", "Main", "Personal"]  # nosec B101
+    assert tabs[0]["id"] == WORK_ID  # nosec B101
+    assert tabs[1]["id"] == MAIN_ID  # nosec B101
+    assert tabs[2]["id"] not in {MAIN_ID, WORK_ID, DANGLING_ID}  # nosec B101
+    assert _workspace(candidate)["tab_order"] == [tab["id"] for tab in tabs]  # nosec B101
+
+
+def test_migration_duplicate_id_is_retained_only_by_first_discovered_tab() -> None:
+    candidate = schema.migrate_v0_to_v1(
+        {
+            "tabs": ["First", "Second"],
+            "tab_ids": {"First": MAIN_ID, "Second": MAIN_ID},
+            "tab_order": [MAIN_ID],
+        }
+    )
+
+    assert candidate is not None  # nosec B101
+    tabs = _tabs(candidate)
+    assert [tab["name"] for tab in tabs] == ["First", "Second"]  # nosec B101
+    assert tabs[0]["id"] == MAIN_ID  # nosec B101
+    assert tabs[1]["id"] != MAIN_ID  # nosec B101
+
+
+def test_malformed_identity_hints_are_tolerated_as_absent() -> None:
+    malformed = schema.migrate_v0_to_v1(
+        {"tabs": ["A", "B"], "tab_ids": [], "tab_order": {"bad": True}}
+    )
+    absent = schema.migrate_v0_to_v1({"tabs": ["A", "B"]})
+
+    assert malformed is not None and absent is not None  # nosec B101
+    assert [tab["name"] for tab in _tabs(malformed)] == ["A", "B"]  # nosec B101
+    assert [tab["name"] for tab in _tabs(absent)] == ["A", "B"]  # nosec B101
+    assert schema.validate_v1(malformed)  # nosec B101
+    assert schema.validate_v1(absent)  # nosec B101
+
+
+def test_migration_deduplicates_filters_and_appends_tile_only_tabs() -> None:
+    candidate = schema.migrate_v0_to_v1(
+        {
+            "tabs": [False, "A", "A", None, "B"],
+            "tiles": [
+                {"name": "C tile", "url": "c.example", "tab": "C"},
+                {"name": "A tile", "url": "a.example", "tab": "A"},
+                {"name": "D tile", "url": "d.example", "tab": "D"},
+            ],
+        }
+    )
+
+    assert candidate is not None  # nosec B101
+    assert [tab["name"] for tab in _tabs(candidate)] == ["A", "B", "C", "D"]  # nosec B101
+
+
+def test_migration_large_ordered_dedup_characterization_is_stable() -> None:
+    count = 512
+    names = [f"Tab {index}" for index in range(count)]
+    identifiers = {name: str(UUID(int=index + 1)) for index, name in enumerate(names)}
+    expected_names = list(reversed(names))
+    ordered_ids = [identifiers[name] for name in expected_names]
+    source = cast(
+        schema.JsonObject,
+        {
+            "tabs": names + names,
+            "tab_ids": identifiers,
+            "tab_order": ordered_ids + ordered_ids,
+            "hidden_tabs": names + names,
+        },
+    )
+
+    candidate = schema.migrate_v0_to_v1(source)
+
+    assert candidate is not None  # nosec B101
+    tabs = _tabs(candidate)
+    assert [tab["name"] for tab in tabs] == expected_names  # nosec B101
+    assert _workspace(candidate)["tab_order"] == ordered_ids  # nosec B101
+    assert tabs[0]["visibility"] == "visible"  # nosec B101
+    assert all(tab["visibility"] == "hidden" for tab in tabs[1:])  # nosec B101
+    assert schema.validate_v1(candidate)  # nosec B101
+
+
+def test_migration_all_hidden_makes_first_final_ordered_tab_visible() -> None:
+    candidate = schema.migrate_v0_to_v1(
+        {
+            "tabs": ["A", "B"],
+            "hidden_tabs": ["A", "B", "A", "Unknown"],
+            "tab_ids": {"A": MAIN_ID, "B": WORK_ID},
+            "tab_order": [WORK_ID, MAIN_ID],
+        }
+    )
+
+    assert candidate is not None  # nosec B101
+    tabs = _tabs(candidate)
+    assert [(tab["name"], tab["visibility"]) for tab in tabs] == [  # nosec B101
+        ("B", "visible"),
+        ("A", "hidden"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {"tabs": [""]},
+        {"tiles": [{"name": "Empty", "url": "x", "tab": ""}]},
+    ],
+)
+def test_migration_rejects_empty_tab_names_without_repair(
+    source: schema.JsonObject,
+) -> None:
+    original = deepcopy(source)
+
+    assert schema.migrate_v0_to_v1(source) is None  # nosec B101
+    assert source == original  # nosec B101
+
+
+def test_migration_rejects_nonfinite_unknown_before_candidate_creation() -> None:
+    source: schema.JsonObject = {"unknown": {"private": float("inf")}}
+
+    assert schema.validate_v0(source)  # nosec B101
+    assert schema.migrate_v0_to_v1(source) is None  # nosec B101
+
+
+def test_exact_empty_v0_digest_uuidv5_vector_and_replay() -> None:
+    expected_workspace = "8b66f209-e64d-50d9-b534-144cac41f7bf"
+    expected_tab = "97587f7c-ca79-5cb7-ad4d-c9e4cd08683d"
+
+    first = schema.migrate_v0_to_v1({})
+    second = schema.migrate_v0_to_v1(json.loads("{}"))
+
+    assert first == second  # nosec B101
+    assert first is not None  # nosec B101
+    assert _workspace(first)["id"] == expected_workspace  # nosec B101
+    assert _tabs(first)[0]["id"] == expected_tab  # nosec B101
+    serialized = json.dumps(
+        first,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ).encode("utf-8")
+    assert serialized.endswith(b"}")  # nosec B101
+    assert not serialized.endswith(b"\n")  # nosec B101
+
+
+def test_canonical_source_changes_change_generated_identities() -> None:
+    plain = schema.migrate_v0_to_v1({})
+    with_unknown = schema.migrate_v0_to_v1({"unknown": "preserved"})
+
+    assert plain is not None and with_unknown is not None  # nosec B101
+    assert _workspace(plain)["id"] != _workspace(with_unknown)["id"]  # nosec B101
+    assert _tabs(plain)[0]["id"] != _tabs(with_unknown)[0]["id"]  # nosec B101
+
+
+def test_migration_rejects_reserved_workspace_collision_without_retry() -> None:
+    calls: list[str] = []
+
+    def collide(_namespace: UUID, name: str) -> UUID:
+        calls.append(name)
+        return UUID(V5_WORKSPACE_ID)
+
+    result = schema.migrate_v0_to_v1(
+        {"tab_ids": {"Removed": V5_WORKSPACE_ID}},
+        uuid5_factory=collide,
+    )
+
+    assert result is None  # nosec B101
+    assert len(calls) == 1  # nosec B101
+    assert calls[0].endswith("/workspace/0")  # nosec B101
+
+
+def test_migration_rejects_reserved_tab_collision_without_retry() -> None:
+    calls: list[str] = []
+
+    def collide_on_tab(_namespace: UUID, name: str) -> UUID:
+        calls.append(name)
+        return UUID(V5_WORKSPACE_ID if name.endswith("/workspace/0") else V5_TAB_ID)
+
+    result = schema.migrate_v0_to_v1(
+        {"tab_ids": {"Removed": V5_TAB_ID}},
+        uuid5_factory=collide_on_tab,
+    )
+
+    assert result is None  # nosec B101
+    assert len(calls) == 2  # nosec B101
+    assert calls[1].endswith("/tab/0")  # nosec B101
+
+
+def test_migration_rejects_collision_between_derived_ids() -> None:
+    calls = 0
+
+    def repeat(_namespace: UUID, _name: str) -> UUID:
+        nonlocal calls
+        calls += 1
+        return UUID(V5_WORKSPACE_ID)
+
+    result = schema.migrate_v0_to_v1({}, uuid5_factory=repeat)
+
+    assert result is None  # nosec B101
+    assert calls == 2  # nosec B101
+
+
+def _allocator(values: list[str | UUID]) -> Callable[[], str | UUID]:
+    remaining = iter(values)
+    return lambda: next(remaining)
+
+
+def test_build_native_v1_is_exact_friendly_configuration() -> None:
+    document = schema.build_native_v1(_allocator([UUID(WORKSPACE_ID), UUID(MAIN_ID)]))
+
+    assert schema.validate_v1(document)  # nosec B101
+    assert _application(document) == {  # nosec B101
+        "title": "My Launcher",
+        "default_workspace_id": WORKSPACE_ID,
+        "extensions": {},
+    }
+    assert _workspace(document) == {  # nosec B101
+        "id": WORKSPACE_ID,
+        "name": "Default Workspace",
+        "tab_order": [MAIN_ID],
+        "extensions": {},
+    }
+    assert _tabs(document) == [  # nosec B101
+        {
+            "id": MAIN_ID,
+            "workspace_id": WORKSPACE_ID,
+            "name": "Main",
+            "visibility": "visible",
+            "extensions": {},
+        }
+    ]
+    assert [tile["name"] for tile in _tiles(document)] == [  # nosec B101
+        "ChatGPT",
+        "Gmail",
+        "Notion",
+    ]
+    assert all(tile["tab_id"] == MAIN_ID for tile in _tiles(document))  # nosec B101
+    assert document["columns"] == 5  # nosec B101
+    assert document["auto_fit"] is True  # nosec B101
+    assert document["extensions"] == {}  # nosec B101
+
+
+def test_build_native_v1_retries_invalid_noncanonical_and_colliding_ids() -> None:
+    document = schema.build_native_v1(
+        _allocator(
+            [
+                "not-a-uuid",
+                WORKSPACE_ID.upper(),
+                WORKSPACE_ID,
+                WORKSPACE_ID,
+                UUID(MAIN_ID),
+            ]
+        )
+    )
+
+    assert _workspace(document)["id"] == WORKSPACE_ID  # nosec B101
+    assert _tabs(document)[0]["id"] == MAIN_ID  # nosec B101
+
+
+def test_build_native_v1_rejects_non_v4_and_exhausted_allocation() -> None:
+    version_five = "8b66f209-e64d-50d9-b534-144cac41f7bf"
+
+    with pytest.raises(schema.NativeV1ConstructionError) as exc_info:
+        schema.build_native_v1(
+            lambda: version_five,
+        )
+
+    assert str(exc_info.value) == "native_v1_identity_allocation_failed"  # nosec B101
+
+
+def test_build_native_v1_sanitizes_allocator_failure() -> None:
+    def fail() -> str:
+        raise RuntimeError("private allocator details")
+
+    with pytest.raises(schema.NativeV1ConstructionError) as exc_info:
+        schema.build_native_v1(fail)
+
+    assert "private" not in str(exc_info.value)  # nosec B101
+    assert exc_info.value.__cause__ is None  # nosec B101
+
+
+def test_pure_schema_layer_has_no_qt_or_ambient_identity_inputs() -> None:
+    tree = ast.parse(inspect.getsource(schema))
+    imports: set[tuple[str, str, str | None, int]] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update((alias.name, "", alias.asname, 0) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.update(
+                (node.module or "", alias.name, alias.asname, node.level)
+                for alias in node.names
+            )
+
+    expected_imports: set[tuple[str, str, str | None, int]] = {
+        ("__future__", "annotations", None, 0),
+        ("hashlib", "", None, 0),
+        ("json", "", None, 0),
+        ("math", "", None, 0),
+        ("collections.abc", "Callable", None, 0),
+        ("collections.abc", "Mapping", None, 0),
+        ("typing", "Final", None, 0),
+        ("typing", "TypeAlias", None, 0),
+        ("typing", "cast", None, 0),
+        ("uuid", "NAMESPACE_URL", None, 0),
+        ("uuid", "UUID", None, 0),
+        ("uuid", "uuid5", None, 0),
+        ("config_recovery", "LegacyConstructionFailure", None, 0),
+        ("config_recovery", "validate_legacy_mapping", None, 0),
+    }
+    assert imports == expected_imports  # nosec B101
+
+    locally_defined = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef))
+    }
+    allowed_name_calls = locally_defined | {
+        "UUID",
+        "all",
+        "allocator",
+        "any",
+        "cast",
+        "dict",
+        "enumerate",
+        "frozenset",
+        "id",
+        "isinstance",
+        "len",
+        "range",
+        "set",
+        "str",
+        "super",
+        "type",
+        "uuid5_factory",
+        "validate_legacy_mapping",
+    }
+    name_calls = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert name_calls <= allowed_name_calls  # nosec B101
+
+    allowed_attribute_calls = {
+        "__init__",
+        "add",
+        "append",
+        "dumps",
+        "encode",
+        "get",
+        "hexdigest",
+        "isfinite",
+        "items",
+        "loads",
+        "lower",
+        "remove",
+        "sha256",
+        "values",
+    }
+    attribute_calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert attribute_calls <= allowed_attribute_calls  # nosec B101

--- a/tests/unit/test_hidden_tabs.py
+++ b/tests/unit/test_hidden_tabs.py
@@ -1,12 +1,207 @@
 from __future__ import annotations
 
+import copy
 import json
 
 import pytest
 
 pytest.importorskip("PySide6.QtWidgets")
 
-from tile_launcher import LauncherConfig
+import config_migration
+import config_persistence
+import config_schema
+import tile_launcher
+from tile_launcher import LauncherConfig, Main
+
+
+_WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+_MAIN_ID = "22222222-2222-4222-8222-222222222222"
+_WORK_ID = "33333333-3333-4333-8333-333333333333"
+_ARCHIVE_ID = "44444444-4444-4444-8444-444444444444"
+_ROOT_EXTENSION = {
+    config_schema.LEGACY_EXTENSION_NAMESPACE: {
+        "retained": {"nested": ["value", 7, True]}
+    }
+}
+
+
+def _runtime_config() -> LauncherConfig:
+    identifiers = iter((_WORKSPACE_ID, _MAIN_ID))
+    document = config_schema.build_native_v1(lambda: next(identifiers))
+    application = document["application"]
+    workspace = document["workspaces"][0]
+    main_tab = document["tabs"][0]
+    assert isinstance(application, dict)  # nosec B101
+    assert isinstance(workspace, dict)  # nosec B101
+    assert isinstance(main_tab, dict)  # nosec B101
+
+    application["title"] = "Independent Application Title"
+    workspace["name"] = "Custom Workspace"
+    workspace["tab_order"] = [_MAIN_ID, _WORK_ID, _ARCHIVE_ID]
+    document["tabs"] = [
+        main_tab,
+        {
+            "id": _WORK_ID,
+            "workspace_id": _WORKSPACE_ID,
+            "name": "Work",
+            "visibility": "visible",
+            "extensions": {},
+        },
+        {
+            "id": _ARCHIVE_ID,
+            "workspace_id": _WORKSPACE_ID,
+            "name": "Archive",
+            "visibility": "hidden",
+            "extensions": {},
+        },
+    ]
+    document["tiles"] = [
+        {
+            "name": "Main A",
+            "url": "https://main-a.example.test/",
+            "tab_id": _MAIN_ID,
+            "icon": None,
+            "bg": "#F5F6FA",
+            "browser": None,
+            "chrome_profile": None,
+            "open_target": "tab",
+        },
+        {
+            "name": "Work X",
+            "url": "https://work-x.example.test/",
+            "tab_id": _WORK_ID,
+            "icon": None,
+            "bg": "#F5F6FA",
+            "browser": None,
+            "chrome_profile": None,
+            "open_target": "tab",
+        },
+        {
+            "name": "Main B",
+            "url": "https://main-b.example.test/",
+            "tab_id": _MAIN_ID,
+            "icon": None,
+            "bg": "#F5F6FA",
+            "browser": None,
+            "chrome_profile": None,
+            "open_target": "tab",
+        },
+        {
+            "name": "Archive Z",
+            "url": "https://archive-z.example.test/",
+            "tab_id": _ARCHIVE_ID,
+            "icon": None,
+            "bg": "#F5F6FA",
+            "browser": None,
+            "chrome_profile": None,
+            "open_target": "tab",
+        },
+    ]
+    document["extensions"] = copy.deepcopy(_ROOT_EXTENSION)
+    assert config_schema.validate_v1(document)  # nosec B101
+    return LauncherConfig.from_v1_mapping(document)
+
+
+class _TabBar:
+    def __init__(self, tab_ids: list[str]) -> None:
+        self._tab_ids = tab_ids
+
+    def count(self) -> int:
+        return len(self._tab_ids)
+
+    def tabData(self, index: int) -> str:
+        return self._tab_ids[index]
+
+
+class _TabsWidget:
+    def __init__(self, tab_ids: list[str]) -> None:
+        self._tab_bar = _TabBar(tab_ids)
+
+    def tabBar(self) -> _TabBar:
+        return self._tab_bar
+
+
+class _AutoFitAction:
+    def __init__(self, *, checked: bool) -> None:
+        self.checked = checked
+        self.signals_blocked = False
+        self.block_calls: list[bool] = []
+        self.set_checked_calls: list[tuple[bool, bool]] = []
+
+    def blockSignals(self, blocked: bool) -> bool:
+        previous = self.signals_blocked
+        self.signals_blocked = blocked
+        self.block_calls.append(blocked)
+        return previous
+
+    def setChecked(self, checked: bool) -> None:
+        self.set_checked_calls.append((checked, self.signals_blocked))
+        if not self.signals_blocked:
+            raise AssertionError("Auto-fit rollback must not emit the toggled signal")
+        self.checked = checked
+
+
+class _RuntimeHarness:
+    def __init__(self, cfg: LauncherConfig, *, current_tab: str = "Main") -> None:
+        self.cfg = cfg
+        self._current_tab = current_tab
+        self._active_refresh = None
+        self.tabs_widget = _TabsWidget([])
+        self.rebuild_count = 0
+        self.selected_tabs: list[str] = []
+        self.populated_tabs: list[str] = []
+        self._computed_columns = 17
+        self.auto_fit_action = _AutoFitAction(checked=cfg.auto_fit)
+        self.resize_calls: list[bool] = []
+
+    def _selection_active(self) -> bool:
+        return False
+
+    def current_tab(self) -> str:
+        return self._current_tab
+
+    def _visible_tabs(self) -> list[str]:
+        return [tab for tab in self.cfg.tabs if tab not in self.cfg.hidden_tabs]
+
+    def rebuild(self) -> None:
+        self.rebuild_count += 1
+
+    def _set_current_tab_by_name(self, tab: str) -> None:
+        if tab in self._visible_tabs():
+            self._current_tab = tab
+            self.selected_tabs.append(tab)
+
+    def _populate_tab(self, tab: str) -> None:
+        self.populated_tabs.append(tab)
+
+    def resize_to_fit_tiles(self, *, snap_window: bool) -> None:
+        self.resize_calls.append(snap_window)
+
+    def set_visible_ids_after_move(self, tab_ids: list[str]) -> None:
+        self.tabs_widget = _TabsWidget(tab_ids)
+
+
+def _install_add_tile_dialog(monkeypatch, data: dict[str, object]) -> None:
+    class TabCombo:
+        def __init__(self) -> None:
+            self.current_index: int | None = None
+
+        def findText(self, text: str, _match_flag: object) -> int:
+            return 1 if text == "Work" else -1
+
+        def setCurrentIndex(self, index: int) -> None:
+            self.current_index = index
+
+    class AddTileDialog:
+        def __init__(self, **_kwargs: object) -> None:
+            self.data = data
+            self.tab_combo = TabCombo()
+
+        def exec(self):
+            return tile_launcher.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(tile_launcher, "TileEditorDialog", AddTileDialog)
+    monkeypatch.setattr(tile_launcher, "available_browsers", lambda: [])
 
 
 @pytest.mark.unit
@@ -29,4 +224,944 @@ def test_hidden_tabs_load_and_save(tmp_path, monkeypatch):
     assert cfg.hidden_tabs == ["Extra"]
     cfg.save()
     data = json.loads(cfg_path.read_text())
-    assert data["hidden_tabs"] == ["Extra"]
+    assert data["schema_version"] == 1
+    assert "hidden_tabs" not in data
+    tabs = {tab["name"]: tab for tab in data["tabs"]}
+    assert tabs["Main"]["visibility"] == "visible"
+    assert tabs["Extra"]["visibility"] == "hidden"
+    assert data["tiles"][0]["tab_id"] == tabs["Extra"]["id"]
+
+
+@pytest.mark.unit
+def test_current_v1_load_is_no_write_and_save_preserves_identity(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    identifiers = iter(
+        (
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222",
+        )
+    )
+    document = config_schema.build_native_v1(lambda: next(identifiers))
+    workspace = document["workspaces"][0]
+    assert isinstance(workspace, dict)
+    workspace["name"] = "Custom Workspace"
+    document["extensions"] = {
+        config_schema.LEGACY_EXTENSION_NAMESPACE: {"retained": ["value"]}
+    }
+    original = json.dumps(
+        document, ensure_ascii=False, separators=(", ", ": ")
+    ).encode()
+    cfg_path.write_bytes(original)
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+
+    def forbid_write(*_args, **_kwargs):
+        raise AssertionError("valid current v1 startup must not write")
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_write)
+    cfg = LauncherConfig.load()
+
+    assert cfg_path.read_bytes() == original
+    assert cfg.workspace_id == "11111111-1111-4111-8111-111111111111"
+    assert cfg.workspace_name == "Custom Workspace"
+    assert cfg.tab_ids == {"Main": "22222222-2222-4222-8222-222222222222"}
+    assert {tile.tab_id for tile in cfg.tiles} == {
+        "22222222-2222-4222-8222-222222222222"
+    }
+
+    writes = []
+    monkeypatch.setattr(
+        tile_launcher,
+        "atomic_write_bytes",
+        lambda path, payload: writes.append((path, payload)),
+    )
+    cfg.save()
+    assert len(writes) == 1
+    saved = json.loads(writes[0][1])
+    assert saved["application"]["default_workspace_id"] == cfg.workspace_id
+    assert saved["workspaces"][0]["name"] == "Custom Workspace"
+    assert saved["tabs"][0]["id"] == cfg.tab_ids["Main"]
+    assert saved["extensions"] == document["extensions"]
+
+
+@pytest.mark.unit
+def test_missing_config_constructs_native_v1_and_restart_preserves_ids(
+    tmp_path, monkeypatch
+):
+    cfg_path = tmp_path / "config.json"
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+
+    created = LauncherConfig.load()
+    original = cfg_path.read_bytes()
+    document = json.loads(original)
+
+    assert config_schema.validate_v1(document)
+    assert created.title == "My Launcher"
+    assert created.workspace_name == "Default Workspace"
+    assert created.tabs == ["Main"]
+    assert {tile.tab_id for tile in created.tiles} == {created.tab_ids["Main"]}
+    created_ids = (created.workspace_id, dict(created.tab_ids))
+
+    def forbid_write(*_args, **_kwargs):
+        raise AssertionError("valid current v1 restart must not write")
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_write)
+    monkeypatch.setattr(config_migration, "atomic_write_bytes", forbid_write)
+    restarted = LauncherConfig.load()
+
+    assert cfg_path.read_bytes() == original
+    assert (restarted.workspace_id, restarted.tab_ids) == created_ids
+
+
+@pytest.mark.unit
+def test_q3_preserve_and_reset_installs_the_same_native_v1(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    original = b'{"malformed":'
+    cfg_path.write_bytes(original)
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    monkeypatch.setattr(
+        tile_launcher,
+        "_prompt_config_recovery",
+        lambda _category: tile_launcher._RecoveryChoice.PRESERVE_AND_RESET,
+    )
+
+    startup = tile_launcher._resolve_startup_configuration()
+
+    assert isinstance(startup, tile_launcher._StartupReady)
+    document = json.loads(cfg_path.read_bytes())
+    assert config_schema.validate_v1(document)
+    assert startup.config.to_v1_mapping() == document
+    assert startup.config.title == "My Launcher"
+    assert startup.config.workspace_name == "Default Workspace"
+    recovery_files = list((tmp_path / "recovery").glob("config-*.recovery"))
+    assert len(recovery_files) == 1
+    assert recovery_files[0].read_bytes() == original
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("failure_mode", "expected_category"),
+    (
+        ("construction", "identity_allocation_failure"),
+        ("validation", "validation_failure"),
+        ("persistence", "persistence_failure"),
+    ),
+)
+def test_missing_native_v1_failure_exits_safely_without_residue(
+    tmp_path,
+    monkeypatch,
+    failure_mode,
+    expected_category,
+):
+    cfg_path = tmp_path / "config.json"
+    sensitive = r"C:\Users\private\native-config-secret.json"
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+
+    if failure_mode == "construction":
+
+        def fail_build(_allocator):
+            raise config_schema.NativeV1ConstructionError
+
+        monkeypatch.setattr(tile_launcher, "build_native_v1", fail_build)
+    elif failure_mode == "validation":
+        monkeypatch.setattr(
+            tile_launcher,
+            "build_native_v1",
+            lambda _allocator: {"schema_version": 1},
+        )
+    else:
+
+        def fail_write(_path, _payload):
+            raise OSError(sensitive)
+
+        monkeypatch.setattr(tile_launcher, "atomic_write_bytes", fail_write)
+
+    breadcrumbs = []
+    shown_errors = []
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+    monkeypatch.setattr(
+        tile_launcher,
+        "_show_migration_failure",
+        shown_errors.append,
+    )
+
+    def forbid_recovery_prompt(_category):
+        raise AssertionError("missing native state must not enter Q3 recovery")
+
+    monkeypatch.setattr(
+        tile_launcher, "_prompt_config_recovery", forbid_recovery_prompt
+    )
+
+    startup = tile_launcher._resolve_startup_configuration()
+
+    assert isinstance(startup, tile_launcher._StartupExit)  # nosec B101
+    assert startup.exit_code == 1  # nosec B101
+    assert len(shown_errors) == 1  # nosec B101
+    error = shown_errors[0]
+    assert (
+        error.notice_category is config_migration.StartupNoticeCategory.MIGRATION_FAILED
+    )
+    assert error.diagnostics == {  # nosec B101
+        "failure_count": 1,
+        "failure_kind": "native_configuration",
+        "failure_category": expected_category,
+    }
+    assert error.__cause__ is None  # nosec B101
+    assert error.__context__ is None  # nosec B101
+    assert breadcrumbs == [("config_migration_exit", error.diagnostics)]  # nosec B101
+    assert sensitive not in repr((shown_errors, breadcrumbs))  # nosec B101
+    assert not cfg_path.exists()  # nosec B101
+    assert list(tmp_path.rglob("*.recovery")) == []  # nosec B101
+    assert list(tmp_path.rglob("*.failed-candidate")) == []  # nosec B101
+    assert list(tmp_path.rglob("*.tmp")) == []  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failure_mode", ("construction", "serialization"))
+def test_q3_native_reset_candidate_failure_is_controlled_and_non_mutating(
+    tmp_path,
+    monkeypatch,
+    failure_mode,
+):
+    cfg_path = tmp_path / "config.json"
+    original = b'{"malformed":'
+    sensitive = r"C:\Users\private\reset-secret.json"
+    cfg_path.write_bytes(original)
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    monkeypatch.setattr(
+        tile_launcher,
+        "_prompt_config_recovery",
+        lambda _category: tile_launcher._RecoveryChoice.PRESERVE_AND_RESET,
+    )
+
+    if failure_mode == "construction":
+
+        def fail_build(_allocator):
+            raise config_schema.NativeV1ConstructionError
+
+        monkeypatch.setattr(tile_launcher, "build_native_v1", fail_build)
+    else:
+
+        def fail_serialization(_config):
+            raise ValueError(sensitive)
+
+        monkeypatch.setattr(LauncherConfig, "_serialized_payload", fail_serialization)
+
+    def forbid_preservation(*_args, **_kwargs):
+        raise AssertionError("invalid reset candidates must not reach preservation")
+
+    monkeypatch.setattr(tile_launcher, "preserve_and_reset", forbid_preservation)
+    breadcrumbs = []
+    shown_categories = []
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+    monkeypatch.setattr(
+        tile_launcher,
+        "_show_recovery_failure",
+        shown_categories.append,
+    )
+
+    startup = tile_launcher._resolve_startup_configuration()
+
+    assert isinstance(startup, tile_launcher._StartupExit)  # nosec B101
+    assert startup.exit_code == 1  # nosec B101
+    assert shown_categories == [  # nosec B101
+        tile_launcher.RecoveryFailureCategory.RESET_FAILURE
+    ]
+    failure_events = [
+        fields for event, fields in breadcrumbs if event == "config_recovery_failed"
+    ]
+    assert failure_events == [  # nosec B101
+        {
+            "recovery_copy_count": 0,
+            "reset_count": 0,
+            "failure_category": "reset_failure",
+        }
+    ]
+    assert cfg_path.read_bytes() == original  # nosec B101
+    assert sensitive not in repr((breadcrumbs, shown_categories))  # nosec B101
+    assert list(tmp_path.rglob("*.recovery")) == []  # nosec B101
+    assert list(tmp_path.rglob("*.failed-candidate")) == []  # nosec B101
+    assert list(tmp_path.rglob("*.tmp")) == []  # nosec B101
+
+
+@pytest.mark.unit
+def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v1(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "config.json"
+    cfg = _runtime_config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    harness = _RuntimeHarness(cfg)
+
+    real_atomic_write = tile_launcher.atomic_write_bytes
+    writes = []
+
+    def capture_write(path, payload):
+        document = json.loads(payload)
+        assert config_schema.validate_v1(document)  # nosec B101
+        writes.append(document)
+        real_atomic_write(path, payload)
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", capture_write)
+
+    def assert_committed(expected_write_count):
+        assert len(writes) == expected_write_count  # nosec B101
+        runtime_document = harness.cfg.to_v1_mapping()
+        persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert config_schema.validate_v1(runtime_document)  # nosec B101
+        assert persisted == runtime_document == writes[-1]  # nosec B101
+        application = persisted["application"]
+        workspace = persisted["workspaces"][0]
+        assert application["title"] == "Independent Application Title"  # nosec B101
+        assert application["default_workspace_id"] == _WORKSPACE_ID  # nosec B101
+        assert application["extensions"] == {}  # nosec B101
+        assert workspace["id"] == _WORKSPACE_ID  # nosec B101
+        assert workspace["name"] == "Custom Workspace"  # nosec B101
+        assert workspace["tab_order"] == harness.cfg.tab_order  # nosec B101
+        assert harness.cfg.tab_order == [  # nosec B101
+            harness.cfg.tab_ids[name] for name in harness.cfg.tabs
+        ]
+        assert persisted["extensions"] == _ROOT_EXTENSION  # nosec B101
+        assert harness.cfg.workspace_extensions == {}  # nosec B101
+        assert all(value == {} for value in harness.cfg.tab_extensions.values())
+        title_by_id = {tab_id: name for name, tab_id in harness.cfg.tab_ids.items()}
+        assert all(  # nosec B101
+            tile.tab_id in title_by_id and tile.tab == title_by_id[tile.tab_id]
+            for tile in harness.cfg.tiles
+        )
+        assert harness.cfg.tab_ids["Main"] == _MAIN_ID  # nosec B101
+        assert harness.cfg.tab_ids["Archive"] == _ARCHIVE_ID  # nosec B101
+        if "Work" in harness.cfg.tab_ids:
+            assert harness.cfg.tab_ids["Work"] == _WORK_ID  # nosec B101
+        if "Focus" in harness.cfg.tab_ids:
+            assert harness.cfg.tab_ids["Focus"] == _WORK_ID  # nosec B101
+
+    tab_names = iter((("Later", True), ("Focus", True)))
+    monkeypatch.setattr(
+        tile_launcher.QInputDialog,
+        "getText",
+        lambda *_args, **_kwargs: next(tab_names),
+    )
+
+    Main.add_tab(harness)
+    assert_committed(1)
+    later_id = harness.cfg.tab_ids["Later"]
+    assert later_id not in {_WORKSPACE_ID, _MAIN_ID, _WORK_ID, _ARCHIVE_ID}
+
+    harness._current_tab = "Work"
+    Main.rename_tab(harness)
+    assert_committed(2)
+    assert "Work" not in harness.cfg.tab_ids  # nosec B101
+    assert harness.cfg.tab_ids["Focus"] == _WORK_ID  # nosec B101
+    assert (
+        next(tile for tile in harness.cfg.tiles if tile.name == "Work X").tab == "Focus"
+    )
+
+    harness._current_tab = "Main"
+    harness.set_visible_ids_after_move([_WORK_ID, _MAIN_ID, later_id])
+    Main._on_tab_moved(harness, 0, 1)
+    assert_committed(3)
+    assert harness.cfg.tabs == ["Focus", "Main", "Archive", "Later"]  # nosec B101
+
+    harness._current_tab = "Focus"
+    Main.toggle_current_tab_visibility(harness)
+    assert_committed(4)
+    assert harness.cfg.hidden_tabs == ["Archive", "Focus"]  # nosec B101
+    Main.toggle_current_tab_visibility(harness)
+    assert_committed(5)
+    assert harness.cfg.hidden_tabs == ["Archive"]  # nosec B101
+
+    class VisibilityDialog:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def exec(self):
+            return tile_launcher.QDialog.DialogCode.Accepted
+
+        def result_hidden(self):
+            return ["Archive", "Later"]
+
+    monkeypatch.setattr(tile_launcher, "TabVisibilityDialog", VisibilityDialog)
+    Main.manage_tab_visibility(harness)
+    assert_committed(6)
+    assert harness.cfg.hidden_tabs == ["Archive", "Later"]  # nosec B101
+
+    harness._current_tab = "Later"
+    Main.toggle_current_tab_visibility(harness)
+    assert_committed(7)
+    assert harness.cfg.hidden_tabs == ["Archive"]  # nosec B101
+
+    class EditDialog:
+        data = {
+            "name": "Main A edited",
+            "url": "https://edited.example.test/",
+            "tab": "Focus",
+            "icon": None,
+            "browser": "firefox",
+            "chrome_profile": None,
+            "open_target": "window",
+        }
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def exec(self):
+            return tile_launcher.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(tile_launcher, "TileEditorDialog", EditDialog)
+    monkeypatch.setattr(tile_launcher, "available_browsers", lambda: [])
+    target = next(tile for tile in harness.cfg.tiles if tile.name == "Main A")
+    harness._current_tab = "Main"
+    Main.edit_tile(harness, target)
+    assert_committed(8)
+    assert target.name == "Main A edited"  # nosec B101
+    assert target.tab == "Focus" and target.tab_id == _WORK_ID  # nosec B101
+
+    Main.change_tile_tab(harness, target, "Main")
+    assert_committed(9)
+    assert target.tab == "Main" and target.tab_id == _MAIN_ID  # nosec B101
+
+    harness._current_tab = "Main"
+    Main.move_tile(harness, "Main", 0, 1)
+    assert_committed(10)
+    assert [tile.name for tile in harness.cfg.tiles] == [  # nosec B101
+        "Work X",
+        "Main B",
+        "Main A edited",
+        "Archive Z",
+    ]
+    assert [  # nosec B101
+        tile.name for tile in harness.cfg.tiles if tile.tab_id == _MAIN_ID
+    ] == ["Main B", "Main A edited"]
+    assert harness.populated_tabs == ["Main"]  # nosec B101
+
+    main_b = next(tile for tile in harness.cfg.tiles if tile.name == "Main B")
+    Main.duplicate_tile(harness, main_b)
+    assert_committed(11)
+    duplicates = [tile for tile in harness.cfg.tiles if tile.name == "Main B"]
+    assert len(duplicates) == 2 and duplicates[0] is not duplicates[1]  # nosec B101
+    assert duplicates[0].tab_id == duplicates[1].tab_id == _MAIN_ID  # nosec B101
+
+    monkeypatch.setattr(
+        tile_launcher.QMessageBox,
+        "warning",
+        lambda *_args, **_kwargs: tile_launcher.QMessageBox.StandardButton.Yes,
+    )
+    Main.remove_tile(harness, duplicates[1])
+    assert_committed(12)
+    assert [tile.name for tile in harness.cfg.tiles].count("Main B") == 1  # nosec B101
+
+    harness._current_tab = "Later"
+    monkeypatch.setattr(
+        tile_launcher.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: tile_launcher.QMessageBox.StandardButton.Yes,
+    )
+    Main.delete_tab(harness)
+    assert_committed(13)
+    assert "Later" not in harness.cfg.tabs  # nosec B101
+    assert later_id not in harness.cfg.tab_order  # nosec B101
+    assert all(tile.tab_id != later_id for tile in harness.cfg.tiles)  # nosec B101
+
+
+@pytest.mark.unit
+def test_auto_fit_toggle_persists_one_complete_strict_v1_document(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "config.json"
+    cfg = _runtime_config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    baseline = copy.deepcopy(cfg.to_v1_mapping())
+    harness = _RuntimeHarness(cfg, current_tab="Work")
+    harness._computed_columns = 23
+    harness.auto_fit_action.checked = False
+    live_tiles = tuple(harness.cfg.tiles)
+    writes = []
+    real_atomic_write = tile_launcher.atomic_write_bytes
+
+    def capture_write(path, payload):
+        document = json.loads(payload)
+        assert config_schema.validate_v1(document)  # nosec B101
+        writes.append(document)
+        real_atomic_write(path, payload)
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", capture_write)
+
+    Main._toggle_auto_fit(harness, False)
+
+    assert harness.cfg is cfg  # nosec B101
+    assert all(  # nosec B101
+        current is original
+        for current, original in zip(harness.cfg.tiles, live_tiles, strict=True)
+    )
+    assert len(writes) == 1  # nosec B101
+    persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert persisted == writes[0] == harness.cfg.to_v1_mapping()  # nosec B101
+    assert config_schema.validate_v1(persisted)  # nosec B101
+    expected = copy.deepcopy(baseline)
+    expected["auto_fit"] = False
+    assert persisted == expected  # nosec B101
+    assert harness.cfg.auto_fit is False  # nosec B101
+    assert harness._computed_columns == harness.cfg.columns  # nosec B101
+    assert harness.auto_fit_action.checked is False  # nosec B101
+    assert harness.auto_fit_action.block_calls == []  # nosec B101
+    assert harness.auto_fit_action.set_checked_calls == []  # nosec B101
+    assert harness.current_tab() == "Work"  # nosec B101
+    assert harness.rebuild_count == 1  # nosec B101
+    assert harness.resize_calls == [False]  # nosec B101
+    assert [path.name for path in tmp_path.iterdir()] == ["config.json"]  # nosec B101
+
+
+@pytest.mark.unit
+def test_auto_fit_size_failure_rolls_back_live_and_action_state(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "private-config.json"
+    cfg = _runtime_config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    baseline_bytes = cfg_path.read_bytes()
+    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    harness = _RuntimeHarness(cfg, current_tab="Work")
+    harness._computed_columns = 23
+    harness.auto_fit_action.checked = False
+    live_tiles = tuple(harness.cfg.tiles)
+    breadcrumbs = []
+    messages = []
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+    monkeypatch.setattr(
+        tile_launcher.QMessageBox,
+        "critical",
+        lambda parent, title, text: messages.append((parent, title, text)),
+    )
+    monkeypatch.setattr(tile_launcher, "MAX_CONFIG_BYTES", len(baseline_bytes))
+
+    def forbid_atomic_write(*_args, **_kwargs):
+        raise AssertionError("the oversized document must be rejected before writing")
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_atomic_write)
+
+    Main._toggle_auto_fit(harness, False)
+
+    assert harness.cfg is cfg  # nosec B101
+    assert all(  # nosec B101
+        current is original
+        for current, original in zip(harness.cfg.tiles, live_tiles, strict=True)
+    )
+    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
+    assert harness.cfg.auto_fit is True  # nosec B101
+    assert harness._computed_columns == 23  # nosec B101
+    assert harness.auto_fit_action.checked is True  # nosec B101
+    assert harness.auto_fit_action.block_calls == [True, False]  # nosec B101
+    assert harness.auto_fit_action.set_checked_calls == [(True, True)]  # nosec B101
+    assert harness.current_tab() == "Work"  # nosec B101
+    assert harness.selected_tabs == ["Work"]  # nosec B101
+    assert harness.rebuild_count == 1  # nosec B101
+    assert harness.resize_calls == []  # nosec B101
+    assert breadcrumbs == [  # nosec B101
+        (
+            "config_change_save_failed",
+            {
+                "failure_count": 1,
+                "failure_category": "size_limit_exceeded",
+                "operation": "auto_fit_toggle",
+            },
+        )
+    ]
+    assert messages == [  # nosec B101
+        (
+            None,
+            "DesktopTileLauncher",
+            "The change could not be saved. No changes were applied.",
+        )
+    ]
+    assert "Work X" not in repr((breadcrumbs, messages))  # nosec B101
+    assert "https://work-x.example.test/" not in repr(  # nosec B101
+        (breadcrumbs, messages)
+    )
+    assert str(cfg_path) not in repr((breadcrumbs, messages))  # nosec B101
+    assert list(tmp_path.rglob("*.tmp")) == []  # nosec B101
+    assert [path.name for path in tmp_path.iterdir()] == [  # nosec B101
+        "private-config.json"
+    ]
+
+
+@pytest.mark.unit
+def test_add_tile_with_strict_v1_preserves_identity_and_extension_state(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "config.json"
+    cfg = _runtime_config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    baseline = copy.deepcopy(cfg.to_v1_mapping())
+    baseline_tab_ids = dict(cfg.tab_ids)
+    baseline_tab_order = list(cfg.tab_order)
+    live_tiles = tuple(cfg.tiles)
+    harness = _RuntimeHarness(cfg, current_tab="Work")
+    writes = []
+    breadcrumbs = []
+    real_atomic_write = tile_launcher.atomic_write_bytes
+    _install_add_tile_dialog(
+        monkeypatch,
+        {
+            "name": "Work Y",
+            "url": "https://work-y.example.test/",
+            "tab": "Work",
+            "icon": None,
+            "browser": None,
+            "chrome_profile": None,
+            "open_target": "tab",
+        },
+    )
+
+    def capture_write(path, payload):
+        document = json.loads(payload)
+        assert config_schema.validate_v1(document)  # nosec B101
+        writes.append(document)
+        real_atomic_write(path, payload)
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", capture_write)
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+
+    Main.add_tile(harness)
+
+    assert harness.cfg is cfg  # nosec B101
+    assert all(  # nosec B101
+        current is original
+        for current, original in zip(harness.cfg.tiles[:-1], live_tiles, strict=True)
+    )
+    assert cfg.workspace_id == _WORKSPACE_ID  # nosec B101
+    assert cfg.tab_ids == baseline_tab_ids  # nosec B101
+    assert cfg.tab_order == baseline_tab_order  # nosec B101
+    assert cfg.tiles[-1].name == "Work Y"  # nosec B101
+    assert cfg.tiles[-1].tab == "Work"  # nosec B101
+    assert cfg.tiles[-1].tab_id == _WORK_ID  # nosec B101
+    assert [tile.name for tile in cfg.tiles] == [  # nosec B101
+        "Main A",
+        "Work X",
+        "Main B",
+        "Archive Z",
+        "Work Y",
+    ]
+    assert [tile.name for tile in cfg.tiles if tile.tab_id == _WORK_ID] == [  # nosec B101
+        "Work X",
+        "Work Y",
+    ]
+    assert len(writes) == 1  # nosec B101
+    persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert persisted == writes[0] == cfg.to_v1_mapping()  # nosec B101
+    assert config_schema.validate_v1(persisted)  # nosec B101
+    assert {key: value for key, value in persisted.items() if key != "tiles"} == {
+        key: value for key, value in baseline.items() if key != "tiles"
+    }  # nosec B101
+    assert persisted["tiles"][:-1] == baseline["tiles"]  # nosec B101
+    assert persisted["tiles"][-1]["tab_id"] == _WORK_ID  # nosec B101
+    assert harness.current_tab() == "Work"  # nosec B101
+    assert harness.selected_tabs == ["Work"]  # nosec B101
+    assert harness.rebuild_count == 1  # nosec B101
+    assert breadcrumbs == [("tile_add", {})]  # nosec B101
+    assert [path.name for path in tmp_path.iterdir()] == ["config.json"]  # nosec B101
+
+
+@pytest.mark.unit
+def test_add_tile_persistence_failure_restores_strict_v1_live_identity(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "private-config.json"
+    cfg = _runtime_config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    baseline_bytes = cfg_path.read_bytes()
+    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    live_tiles = tuple(cfg.tiles)
+    harness = _RuntimeHarness(cfg, current_tab="Work")
+    sensitive_name = "Private work tile"
+    sensitive_url = "https://private-work.example.test/account"
+    sensitive_error = "C:\\private\\DesktopTileLauncher\\config.json"
+    attempted_documents = []
+    breadcrumbs = []
+    messages = []
+    real_atomic_write = tile_launcher.atomic_write_bytes
+    _install_add_tile_dialog(
+        monkeypatch,
+        {
+            "name": sensitive_name,
+            "url": sensitive_url,
+            "tab": "Work",
+            "icon": None,
+            "browser": None,
+            "chrome_profile": None,
+            "open_target": "tab",
+        },
+    )
+
+    def capture_candidate(path, payload):
+        document = json.loads(payload)
+        assert config_schema.validate_v1(document)  # nosec B101
+        attempted_documents.append(document)
+        real_atomic_write(path, payload)
+
+    def reject_replace(_source, _destination):
+        raise OSError(sensitive_error)
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", capture_candidate)
+    monkeypatch.setattr(config_persistence.os, "replace", reject_replace)
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+    monkeypatch.setattr(
+        tile_launcher.QMessageBox,
+        "critical",
+        lambda parent, title, text: messages.append((parent, title, text)),
+    )
+
+    Main.add_tile(harness)
+
+    assert len(attempted_documents) == 1  # nosec B101
+    assert attempted_documents[0]["tiles"][-1]["tab_id"] == _WORK_ID  # nosec B101
+    assert harness.cfg is cfg  # nosec B101
+    assert len(harness.cfg.tiles) == len(live_tiles)  # nosec B101
+    assert all(  # nosec B101
+        current is original
+        for current, original in zip(harness.cfg.tiles, live_tiles, strict=True)
+    )
+    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
+    assert harness.current_tab() == "Work"  # nosec B101
+    assert harness.selected_tabs == ["Work"]  # nosec B101
+    assert harness.rebuild_count == 1  # nosec B101
+    assert breadcrumbs == [  # nosec B101
+        (
+            "config_change_save_failed",
+            {
+                "failure_count": 1,
+                "failure_category": "persistence_failure",
+                "operation": "tile_add",
+            },
+        )
+    ]
+    assert messages == [  # nosec B101
+        (
+            None,
+            "DesktopTileLauncher",
+            "The change could not be saved. No changes were applied.",
+        )
+    ]
+    assert sensitive_name not in repr((breadcrumbs, messages))  # nosec B101
+    assert sensitive_url not in repr((breadcrumbs, messages))  # nosec B101
+    assert sensitive_error not in repr((breadcrumbs, messages))  # nosec B101
+    assert str(cfg_path) not in repr((breadcrumbs, messages))  # nosec B101
+    assert list(tmp_path.rglob("*.tmp")) == []  # nosec B101
+    assert [path.name for path in tmp_path.iterdir()] == [  # nosec B101
+        "private-config.json"
+    ]
+
+
+@pytest.mark.unit
+def test_close_geometry_save_failures_restore_state_and_leave_no_residue(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "private-config.json"
+    cfg = _runtime_config()
+    cfg.window_x = 1
+    cfg.window_y = 2
+    cfg.window_w = 640
+    cfg.window_h = 480
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    baseline_bytes = cfg_path.read_bytes()
+    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    live_tiles = tuple(cfg.tiles)
+    breadcrumbs = []
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+
+    with monkeypatch.context() as size_limit_patch:
+        size_limit_patch.setattr(
+            tile_launcher,
+            "MAX_CONFIG_BYTES",
+            len(baseline_bytes),
+        )
+        saved = tile_launcher._persist_close_geometry(
+            cfg,
+            x=1_000_000,
+            y=2_000_000,
+            width=3_000_000,
+            height=4_000_000,
+        )
+
+    assert saved is False  # nosec B101
+    assert cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
+    assert tuple(cfg.tiles) == live_tiles  # nosec B101
+    assert all(  # nosec B101
+        current is original
+        for current, original in zip(cfg.tiles, live_tiles, strict=True)
+    )
+
+    sensitive_error = "C:\\private\\DesktopTileLauncher\\close-config.json"
+
+    def reject_replace(_source, _destination):
+        raise OSError(sensitive_error)
+
+    with monkeypatch.context() as persistence_patch:
+        persistence_patch.setattr(config_persistence.os, "replace", reject_replace)
+        saved = tile_launcher._persist_close_geometry(
+            cfg,
+            x=10,
+            y=20,
+            width=800,
+            height=600,
+        )
+
+    assert saved is False  # nosec B101
+    assert cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
+    assert all(  # nosec B101
+        current is original
+        for current, original in zip(cfg.tiles, live_tiles, strict=True)
+    )
+    assert breadcrumbs == [  # nosec B101
+        (
+            "geometry_save_failed",
+            {
+                "failure_count": 1,
+                "failure_category": "size_limit_exceeded",
+            },
+        ),
+        (
+            "geometry_save_failed",
+            {
+                "failure_count": 1,
+                "failure_category": "persistence_failure",
+            },
+        ),
+    ]
+    assert sensitive_error not in repr(breadcrumbs)  # nosec B101
+    assert str(cfg_path) not in repr(breadcrumbs)  # nosec B101
+    assert list(tmp_path.rglob("*.tmp")) == []  # nosec B101
+    assert [path.name for path in tmp_path.iterdir()] == [  # nosec B101
+        "private-config.json"
+    ]
+
+
+@pytest.mark.unit
+def test_runtime_size_and_validation_failures_roll_back_live_identity_graph(
+    tmp_path,
+    monkeypatch,
+):
+    cfg_path = tmp_path / "config.json"
+    cfg = _runtime_config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    cfg.save()
+    baseline_bytes = cfg_path.read_bytes()
+    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    harness = _RuntimeHarness(cfg)
+    live_config = harness.cfg
+    live_main_tile = harness.cfg.tiles[0]
+    breadcrumbs = []
+    messages = []
+    monkeypatch.setattr(
+        tile_launcher,
+        "record_breadcrumb",
+        lambda event, **fields: breadcrumbs.append((event, fields)),
+    )
+    monkeypatch.setattr(
+        tile_launcher.QMessageBox,
+        "critical",
+        lambda parent, title, text: messages.append((parent, title, text)),
+    )
+
+    monkeypatch.setattr(tile_launcher, "MAX_CONFIG_BYTES", len(baseline_bytes))
+    Main.duplicate_tile(harness, harness.cfg.tiles[0])
+
+    assert harness.cfg is live_config  # nosec B101
+    assert harness.cfg.tiles[0] is live_main_tile  # nosec B101
+    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
+    assert breadcrumbs[-1] == (  # nosec B101
+        "config_change_save_failed",
+        {
+            "failure_count": 1,
+            "failure_category": "size_limit_exceeded",
+            "operation": "tile_duplicate",
+        },
+    )
+    assert list(tmp_path.rglob("*.tmp")) == []  # nosec B101
+
+    sensitive_name = "Private renamed workspace tab"
+    harness._current_tab = "Work"
+    live_work_tile = next(tile for tile in harness.cfg.tiles if tile.tab == "Work")
+    monkeypatch.setattr(
+        tile_launcher.QInputDialog,
+        "getText",
+        lambda *_args, **_kwargs: (sensitive_name, True),
+    )
+
+    def reject_save(_config):
+        raise ValueError("invalid_schema_v1_runtime_state")
+
+    monkeypatch.setattr(LauncherConfig, "save", reject_save)
+    Main.rename_tab(harness)
+
+    assert harness.cfg is live_config  # nosec B101
+    assert any(tile is live_work_tile for tile in harness.cfg.tiles)  # nosec B101
+    assert live_work_tile.tab == "Work"  # nosec B101
+    assert live_work_tile.tab_id == _WORK_ID  # nosec B101
+    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
+    assert breadcrumbs[-1] == (  # nosec B101
+        "config_change_save_failed",
+        {
+            "failure_count": 1,
+            "failure_category": "validation_failure",
+            "operation": "tab_rename",
+        },
+    )
+    assert len(messages) == 2  # nosec B101
+    assert sensitive_name not in repr((breadcrumbs, messages))  # nosec B101
+
+
+@pytest.mark.unit
+def test_runtime_utf8_encoding_failure_is_fixed_and_context_free(
+    monkeypatch,
+) -> None:
+    cfg = _runtime_config()
+    monkeypatch.setattr(LauncherConfig, "serialize", lambda _config: "\ud800")
+
+    with pytest.raises(ValueError) as exc_info:
+        cfg._serialized_payload()
+
+    assert exc_info.value.args == ("invalid_schema_v1_runtime_state",)  # nosec B101
+    assert exc_info.value.__cause__ is None  # nosec B101
+    assert exc_info.value.__context__ is None  # nosec B101

--- a/tests/unit/test_tab_order.py
+++ b/tests/unit/test_tab_order.py
@@ -146,6 +146,29 @@ def test_add_appends_unique_identifier_after_factory_collision() -> None:
 
 
 @pytest.mark.unit
+def test_workspace_identity_is_blocked_for_retained_and_new_tab_ids() -> None:
+    normalized = normalize_tab_order(
+        ["A"],
+        {"A": A_ID},
+        [A_ID],
+        _id_factory([A_ID, B_ID]),
+        blocked_ids=(A_ID,),
+    )
+
+    added = add_tab(
+        normalized,
+        "B",
+        _id_factory([A_ID, C_ID]),
+        blocked_ids=(A_ID,),
+    )
+
+    assert normalized.tab_ids == {"A": B_ID}
+    assert normalized.tab_order == [B_ID]
+    assert added.tab_ids == {"A": B_ID, "B": C_ID}
+    assert added.tab_order == [B_ID, C_ID]
+
+
+@pytest.mark.unit
 def test_delete_removes_identifier_and_all_order_occurrences() -> None:
     state = TabOrderState(
         ["A", "B", "C"],

--- a/tests/unit/test_url_import_integration.py
+++ b/tests/unit/test_url_import_integration.py
@@ -103,6 +103,10 @@ def _config(*, hidden_tabs: list[str] | None = None) -> LauncherConfig:
         window_y=20,
         window_w=800,
         window_h=600,
+        workspace_name="Custom Workspace",
+        extensions={
+            "io.github.108thecitizen.legacy": {"retained": {"source": "legacy"}}
+        },
     )
 
 
@@ -155,6 +159,11 @@ def test_import_saves_detached_candidate_once_then_commits_in_source_order(
         assert candidate.hidden_tabs is not original.hidden_tabs
         assert candidate.tab_ids is not original.tab_ids
         assert candidate.tab_order is not original.tab_order
+        assert candidate.workspace_id == original.workspace_id
+        assert candidate.workspace_name == "Custom Workspace"
+        assert candidate.tab_extensions is not original.tab_extensions
+        assert candidate.extensions is not original.extensions
+        assert candidate.extensions == original.extensions
         saved.append(candidate)
 
     monkeypatch.setattr(LauncherConfig, "save", fake_save)
@@ -185,6 +194,10 @@ def test_import_saves_detached_candidate_once_then_commits_in_source_order(
         ("Second", "https://second.example.test/"),
     ]
     assert [tile.tab for tile in imported] == ["Work", "Work"]
+    assert [tile.tab_id for tile in imported] == [
+        harness.cfg.tab_ids["Work"],
+        harness.cfg.tab_ids["Work"],
+    ]
     for tile in imported:
         assert tile.icon is None
         assert tile.bg == "#F5F6FA"
@@ -225,8 +238,38 @@ def test_import_into_hidden_tab_never_unhides_or_selects_it(
     assert "Hidden" not in harness.selected_tabs
 
 
+def test_refresh_detached_candidate_preserves_identity_and_extension_state() -> None:
+    original = _config(hidden_tabs=["Hidden"])
+    harness = _MainHarness(original)
+
+    candidate, detached_by_identity = Main._detached_configuration(harness)
+
+    assert candidate is not original
+    assert candidate.workspace_id == original.workspace_id
+    assert candidate.workspace_name == original.workspace_name
+    assert candidate.tab_ids == original.tab_ids
+    assert candidate.tab_order == original.tab_order
+    assert candidate.hidden_tabs == original.hidden_tabs
+    assert candidate.tab_extensions == original.tab_extensions
+    assert candidate.extensions == original.extensions
+    assert candidate.tab_extensions is not original.tab_extensions
+    assert candidate.extensions is not original.extensions
+    assert candidate.tiles[0].tab_id == original.tiles[0].tab_id
+    assert detached_by_identity[id(original.tiles[0])] is candidate.tiles[0]
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_category"),
+    (
+        (OSError(_SENSITIVE_PATH), "persistence_failure"),
+        (ValueError("invalid_schema_v1_runtime_state"), "validation_failure"),
+        (ValueError("schema_v1_size_limit_exceeded"), "size_limit_exceeded"),
+    ),
+)
 def test_save_failure_keeps_live_config_and_review_state_without_rebuild(
     monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+    expected_category: str,
 ) -> None:
     original = _config()
     original_snapshot = copy.deepcopy(original)
@@ -247,7 +290,7 @@ def test_save_failure_keeps_live_config_and_review_state_without_rebuild(
 
     def fail_save(candidate: LauncherConfig) -> None:
         save_attempts.append(candidate)
-        raise OSError(_SENSITIVE_PATH)
+        raise failure
 
     monkeypatch.setattr(LauncherConfig, "save", fail_save)
     errors: list[tuple[object, str, str]] = []
@@ -275,6 +318,63 @@ def test_save_failure_keeps_live_config_and_review_state_without_rebuild(
     assert _SENSITIVE_URL not in repr(captured)
     assert _SENSITIVE_NAME not in repr(captured)
     assert _SENSITIVE_PATH not in repr(captured)
+    assert captured == [
+        (
+            "url_import_save_failed",
+            {"imported_count": 1, "failure_category": expected_category},
+        )
+    ]
+
+
+def test_actual_over_limit_import_keeps_live_review_and_file_exact(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg_path = tmp_path / "config.json"
+    original = _config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    original.save()
+    baseline_bytes = cfg_path.read_bytes()
+    original_snapshot = copy.deepcopy(original)
+    harness = _MainHarness(original)
+    dialog = _Dialog(
+        destination="Work",
+        selections=(_Selection(1, _SENSITIVE_NAME, _SENSITIVE_URL),),
+        results=(
+            tile_launcher.QDialog.DialogCode.Accepted,
+            tile_launcher.QDialog.DialogCode.Rejected,
+        ),
+    )
+    _install_dialog(monkeypatch, dialog)
+    captured = _capture_breadcrumbs(monkeypatch)
+    errors: list[tuple[object, str, str]] = []
+    monkeypatch.setattr(
+        tile_launcher.QMessageBox,
+        "critical",
+        lambda parent, title, text: errors.append((parent, title, text)),
+    )
+    monkeypatch.setattr(tile_launcher, "MAX_CONFIG_BYTES", len(baseline_bytes))
+
+    Main.import_urls(harness)
+
+    assert harness.cfg is original
+    assert harness.cfg == original_snapshot
+    assert cfg_path.read_bytes() == baseline_bytes
+    assert harness.rebuild_count == 0
+    assert harness.selected_tabs == []
+    assert dialog.exec_count == 2
+    assert dialog.selected_imports_count == 1
+    assert captured == [
+        (
+            "url_import_save_failed",
+            {"imported_count": 1, "failure_category": "size_limit_exceeded"},
+        )
+    ]
+    assert len(errors) == 1
+    assert "No tiles were imported" in errors[0][2]
+    assert _SENSITIVE_URL not in repr((captured, errors))
+    assert _SENSITIVE_NAME not in repr((captured, errors))
+    assert list(tmp_path.glob(".config.json.*.tmp")) == []
 
 
 def test_cancel_makes_no_config_or_ui_mutations(

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -16,11 +16,13 @@ import sys
 import threading
 import urllib.parse
 import webbrowser
-from collections.abc import Iterable
-from dataclasses import asdict, dataclass, field, replace
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, cast
+from typing import Any, Callable, Literal, Optional, TypeAlias, cast
+from uuid import UUID, uuid4
 
 from PySide6.QtCore import (
     QEvent,
@@ -82,14 +84,16 @@ from config_migration import (
     MigrationCommitted,
     PRODUCTION_REGISTRY,
     StartupFailureRoute,
+    StartupNoticeCategory,
     VersionedCurrent,
     guarded_legacy_normalization_save,
     load_startup_configuration,
     startup_failure_route,
     startup_notice_message,
 )
-from config_persistence import atomic_write_text
+from config_persistence import atomic_write_bytes
 from config_recovery import (
+    MAX_CONFIG_BYTES,
     ConfigLoadFailureCategory,
     ConfigMissing,
     ConfigRecoveryRequired,
@@ -102,6 +106,15 @@ from config_recovery import (
     recovery_required_diagnostics,
     recovery_result_diagnostics,
     validate_legacy_mapping,
+)
+from config_schema import (
+    DEFAULT_WORKSPACE_NAME,
+    JsonObject,
+    JsonValue,
+    NativeV1ConstructionError,
+    Uuid4Allocator,
+    build_native_v1,
+    validate_v1,
 )
 from debug_scaffold import (
     record_breadcrumb,
@@ -308,6 +321,60 @@ class Tile:
     browser: Optional[str] = None  # webbrowser name
     chrome_profile: Optional[str] = None  # e.g. "Default", "Profile 1"
     open_target: Literal["tab", "window"] = "tab"
+    tab_id: str | None = None
+
+
+NativeConfigurationFailureCategory: TypeAlias = Literal[
+    "identity_allocation_failure",
+    "validation_failure",
+    "persistence_failure",
+]
+
+
+def _native_configuration_error(
+    category: NativeConfigurationFailureCategory,
+) -> ConfigurationMigrationError:
+    return ConfigurationMigrationError(
+        StartupNoticeCategory.MIGRATION_FAILED,
+        {
+            "failure_count": 1,
+            "failure_kind": "native_configuration",
+            "failure_category": category,
+        },
+    )
+
+
+RuntimeChangeOperation: TypeAlias = Literal[
+    "auto_fit_toggle",
+    "tab_reorder",
+    "tile_reorder",
+    "tile_add",
+    "tile_edit",
+    "tile_duplicate",
+    "tile_remove",
+    "tile_move",
+    "tab_add",
+    "tab_rename",
+    "tab_delete",
+    "tab_visibility_toggle",
+    "tab_visibility_manage",
+]
+
+RuntimeSaveFailureCategory: TypeAlias = Literal[
+    "validation_failure",
+    "size_limit_exceeded",
+    "persistence_failure",
+]
+
+
+def _runtime_save_failure_category(
+    error: OSError | ValueError,
+) -> RuntimeSaveFailureCategory:
+    if isinstance(error, OSError):
+        return "persistence_failure"
+    if error.args == ("schema_v1_size_limit_exceeded",):
+        return "size_limit_exceeded"
+    return "validation_failure"
 
 
 @dataclass
@@ -324,6 +391,17 @@ class LauncherConfig:
     window_y: Optional[int] = None
     window_w: Optional[int] = None
     window_h: Optional[int] = None
+    workspace_id: str = ""
+    workspace_name: str = DEFAULT_WORKSPACE_NAME
+    application_extensions: JsonObject = field(default_factory=dict)
+    workspace_extensions: JsonObject = field(default_factory=dict)
+    tab_extensions: dict[str, JsonObject] = field(default_factory=dict)
+    extensions: JsonObject = field(default_factory=dict)
+    _identity_ready: bool = field(default=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not self._identity_ready:
+            enforce_tab_invariants(self)
 
     @classmethod
     def from_legacy_mapping(cls, data: dict[str, object]) -> "LauncherConfig":
@@ -351,6 +429,7 @@ class LauncherConfig:
             window_y=legacy.get("window_y"),
             window_w=legacy.get("window_w"),
             window_h=legacy.get("window_h"),
+            _identity_ready=True,
         )
         enforce_tab_invariants(
             cfg,
@@ -360,22 +439,75 @@ class LauncherConfig:
         return cfg
 
     @classmethod
-    def first_run(cls) -> "LauncherConfig":
-        """Return the single friendly first-run configuration definition."""
-        cfg = cls(
-            title="My Launcher",
-            columns=5,
-            tiles=[
-                Tile("ChatGPT", "https://chat.openai.com"),
-                Tile("Gmail", "https://mail.google.com"),
-                Tile("Notion", "https://www.notion.so"),
-            ],
-            tabs=["Main"],
-            hidden_tabs=[],
-            auto_fit=True,
+    def from_v1_mapping(
+        cls,
+        data: Mapping[str, JsonValue],
+    ) -> "LauncherConfig":
+        """Construct validated v1 state without legacy repair or ID allocation."""
+
+        if not validate_v1(data):
+            raise ValueError("invalid_schema_v1_runtime_state")
+        document = cast(dict[str, Any], deepcopy(dict(data)))
+        application = cast(dict[str, Any], document["application"])
+        workspace = cast(list[dict[str, Any]], document["workspaces"])[0]
+        raw_tabs = cast(list[dict[str, Any]], document["tabs"])
+        tabs_by_id = {cast(str, tab["id"]): tab for tab in raw_tabs}
+        tab_order = cast(list[str], workspace["tab_order"])
+        tabs = [cast(str, tabs_by_id[tab_id]["name"]) for tab_id in tab_order]
+        tab_ids = {tabs_by_id[tab_id]["name"]: tab_id for tab_id in tab_order}
+        hidden_tabs = [
+            cast(str, tabs_by_id[tab_id]["name"])
+            for tab_id in tab_order
+            if tabs_by_id[tab_id]["visibility"] == "hidden"
+        ]
+        title_by_id = {cast(str, tab["id"]): cast(str, tab["name"]) for tab in raw_tabs}
+        tiles = [
+            Tile(
+                name=cast(str, raw_tile["name"]),
+                url=cast(str, raw_tile["url"]),
+                tab=title_by_id[cast(str, raw_tile["tab_id"])],
+                icon=cast(str | None, raw_tile["icon"]),
+                bg=cast(str, raw_tile["bg"]),
+                browser=cast(str | None, raw_tile["browser"]),
+                chrome_profile=cast(str | None, raw_tile["chrome_profile"]),
+                open_target=cast(Literal["tab", "window"], raw_tile["open_target"]),
+                tab_id=cast(str, raw_tile["tab_id"]),
+            )
+            for raw_tile in cast(list[dict[str, Any]], document["tiles"])
+        ]
+        return cls(
+            title=cast(str, application["title"]),
+            columns=cast(int, document["columns"]),
+            tiles=tiles,
+            tabs=tabs,
+            hidden_tabs=hidden_tabs,
+            tab_ids=cast(dict[str, str], tab_ids),
+            tab_order=list(tab_order),
+            auto_fit=cast(bool, document["auto_fit"]),
+            window_x=cast(int | None, document["window_x"]),
+            window_y=cast(int | None, document["window_y"]),
+            window_w=cast(int | None, document["window_w"]),
+            window_h=cast(int | None, document["window_h"]),
+            workspace_id=cast(str, workspace["id"]),
+            workspace_name=cast(str, workspace["name"]),
+            application_extensions=cast(JsonObject, application["extensions"]),
+            workspace_extensions=cast(JsonObject, workspace["extensions"]),
+            tab_extensions={
+                tab_id: cast(JsonObject, tabs_by_id[tab_id]["extensions"])
+                for tab_id in tab_order
+            },
+            extensions=cast(JsonObject, document["extensions"]),
+            _identity_ready=True,
         )
-        enforce_tab_invariants(cfg)
-        return cfg
+
+    @classmethod
+    def first_run(
+        cls,
+        id_factory: Uuid4Allocator = uuid4,
+    ) -> "LauncherConfig":
+        """Return one validated native-v1 friendly configuration."""
+
+        return cls.from_v1_mapping(build_native_v1(id_factory))
 
     @staticmethod
     def load(
@@ -388,10 +520,24 @@ class LauncherConfig:
             CFG_PATH,
             _construct_legacy_configuration,
             PRODUCTION_REGISTRY,
+            legacy_validator=validate_legacy_mapping,
         )
         if isinstance(result, ConfigMissing):
-            cfg = LauncherConfig.first_run()
-            cfg.save()
+            cfg: LauncherConfig | None = None
+            failure_category: NativeConfigurationFailureCategory | None = None
+            try:
+                cfg = LauncherConfig.first_run()
+                cfg.save()
+            except NativeV1ConstructionError:
+                failure_category = "identity_allocation_failure"
+            except ValueError:
+                failure_category = "validation_failure"
+            except OSError:
+                failure_category = "persistence_failure"
+            if failure_category is not None:
+                raise _native_configuration_error(failure_category)
+            if cfg is None:
+                raise _native_configuration_error("validation_failure")
             return cfg
         if isinstance(result, ConfigRecoveryRequired):
             if startup_failure_route(result) is StartupFailureRoute.Q3_RECOVERY:
@@ -403,38 +549,239 @@ class LauncherConfig:
                 on_existing_legacy(cfg, result.raw)
             return cfg
         if isinstance(result, (VersionedCurrent, MigrationCommitted)):
-            raise ConfigurationMigrationError.unexpected_success()
+            return LauncherConfig.from_v1_mapping(result.document)
         if startup_failure_route(result) is StartupFailureRoute.EXIT_ONLY:
             raise ConfigurationMigrationError.from_outcome(result)
         raise ConfigurationMigrationError.unexpected_success()
 
     def serialize(self) -> str:
-        """Serialize using the existing unversioned schema and formatting."""
-        enforce_tab_invariants(self)
-        tiles = []
-        for t in self.tiles:
-            d = asdict(t)
-            if d.get("chrome_profile") is None:
-                d.pop("chrome_profile", None)
-            tiles.append(d)
-        data = {
-            "title": self.title,
-            "columns": self.columns,
-            "tiles": tiles,
-            "tabs": self.tabs,
-            "hidden_tabs": self.hidden_tabs,
-            "tab_ids": self.tab_ids,
-            "tab_order": self.tab_order,
-            "auto_fit": self.auto_fit,
-            "window_x": self.window_x,
-            "window_y": self.window_y,
-            "window_w": self.window_w,
-            "window_h": self.window_h,
-        }
-        return json.dumps(data, indent=2)
+        """Serialize one complete, strictly validated schema-version 1 document."""
+
+        document = self.to_v1_mapping()
+        serialized: str | None = None
+        try:
+            serialized = json.dumps(
+                document,
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=2,
+                allow_nan=False,
+            )
+        except (TypeError, ValueError, OverflowError, UnicodeError):
+            serialized = None
+        if serialized is None:
+            raise ValueError("invalid_schema_v1_runtime_state")
+        return serialized
+
+    def to_v1_mapping(self) -> JsonObject:
+        """Return current state as v1 without repairing or regenerating identity."""
+
+        tabs: list[JsonValue] = []
+        tiles: list[JsonValue] = []
+        invalid_state = False
+        try:
+            if (
+                not self.tabs
+                or len(set(self.tabs)) != len(self.tabs)
+                or set(self.tab_ids) != set(self.tabs)
+                or len(self.tab_order) != len(self.tabs)
+                or set(self.tab_order) != set(self.tab_ids.values())
+                or len(set(self.tab_order)) != len(self.tab_order)
+                or not set(self.hidden_tabs).issubset(self.tabs)
+                or len(set(self.hidden_tabs)) != len(self.hidden_tabs)
+                or len(self.hidden_tabs) == len(self.tabs)
+                or set(self.tab_extensions) != set(self.tab_order)
+            ):
+                raise ValueError
+            title_by_id = {tab_id: title for title, tab_id in self.tab_ids.items()}
+            ordered_titles = [title_by_id[tab_id] for tab_id in self.tab_order]
+            if ordered_titles != self.tabs:
+                raise ValueError
+
+            tabs = [
+                {
+                    "id": tab_id,
+                    "workspace_id": self.workspace_id,
+                    "name": title_by_id[tab_id],
+                    "visibility": (
+                        "hidden"
+                        if title_by_id[tab_id] in self.hidden_tabs
+                        else "visible"
+                    ),
+                    "extensions": deepcopy(self.tab_extensions[tab_id]),
+                }
+                for tab_id in self.tab_order
+            ]
+            for tile in self.tiles:
+                if tile.tab_id is None or title_by_id.get(tile.tab_id) != tile.tab:
+                    raise ValueError
+                tiles.append(
+                    {
+                        "name": tile.name,
+                        "url": tile.url,
+                        "tab_id": tile.tab_id,
+                        "icon": tile.icon,
+                        "bg": tile.bg,
+                        "browser": tile.browser,
+                        "chrome_profile": tile.chrome_profile,
+                        "open_target": tile.open_target,
+                    }
+                )
+        except (KeyError, RecursionError, TypeError, ValueError):
+            invalid_state = True
+        if invalid_state:
+            raise ValueError("invalid_schema_v1_runtime_state")
+
+        document: JsonObject | None = None
+        try:
+            document = {
+                "schema_version": 1,
+                "application": {
+                    "title": self.title,
+                    "default_workspace_id": self.workspace_id,
+                    "extensions": deepcopy(self.application_extensions),
+                },
+                "workspaces": [
+                    {
+                        "id": self.workspace_id,
+                        "name": self.workspace_name,
+                        "tab_order": list(self.tab_order),
+                        "extensions": deepcopy(self.workspace_extensions),
+                    }
+                ],
+                "tabs": tabs,
+                "tiles": tiles,
+                "columns": self.columns,
+                "auto_fit": self.auto_fit,
+                "window_x": self.window_x,
+                "window_y": self.window_y,
+                "window_w": self.window_w,
+                "window_h": self.window_h,
+                "extensions": deepcopy(self.extensions),
+            }
+        except (RecursionError, TypeError, ValueError):
+            document = None
+        if document is None or not validate_v1(document):
+            raise ValueError("invalid_schema_v1_runtime_state")
+        return document
 
     def save(self) -> None:
-        atomic_write_text(CFG_PATH, self.serialize())
+        payload = self._serialized_payload()
+        atomic_write_bytes(CFG_PATH, payload)
+
+    def _serialized_payload(self) -> bytes:
+        payload: bytes | None = None
+        try:
+            payload = self.serialize().encode("utf-8")
+        except UnicodeError:
+            payload = None
+        if payload is None:
+            raise ValueError("invalid_schema_v1_runtime_state")
+        if len(payload) > MAX_CONFIG_BYTES:
+            raise ValueError("schema_v1_size_limit_exceeded")
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimeChangeSnapshot:
+    live: object = field(repr=False)
+    state: object = field(repr=False)
+    tiles: tuple[object, ...] = field(repr=False)
+
+
+def _runtime_change_snapshot(config: LauncherConfig) -> _RuntimeChangeSnapshot:
+    return _RuntimeChangeSnapshot(
+        live=config,
+        state=deepcopy(config),
+        tiles=tuple(config.tiles),
+    )
+
+
+def _restore_tile(tile: Tile, saved: Tile) -> None:
+    tile.name = saved.name
+    tile.url = saved.url
+    tile.tab = saved.tab
+    tile.icon = saved.icon
+    tile.bg = saved.bg
+    tile.browser = saved.browser
+    tile.chrome_profile = saved.chrome_profile
+    tile.open_target = saved.open_target
+    tile.tab_id = saved.tab_id
+
+
+def _restore_runtime_change(snapshot: _RuntimeChangeSnapshot) -> LauncherConfig:
+    live = snapshot.live
+    state = snapshot.state
+    if not isinstance(live, LauncherConfig) or not isinstance(state, LauncherConfig):
+        return cast(LauncherConfig, state)
+
+    original_tiles = cast(tuple[Tile, ...], snapshot.tiles)
+    for tile, saved in zip(original_tiles, state.tiles, strict=True):
+        _restore_tile(tile, saved)
+    live.title = state.title
+    live.columns = state.columns
+    live.tiles = list(original_tiles)
+    live.tabs = state.tabs
+    live.hidden_tabs = state.hidden_tabs
+    live.tab_ids = state.tab_ids
+    live.tab_order = state.tab_order
+    live.auto_fit = state.auto_fit
+    live.window_x = state.window_x
+    live.window_y = state.window_y
+    live.window_w = state.window_w
+    live.window_h = state.window_h
+    live.workspace_id = state.workspace_id
+    live.workspace_name = state.workspace_name
+    live.application_extensions = state.application_extensions
+    live.workspace_extensions = state.workspace_extensions
+    live.tab_extensions = state.tab_extensions
+    live.extensions = state.extensions
+    live._identity_ready = state._identity_ready
+    return live
+
+
+def _persist_close_geometry(
+    config: LauncherConfig,
+    *,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+) -> bool:
+    previous_geometry = (
+        config.window_x,
+        config.window_y,
+        config.window_w,
+        config.window_h,
+    )
+    config.window_x = x
+    config.window_y = y
+    config.window_w = width
+    config.window_h = height
+    try:
+        config.save()
+    except (OSError, ValueError) as error:
+        (
+            config.window_x,
+            config.window_y,
+            config.window_w,
+            config.window_h,
+        ) = previous_geometry
+        record_breadcrumb(
+            "geometry_save_failed",
+            failure_count=1,
+            failure_category=_runtime_save_failure_category(error),
+        )
+        return False
+
+    record_breadcrumb(
+        "geometry_saved",
+        w=config.window_w,
+        h=config.window_h,
+        x=config.window_x,
+        y=config.window_y,
+    )
+    return True
 
 
 def _construct_legacy_configuration(data: dict[str, object]) -> LauncherConfig:
@@ -464,9 +811,61 @@ def _tab_order_state(cfg: LauncherConfig) -> TabOrderState:
 
 
 def _apply_tab_order_state(cfg: LauncherConfig, state: TabOrderState) -> None:
+    previous_extensions = cfg.tab_extensions
     cfg.tabs = state.tabs
     cfg.tab_ids = state.tab_ids
     cfg.tab_order = state.tab_order
+    cfg.tab_extensions = {
+        tab_id: deepcopy(previous_extensions.get(tab_id, {}))
+        for tab_id in state.tab_order
+    }
+
+
+def _canonicalized_uuid(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return str(UUID(value))
+    except ValueError:
+        return None
+
+
+def _reserved_tab_identity_hints(
+    raw_tab_ids: object,
+    raw_tab_order: object,
+) -> set[str]:
+    reserved: set[str] = set()
+    if isinstance(raw_tab_ids, dict):
+        values: Iterable[object] = raw_tab_ids.values()
+        reserved.update(
+            candidate
+            for value in values
+            if (candidate := _canonicalized_uuid(value)) is not None
+        )
+    if isinstance(raw_tab_order, list):
+        reserved.update(
+            candidate
+            for value in raw_tab_order
+            if (candidate := _canonicalized_uuid(value)) is not None
+        )
+    return reserved
+
+
+def _ensure_workspace_identity(
+    cfg: LauncherConfig,
+    raw_tab_ids: object,
+    raw_tab_order: object,
+) -> None:
+    reserved = _reserved_tab_identity_hints(raw_tab_ids, raw_tab_order)
+    workspace_id = _canonicalized_uuid(cfg.workspace_id)
+    if workspace_id is not None and workspace_id not in reserved:
+        cfg.workspace_id = workspace_id
+        return
+    while True:
+        workspace_id = str(uuid4())
+        if workspace_id not in reserved:
+            cfg.workspace_id = workspace_id
+            return
 
 
 def enforce_tab_invariants(
@@ -491,18 +890,30 @@ def enforce_tab_invariants(
     if not clean_tabs:
         clean_tabs = ["Main"]
 
+    saved_tab_ids = cfg.tab_ids if raw_tab_ids is None else raw_tab_ids
+    saved_tab_order = cfg.tab_order if raw_tab_order is None else raw_tab_order
+    _ensure_workspace_identity(cfg, saved_tab_ids, saved_tab_order)
     state = normalize_tab_order(
         clean_tabs,
-        cfg.tab_ids if raw_tab_ids is None else raw_tab_ids,
-        cfg.tab_order if raw_tab_order is None else raw_tab_order,
+        saved_tab_ids,
+        saved_tab_order,
+        blocked_ids=(cfg.workspace_id,),
     )
     _apply_tab_order_state(cfg, state)
 
     first_tab = cfg.tabs[0]
     valid_tabs = set(cfg.tabs)
+    title_by_id = {tab_id: title for title, tab_id in cfg.tab_ids.items()}
     for tile in cfg.tiles:
-        if tile.tab not in valid_tabs:
+        canonical_tile_id = _canonicalized_uuid(tile.tab_id)
+        if canonical_tile_id in title_by_id:
+            tile.tab_id = canonical_tile_id
+            tile.tab = title_by_id[canonical_tile_id]
+        elif tile.tab in valid_tabs:
+            tile.tab_id = cfg.tab_ids[tile.tab]
+        else:
             tile.tab = first_tab
+            tile.tab_id = cfg.tab_ids[first_tab]
 
     clean_hidden: list[str] = []
     for t in cfg.hidden_tabs:
@@ -511,6 +922,7 @@ def enforce_tab_invariants(
     cfg.hidden_tabs = clean_hidden
     if len(cfg.hidden_tabs) >= len(cfg.tabs):
         cfg.hidden_tabs = [t for t in cfg.hidden_tabs if t != first_tab]
+    cfg._identity_ready = True
 
 
 def _config_with_imported_tiles(
@@ -524,7 +936,21 @@ def _config_with_imported_tiles(
         hidden_tabs=list(cfg.hidden_tabs),
         tab_ids=dict(cfg.tab_ids),
         tab_order=list(cfg.tab_order),
+        application_extensions=deepcopy(cfg.application_extensions),
+        workspace_extensions=deepcopy(cfg.workspace_extensions),
+        tab_extensions=deepcopy(cfg.tab_extensions),
+        extensions=deepcopy(cfg.extensions),
     )
+
+
+def _tab_id_for_runtime_name(config: object, tab_name: str) -> str | None:
+    """Resolve identity while preserving lightweight direct-construction seams."""
+
+    tab_ids = getattr(config, "tab_ids", None)
+    if not isinstance(tab_ids, dict):
+        return None
+    tab_id = tab_ids.get(tab_name)
+    return tab_id if isinstance(tab_id, str) else None
 
 
 @dataclass
@@ -1397,7 +1823,7 @@ class Main(QMainWindow):
         self._selection_tiles = {}
         self._selection_tokens_by_identity = {}
         for tile in self.cfg.tiles:
-            if tile.tab != tab_name:
+            if tile.tab_id != tab_id:
                 continue
             identity = id(tile)
             if identity in self._selection_tokens_by_identity:
@@ -1436,11 +1862,13 @@ class Main(QMainWindow):
         if self._active_refresh is not None:
             return
         selection_tab = self._selection_tab_name
+        selection_tab_id = self._selection_tab_id
         if (
             not self._selection_active()
             or selection_tab is None
+            or selection_tab_id is None
             or self._selection_tiles.get(token) is not tile
-            or tile.tab != selection_tab
+            or tile.tab_id != selection_tab_id
             or not any(candidate is tile for candidate in self.cfg.tiles)
         ):
             if selection_tab is not None and selection_tab in self._grids:
@@ -1458,7 +1886,7 @@ class Main(QMainWindow):
             token=token,
             url=tile.url,
             name=tile.name,
-            tab=tile.tab,
+            tab=tile.tab_id or "",
             icon=tile.icon,
             bg=tile.bg,
             browser=tile.browser,
@@ -1477,13 +1905,14 @@ class Main(QMainWindow):
         if not self._selection_active() or self._active_refresh is not None:
             return
         tab_name = self._selection_tab_name
-        if tab_name is None:
+        tab_id = self._selection_tab_id
+        if tab_name is None or tab_id is None:
             return
         snapshots = tuple(
             self._snapshot_tile(token, tile)
             for token, tile in self._selection_tiles.items()
         )
-        self._selected_tokens = set(select_all_for_active_tab(snapshots, tab_name))
+        self._selected_tokens = set(select_all_for_active_tab(snapshots, tab_id))
         self._update_selection_controls()
         if tab_name is not None and tab_name in self._grids:
             self._populate_tab(tab_name)
@@ -1656,6 +2085,10 @@ class Main(QMainWindow):
                 hidden_tabs=list(self.cfg.hidden_tabs),
                 tab_ids=dict(self.cfg.tab_ids),
                 tab_order=list(self.cfg.tab_order),
+                application_extensions=deepcopy(self.cfg.application_extensions),
+                workspace_extensions=deepcopy(self.cfg.workspace_extensions),
+                tab_extensions=deepcopy(self.cfg.tab_extensions),
+                extensions=deepcopy(self.cfg.extensions),
             ),
             tiles_by_identity,
         )
@@ -1886,8 +2319,9 @@ class Main(QMainWindow):
 
         self.add_action.setEnabled(not selecting and not busy)
         self.import_action.setEnabled(not selecting and not busy)
+        active_tab_id = self.cfg.tab_ids[self.current_tab()]
         active_tab_has_tiles = any(
-            tile.tab == self.current_tab() for tile in self.cfg.tiles
+            tile.tab_id == active_tab_id for tile in self.cfg.tiles
         )
         self.select_tiles_action.setEnabled(not busy and active_tab_has_tiles)
         self.selection_count_label.setText(
@@ -1911,6 +2345,41 @@ class Main(QMainWindow):
         self.tabs_widget.tabBar().setMovable(not selecting and not busy)
         self.tabs_widget.setEnabled(not busy)
 
+    def _save_runtime_change(
+        self,
+        previous: _RuntimeChangeSnapshot,
+        *,
+        operation: RuntimeChangeOperation,
+        restore_tab: str,
+        restore_before_rebuild: Callable[[], None] | None = None,
+    ) -> bool:
+        failure_category: RuntimeSaveFailureCategory | None = None
+        try:
+            self.cfg.save()
+        except (OSError, ValueError) as error:
+            failure_category = _runtime_save_failure_category(error)
+        if failure_category is None:
+            return True
+
+        self.cfg = _restore_runtime_change(previous)
+        if restore_before_rebuild is not None:
+            restore_before_rebuild()
+        self.rebuild()
+        self._set_current_tab_by_name(restore_tab)
+        record_breadcrumb(
+            "config_change_save_failed",
+            failure_count=1,
+            failure_category=failure_category,
+            operation=operation,
+        )
+        parent = self if isinstance(self, QWidget) else None
+        QMessageBox.critical(
+            parent,
+            "DesktopTileLauncher",
+            "The change could not be saved. No changes were applied.",
+        )
+        return False
+
     def _on_tab_moved(self, from_index: int, to_index: int) -> None:
         if self._selection_active() or self._active_refresh is not None:
             return
@@ -1927,15 +2396,25 @@ class Main(QMainWindow):
         if updated_order == self.cfg.tab_order:
             return
 
-        state = normalize_tab_order(
-            self.cfg.tabs,
-            self.cfg.tab_ids,
-            updated_order,
-        )
-        if state.tab_ids != self.cfg.tab_ids or state.tab_order != updated_order:
+        if len(updated_order) != len(self.cfg.tab_order) or set(updated_order) != set(
+            self.cfg.tab_order
+        ):
             return
-        _apply_tab_order_state(self.cfg, state)
-        self.cfg.save()
+        title_by_id = {tab_id: title for title, tab_id in self.cfg.tab_ids.items()}
+        try:
+            ordered_titles = [title_by_id[tab_id] for tab_id in updated_order]
+        except KeyError:
+            return
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
+        self.cfg.tab_order = updated_order
+        self.cfg.tabs = ordered_titles
+        Main._save_runtime_change(
+            self,
+            previous,
+            operation="tab_reorder",
+            restore_tab=restore_tab,
+        )
 
     def _set_current_tab_by_name(self, name: str) -> None:
         vis = self._visible_tabs()
@@ -1957,10 +2436,30 @@ class Main(QMainWindow):
             self.toggle_tab_action.setEnabled(False)
 
     def _toggle_auto_fit(self, checked: bool) -> None:
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
+        previous_auto_fit = self.cfg.auto_fit
+        previous_computed_columns = self._computed_columns
         self.cfg.auto_fit = checked
         if not checked:
             self._computed_columns = self.cfg.columns
-        self.cfg.save()
+
+        def restore_auto_fit_state() -> None:
+            self._computed_columns = previous_computed_columns
+            signals_were_blocked = self.auto_fit_action.blockSignals(True)
+            try:
+                self.auto_fit_action.setChecked(previous_auto_fit)
+            finally:
+                self.auto_fit_action.blockSignals(signals_were_blocked)
+
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="auto_fit_toggle",
+            restore_tab=restore_tab,
+            restore_before_rebuild=restore_auto_fit_state,
+        ):
+            return
         self.rebuild()
         self.resize_to_fit_tiles(snap_window=checked)
 
@@ -2014,7 +2513,8 @@ class Main(QMainWindow):
         else:
             cols = max(1, int(self.cfg.columns))
         r = c = 0
-        tab_tiles = [t for t in self.cfg.tiles if t.tab == tab]
+        tab_id = self.cfg.tab_ids[tab]
+        tab_tiles = [t for t in self.cfg.tiles if t.tab_id == tab_id]
         all_tabs = list(self.cfg.tabs)
         for idx, tile in enumerate(tab_tiles):
 
@@ -2120,7 +2620,8 @@ class Main(QMainWindow):
             margins = grid.contentsMargins()
             margins_lr = margins.left() + margins.right()
             margins_tb = margins.top() + margins.bottom()
-            tile_count = len([t for t in self.cfg.tiles if t.tab == current])
+            current_tab_id = self.cfg.tab_ids[current]
+            tile_count = len([t for t in self.cfg.tiles if t.tab_id == current_tab_id])
 
             screen = (
                 self.windowHandle().screen()
@@ -2208,17 +2709,12 @@ class Main(QMainWindow):
         self._closing = True
         try:
             g = self.normalGeometry() if self.isMaximized() else self.frameGeometry()
-            self.cfg.window_w = int(g.width())
-            self.cfg.window_h = int(g.height())
-            self.cfg.window_x = int(g.x())
-            self.cfg.window_y = int(g.y())
-            self.cfg.save()
-            record_breadcrumb(
-                "geometry_saved",
-                w=self.cfg.window_w,
-                h=self.cfg.window_h,
-                x=self.cfg.window_x,
-                y=self.cfg.window_y,
+            _persist_close_geometry(
+                self.cfg,
+                x=int(g.x()),
+                y=int(g.y()),
+                width=int(g.width()),
+                height=int(g.height()),
             )
         finally:
             super().closeEvent(event)
@@ -2510,13 +3006,20 @@ class Main(QMainWindow):
             return
         if from_idx == to_idx:
             return
-        indices = [i for i, t in enumerate(self.cfg.tiles) if t.tab == tab]
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
+        tab_id = self.cfg.tab_ids[tab]
+        indices = [i for i, t in enumerate(self.cfg.tiles) if t.tab_id == tab_id]
         tile = self.cfg.tiles.pop(indices[from_idx])
         insert_at = indices[to_idx]
-        if from_idx < to_idx:
-            insert_at -= 1
         self.cfg.tiles.insert(insert_at, tile)
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tile_reorder",
+            restore_tab=restore_tab,
+        ):
+            return
         self._populate_tab(tab)
 
     def add_tile(self, default_tab: str | None = None) -> None:
@@ -2533,6 +3036,8 @@ class Main(QMainWindow):
             dlg.tab_combo.setCurrentIndex(idx)
         if dlg.exec() == QDialog.DialogCode.Accepted and dlg.data:
             data = dlg.data
+            previous = _runtime_change_snapshot(self.cfg)
+            restore_tab = self.current_tab()
             self.cfg.tiles.append(
                 Tile(
                     name=cast(str, data["name"]),
@@ -2543,23 +3048,33 @@ class Main(QMainWindow):
                     browser=data["browser"],
                     chrome_profile=data["chrome_profile"],
                     open_target=cast(str, data["open_target"]),
+                    tab_id=_tab_id_for_runtime_name(
+                        self.cfg,
+                        cast(str, data["tab"]),
+                    ),
                 )
             )
-            self.cfg.save()
+            if not Main._save_runtime_change(
+                self,
+                previous,
+                operation="tile_add",
+                restore_tab=restore_tab,
+            ):
+                return
             self.rebuild()
             self._set_current_tab_by_name(cast(str, data["tab"]))
-            record_breadcrumb(
-                "tile_add",
-                url=sanitize_url(cast(str, data["url"])),
-                tab=cast(str, data["tab"]),
-            )
+            record_breadcrumb("tile_add")
 
     def import_urls(self, default_tab: str | None = None) -> None:
         previous_visible_tab = self.current_tab()
         destinations = tuple(
             ImportDestination(
                 name=tab,
-                urls=tuple(tile.url for tile in self.cfg.tiles if tile.tab == tab),
+                urls=tuple(
+                    tile.url
+                    for tile in self.cfg.tiles
+                    if tile.tab_id == self.cfg.tab_ids[tab]
+                ),
                 hidden=tab in self.cfg.hidden_tabs,
             )
             for tab in self.cfg.tabs
@@ -2588,17 +3103,21 @@ class Main(QMainWindow):
                     browser=None,
                     chrome_profile=None,
                     open_target="tab",
+                    tab_id=self.cfg.tab_ids[destination],
                 )
                 for selection in selections
             ]
             candidate = _config_with_imported_tiles(self.cfg, imported_tiles)
+            failure_category: RuntimeSaveFailureCategory | None = None
             try:
                 candidate.save()
-            except OSError as exc:
+            except (OSError, ValueError) as exc:
+                failure_category = _runtime_save_failure_category(exc)
+            if failure_category is not None:
                 record_breadcrumb(
                     "url_import_save_failed",
                     imported_count=len(imported_tiles),
-                    error_type=type(exc).__name__,
+                    failure_category=failure_category,
                 )
                 QMessageBox.critical(
                     self,
@@ -2632,22 +3151,39 @@ class Main(QMainWindow):
         )
         if dlg.exec() == QDialog.DialogCode.Accepted and dlg.data:
             data = dlg.data
+            previous = _runtime_change_snapshot(self.cfg)
+            restore_tab = self.current_tab()
             tile.name = cast(str, data["name"])
             tile.url = cast(str, data["url"])
             tile.icon = data["icon"]
             tile.tab = cast(str, data["tab"])
+            tile.tab_id = self.cfg.tab_ids[tile.tab]
             tile.browser = data["browser"]
             tile.chrome_profile = data["chrome_profile"]
             tile.open_target = cast(str, data["open_target"])
-            self.cfg.save()
+            if not Main._save_runtime_change(
+                self,
+                previous,
+                operation="tile_edit",
+                restore_tab=restore_tab,
+            ):
+                return
             self.rebuild()
             self._set_current_tab_by_name(tile.tab)
 
     def duplicate_tile(self, tile: Tile) -> None:
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
         new_tile = replace(tile)
         idx = self.cfg.tiles.index(tile)
         self.cfg.tiles.insert(idx + 1, new_tile)
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tile_duplicate",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
         self._set_current_tab_by_name(tile.tab)
 
@@ -2660,13 +3196,30 @@ class Main(QMainWindow):
             QMessageBox.StandardButton.No,
         )
         if ok == QMessageBox.StandardButton.Yes:
+            previous = _runtime_change_snapshot(self.cfg)
+            restore_tab = self.current_tab()
             self.cfg.tiles = [t for t in self.cfg.tiles if t is not tile]
-            self.cfg.save()
+            if not Main._save_runtime_change(
+                self,
+                previous,
+                operation="tile_remove",
+                restore_tab=restore_tab,
+            ):
+                return
             self.rebuild()
 
     def change_tile_tab(self, tile: Tile, new_tab: str) -> None:
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
         tile.tab = new_tab
-        self.cfg.save()
+        tile.tab_id = self.cfg.tab_ids[new_tab]
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tile_move",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
         self._set_current_tab_by_name(new_tab)
 
@@ -2680,10 +3233,21 @@ class Main(QMainWindow):
                 self, "Tab exists", "A tab with that name exists already."
             )
             return
-        state = add_tab_to_order(_tab_order_state(self.cfg), name)
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
+        state = add_tab_to_order(
+            _tab_order_state(self.cfg),
+            name,
+            blocked_ids=(self.cfg.workspace_id,),
+        )
         _apply_tab_order_state(self.cfg, state)
-        self._enforce_tab_invariants()
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tab_add",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
         self._set_current_tab_by_name(name)
 
@@ -2698,16 +3262,24 @@ class Main(QMainWindow):
                 self, "Tab exists", "A tab with that name exists already."
             )
             return
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
+        renamed_tab_id = self.cfg.tab_ids[current]
         state = rename_tab_in_order(_tab_order_state(self.cfg), current, name)
         _apply_tab_order_state(self.cfg, state)
         for t in self.cfg.tiles:
-            if t.tab == current:
+            if t.tab_id == renamed_tab_id:
                 t.tab = name
         if current in self.cfg.hidden_tabs:
             hidx = self.cfg.hidden_tabs.index(current)
             self.cfg.hidden_tabs[hidx] = name
-        self._enforce_tab_invariants()
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tab_rename",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
         self._set_current_tab_by_name(name)
 
@@ -2715,9 +3287,7 @@ class Main(QMainWindow):
         current = self.current_tab()
         if len(self.cfg.tabs) == 1:
             QMessageBox.warning(self, "Not allowed", "At least one tab must exist.")
-            record_breadcrumb(
-                "tab_action_blocked", action="delete", reason="last_tab", tab=current
-            )
+            record_breadcrumb("tab_action_blocked", action="delete", reason="last_tab")
             return
         ok = QMessageBox.question(
             self,
@@ -2728,12 +3298,20 @@ class Main(QMainWindow):
         )
         if ok != QMessageBox.StandardButton.Yes:
             return
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
+        deleted_tab_id = self.cfg.tab_ids[current]
         state = delete_tab_from_order(_tab_order_state(self.cfg), current)
         _apply_tab_order_state(self.cfg, state)
-        self.cfg.tiles = [t for t in self.cfg.tiles if t.tab != current]
+        self.cfg.tiles = [t for t in self.cfg.tiles if t.tab_id != deleted_tab_id]
         self.cfg.hidden_tabs = [t for t in self.cfg.hidden_tabs if t != current]
-        self._enforce_tab_invariants()
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tab_delete",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
 
     def toggle_current_tab_visibility(self) -> None:
@@ -2747,20 +3325,25 @@ class Main(QMainWindow):
                 "tab_action_blocked",
                 action="hide",
                 reason="last_visible",
-                tab=name,
             )
             return
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
         if hidden:
             self.cfg.hidden_tabs.remove(name)
         else:
             self.cfg.hidden_tabs.append(name)
-        self._enforce_tab_invariants()
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tab_visibility_toggle",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
         self._set_current_tab_by_name(name)
         record_breadcrumb(
             "tab_visibility_toggle_single",
-            tab=name,
             visible=name not in self.cfg.hidden_tabs,
         )
 
@@ -2770,7 +3353,11 @@ class Main(QMainWindow):
             if dlg.exec() != QDialog.DialogCode.Accepted:
                 return
             hidden = dlg.result_hidden()
-            if len(hidden) == len(self.cfg.tabs):
+            if (
+                len(hidden) == len(self.cfg.tabs)
+                or len(set(hidden)) != len(hidden)
+                or not set(hidden).issubset(self.cfg.tabs)
+            ):
                 QMessageBox.warning(
                     self,
                     "Not allowed",
@@ -2778,17 +3365,24 @@ class Main(QMainWindow):
                 )
                 continue
             break
+        previous = _runtime_change_snapshot(self.cfg)
+        restore_tab = self.current_tab()
         self.cfg.hidden_tabs = hidden
-        self._enforce_tab_invariants()
-        self.cfg.save()
+        if not Main._save_runtime_change(
+            self,
+            previous,
+            operation="tab_visibility_manage",
+            restore_tab=restore_tab,
+        ):
+            return
         self.rebuild()
         vis = self._visible_tabs()
         if vis:
             self._set_current_tab_by_name(vis[0])
         record_breadcrumb(
             "tab_visibility_apply",
-            hidden_tabs=self.cfg.hidden_tabs,
-            visible_tabs=self._visible_tabs(),
+            hidden_count=len(self.cfg.hidden_tabs),
+            visible_count=len(self._visible_tabs()),
         )
 
     def _debug_raise(self) -> None:
@@ -2927,8 +3521,21 @@ def _resolve_startup_configuration() -> _StartupReady | _StartupExit:
         )
         return _StartupExit(0)
 
-    config = LauncherConfig.first_run()
-    recovery = preserve_and_reset(CFG_PATH, snapshot, config.serialize())
+    config: LauncherConfig | None = None
+    reset_payload: bytes | None = None
+    try:
+        config = LauncherConfig.first_run()
+        reset_payload = config._serialized_payload()
+    except ValueError:
+        reset_payload = None
+    if config is None or reset_payload is None:
+        recovery = RecoveryFailed(RecoveryFailureCategory.RESET_FAILURE)
+    else:
+        recovery = preserve_and_reset(
+            CFG_PATH,
+            snapshot,
+            reset_payload.decode("utf-8"),
+        )
     if isinstance(recovery, RecoveryFailed):
         record_breadcrumb(
             "config_recovery_failed",
@@ -2941,6 +3548,8 @@ def _resolve_startup_configuration() -> _StartupReady | _StartupExit:
         "config_recovery_succeeded",
         **recovery_result_diagnostics(recovery),
     )
+    if config is None:
+        return _StartupExit(1)
     return _StartupReady(config)
 
 


### PR DESCRIPTION
Closes #112

## Summary

- Add the strict, identity-only configuration schema v1 with stable canonical UUID identities for the single Workspace and its Tabs.
- Add the pure deterministic v0-to-v1 migration that creates exactly one `Default Workspace`, preserves `application.title` independently, and converts Tile membership to Tab IDs.
- Add native-v1 missing/reset configuration construction with bounded injected UUID allocation.
- Preserve legacy Tab order, visibility, Tiles, Tile order, launch behavior, supported identity/order hints, and unknown top-level extensions.
- Integrate stable Workspace/Tab identity through runtime Tab and Tile operations without regenerating IDs during loading, normalization, or saving.
- Contain runtime persistence failures with identity-preserving rollback, fixed privacy-safe classification, and cleanup-safe behavior.

## Compatibility and safety

- Valid current-v1 startup loads directly without a normalization write.
- Unsupported versions, invalid markers or identity graphs, migration rejection, and migration defects fail closed.
- The existing Q4 guarded migration transaction and atomic-write path remain in use.
- Q3 corrupt-configuration recovery and Q4 recovery-copy, failed-candidate, rollback, verification, redaction, and cleanup guarantees remain intact.
- `config_recovery.py` and `config_persistence.py` are unchanged.
- No dependencies, packaging, workflows, releases, v2 entities, Workspace-selection UI, or later-roadmap capabilities are included.

## Validation

- `make format-check`
- `make lint`
- `make lint_tests`
- `.venv/Scripts/python.exe -m ruff check tests`
- `make typecheck`
- `make test_unit`

All gates passed. The unit gate collected 584 tests, selected and passed 577, and deselected 7 under the authorized selector.

Focused coverage includes strict schema validation, deterministic migration, identity collision and reference handling, current-v1 no-write startup, native construction and reset, stable runtime identities, transactional Tab/Tile mutations, Auto-fit rollback, close-time geometry containment, URL-import persistence, privacy, and failure cleanup.

## Manual validation

Isolated Windows source-tree validation at candidate `18433a2784065d1ae4b5e32e6e3f723f7a7c7308` passed.

- Missing-config startup created strict native-v1 state with title `My Launcher`, exactly one `Default Workspace`, stable canonical Workspace/Tab UUIDs, and no identity regeneration on restart.
- A valid current-v1 profile loaded without a startup normalization write. Real QAction and closeEvent paths preserved the identity graph, ordered Tab/Tile membership, state across restart, and existing launch behavior.
- Invalid-profile and controlled persistence-failure cases failed closed. Rollback restored the last complete strict-v1 state and live/action identity state; diagnostics remained privacy-safe; cleanup checks found no temporary transaction residue.
- A representative noncanonical implicit-v0 profile migrated transparently while preserving application title, visible and hidden Tab order, Tile membership and order, supported identity hints, and unknown fields.
- The migration installed exactly one byte-identical recovery copy of the original 1,078-byte v0 source (`SHA-256 7f81e0a69c959dda7868d76bb22710b4252106c1fa62ca475466032e2fe3e97a`).
- Before close, the 2,642-byte live strict-v1 candidate exactly matched deterministic replay (`SHA-256 305aaf20635e7767eb245937f5031ad542a4eb2afdd8c4432d93ddc768b6162e`). Post-close inspection proved that only the four permitted window-geometry fields changed.
- Normal launch and close returned exit code `0`. Final inspection found one permanent recovery copy and zero atomic temporary, partial, failed-candidate, unexpected, or combined transaction-residue entries.

No Q5 package has been built or smoke-tested. The independently packaged baseline remains `e7917ef`.
