### PR TITLE
chore: constrain Ruff below 0.16

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest>=8.2,<10
 pytest-mock>=3.15.1,<4
 
 # Linting / Typing (present or planned in Makefile)
-ruff>=0.15.21,<1
+ruff>=0.15.21,<0.16
 mypy>=2.3.0,<3


### PR DESCRIPTION
## Summary

- Constrains Ruff to `>=0.15.21,<0.16` pending a deliberate Ruff 0.16 migration.
- Restores reproducible lint behavior after Ruff 0.16 expanded its default rules and exposed 166 findings across 36 files.
- Changes only `requirements-dev.txt`; there are no application behavior, production/test code, workflow, Ruff-configuration, ignore, or suppression changes.

## Evidence

- Resolved Ruff version: `ruff 0.15.21`
- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed
- The committed diff is one requirement-line replacement (`+1/-1`).

Closes #116