### PR TITLE
feat: add dormant schema-v2 foundation

### DIFF
--- a/config_schema_v2.py
+++ b/config_schema_v2.py
@@ -1,0 +1,929 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dormant, Qt-free schema-version 2 wire types and strict validation.
+
+This module deliberately does not parse files, register schema support, allocate
+identities, migrate state, or import production startup and persistence code.
+The object-pairs callback is a dormant capability for a later parser boundary;
+``validate_v2`` accepts only an already-decoded mapping.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Final, Literal, TypeAlias, TypedDict, cast
+from uuid import UUID
+
+SCHEMA_VERSION_V2: Final = 2
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+StrictJsonValue: TypeAlias = (
+    JsonScalar | list["StrictJsonValue"] | dict[str, "StrictJsonValue"]
+)
+JsonObject: TypeAlias = dict[str, StrictJsonValue]
+Extensions: TypeAlias = dict[str, StrictJsonValue]
+EntityUUID: TypeAlias = str
+ExternalDeviceKey: TypeAlias = str
+
+Visibility: TypeAlias = Literal["visible", "hidden"]
+Lifecycle: TypeAlias = Literal["active", "archived"]
+ViewMode: TypeAlias = Literal["display", "kanban"]
+WorkflowStatus: TypeAlias = Literal["new", "in_use", "archived"]
+OpenTarget: TypeAlias = Literal["tab", "window"]
+
+
+class Application(TypedDict):
+    """Closed schema-v2 Application wire shape."""
+
+    title: str
+    default_workspace_id: EntityUUID
+    extensions: Extensions
+
+
+class Workspace(TypedDict):
+    """Closed schema-v2 Workspace wire shape."""
+
+    id: EntityUUID
+    name: str
+    tab_order: list[EntityUUID]
+    extensions: Extensions
+
+
+class KanbanOrder(TypedDict):
+    """Closed schema-v2 per-status Kanban queues."""
+
+    new: list[EntityUUID]
+    in_use: list[EntityUUID]
+    archived: list[EntityUUID]
+
+
+class Tab(TypedDict):
+    """Closed schema-v2 Tab wire shape."""
+
+    id: EntityUUID
+    workspace_id: EntityUUID
+    name: str
+    visibility: Visibility
+    lifecycle: Lifecycle
+    view_mode: ViewMode
+    display_filter: list[WorkflowStatus]
+    display_order: list[EntityUUID]
+    kanban_order: KanbanOrder
+    extensions: Extensions
+
+
+class UrlTarget(TypedDict):
+    """Closed opaque URL target."""
+
+    url: str
+
+
+class LegacyStringIcon(TypedDict):
+    """Closed opaque legacy icon value."""
+
+    kind: Literal["legacy_string"]
+    value: str
+
+
+class Resource(TypedDict):
+    """Closed URL-only schema-v2 Resource wire shape."""
+
+    id: EntityUUID
+    kind: Literal["url"]
+    target: UrlTarget
+    default_label: str
+    default_icon: LegacyStringIcon | None
+    extensions: Extensions
+
+
+class Placement(TypedDict):
+    """Closed schema-v2 Placement wire shape."""
+
+    id: EntityUUID
+    resource_id: EntityUUID
+    tab_id: EntityUUID
+    label_override: str | None
+    icon_override: LegacyStringIcon | None
+    background_color: str
+    workflow_status: WorkflowStatus
+    extensions: Extensions
+
+
+class PortableFallback(TypedDict):
+    """Closed portable-fallback applicability selector."""
+
+    kind: Literal["portable_fallback"]
+
+
+class DeviceSpecific(TypedDict):
+    """Closed exact-device applicability selector."""
+
+    kind: Literal["device_specific"]
+    device_key: ExternalDeviceKey
+
+
+DeviceApplicability: TypeAlias = PortableFallback | DeviceSpecific
+
+
+class WindowSettings(TypedDict):
+    """Closed Workspace/window settings."""
+
+    columns: int
+    auto_fit: bool
+    window_x: int | None
+    window_y: int | None
+    window_w: int | None
+    window_h: int | None
+
+
+class UrlLaunchSettings(TypedDict):
+    """Closed Placement/launch settings."""
+
+    browser: str | None
+    chrome_profile: str | None
+    open_target: OpenTarget
+
+
+class WorkspaceWindowBinding(TypedDict):
+    """Closed Workspace/window DeviceBinding variant."""
+
+    id: EntityUUID
+    subject_kind: Literal["workspace"]
+    subject_id: EntityUUID
+    binding_kind: Literal["window"]
+    applicability: DeviceApplicability
+    settings: WindowSettings
+    extensions: Extensions
+
+
+class PlacementLaunchBinding(TypedDict):
+    """Closed Placement/launch DeviceBinding variant."""
+
+    id: EntityUUID
+    subject_kind: Literal["placement"]
+    subject_id: EntityUUID
+    binding_kind: Literal["launch"]
+    applicability: DeviceApplicability
+    settings: UrlLaunchSettings
+    extensions: Extensions
+
+
+DeviceBinding: TypeAlias = WorkspaceWindowBinding | PlacementLaunchBinding
+
+
+class Root(TypedDict):
+    """Complete closed schema-v2 root wire shape."""
+
+    schema_version: Literal[2]
+    application: Application
+    workspaces: list[Workspace]
+    tabs: list[Tab]
+    resources: list[Resource]
+    placements: list[Placement]
+    device_bindings: list[DeviceBinding]
+    extensions: Extensions
+
+
+class DuplicateJsonMemberError(ValueError):
+    """A JSON object repeated a decoded member name at some nesting depth."""
+
+    def __init__(self) -> None:
+        super().__init__("malformed_json")
+
+
+def reject_duplicate_json_members(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    """Build one object or reject a duplicate without exposing its key or value.
+
+    This function is suitable as ``json.loads(..., object_pairs_hook=...)`` but
+    intentionally performs no decoding itself and is not wired into production.
+    """
+
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateJsonMemberError
+        result[key] = value
+    return result
+
+
+_ROOT_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "application",
+        "workspaces",
+        "tabs",
+        "resources",
+        "placements",
+        "device_bindings",
+        "extensions",
+    }
+)
+_APPLICATION_FIELDS: Final = frozenset({"title", "default_workspace_id", "extensions"})
+_WORKSPACE_FIELDS: Final = frozenset({"id", "name", "tab_order", "extensions"})
+_TAB_FIELDS: Final = frozenset(
+    {
+        "id",
+        "workspace_id",
+        "name",
+        "visibility",
+        "lifecycle",
+        "view_mode",
+        "display_filter",
+        "display_order",
+        "kanban_order",
+        "extensions",
+    }
+)
+_KANBAN_FIELDS: Final = frozenset({"new", "in_use", "archived"})
+_URL_TARGET_FIELDS: Final = frozenset({"url"})
+_LEGACY_ICON_FIELDS: Final = frozenset({"kind", "value"})
+_RESOURCE_FIELDS: Final = frozenset(
+    {"id", "kind", "target", "default_label", "default_icon", "extensions"}
+)
+_PLACEMENT_FIELDS: Final = frozenset(
+    {
+        "id",
+        "resource_id",
+        "tab_id",
+        "label_override",
+        "icon_override",
+        "background_color",
+        "workflow_status",
+        "extensions",
+    }
+)
+_DEVICE_BINDING_FIELDS: Final = frozenset(
+    {
+        "id",
+        "subject_kind",
+        "subject_id",
+        "binding_kind",
+        "applicability",
+        "settings",
+        "extensions",
+    }
+)
+_PORTABLE_FALLBACK_FIELDS: Final = frozenset({"kind"})
+_DEVICE_SPECIFIC_FIELDS: Final = frozenset({"kind", "device_key"})
+_WINDOW_SETTINGS_FIELDS: Final = frozenset(
+    {
+        "columns",
+        "auto_fit",
+        "window_x",
+        "window_y",
+        "window_w",
+        "window_h",
+    }
+)
+_URL_LAUNCH_SETTINGS_FIELDS: Final = frozenset(
+    {"browser", "chrome_profile", "open_target"}
+)
+_DISPLAY_FILTER_VALUES: Final = frozenset(
+    {
+        (),
+        ("new",),
+        ("in_use",),
+        ("archived",),
+        ("new", "in_use"),
+        ("new", "archived"),
+        ("in_use", "archived"),
+        ("new", "in_use", "archived"),
+    }
+)
+_WORKFLOW_STATUSES: Final = ("new", "in_use", "archived")
+
+
+def _is_utf8_text(value: str) -> bool:
+    try:
+        value.encode("utf-8")
+    except UnicodeError:
+        return False
+    return True
+
+
+def _is_strict_json(value: object) -> bool:
+    """Validate a finite, UTF-8-encodable JSON tree without a depth limit."""
+
+    active: set[int] = set()
+    stack: list[tuple[object, bool]] = [(value, False)]
+    while stack:
+        current, leaving = stack.pop()
+        value_type = type(current)
+        if leaving:
+            active.remove(id(current))
+            continue
+        if current is None or value_type in (bool, int):
+            continue
+        if value_type is float:
+            if not math.isfinite(cast(float, current)):
+                return False
+            continue
+        if value_type is str:
+            if not _is_utf8_text(cast(str, current)):
+                return False
+            continue
+        if value_type is list:
+            marker = id(current)
+            if marker in active:
+                return False
+            active.add(marker)
+            stack.append((current, True))
+            for item in reversed(cast(list[object], current)):
+                stack.append((item, False))
+            continue
+        if value_type is dict:
+            marker = id(current)
+            if marker in active:
+                return False
+            mapping = cast(dict[object, object], current)
+            for key in mapping:
+                if type(key) is not str or not _is_utf8_text(key):
+                    return False
+            active.add(marker)
+            stack.append((current, True))
+            for item in reversed(list(mapping.values())):
+                stack.append((item, False))
+            continue
+        return False
+    return True
+
+
+def _object(value: object) -> dict[str, object] | None:
+    if type(value) is not dict:
+        return None
+    return cast(dict[str, object], value)
+
+
+def _array(value: object) -> list[object] | None:
+    if type(value) is not list:
+        return None
+    return cast(list[object], value)
+
+
+def _closed(value: object, fields: frozenset[str]) -> dict[str, object] | None:
+    mapping = _object(value)
+    if mapping is None or set(mapping) != fields:
+        return None
+    return mapping
+
+
+def _is_string(value: object) -> bool:
+    return type(value) is str
+
+
+def _is_nonempty_string(value: object) -> bool:
+    return type(value) is str and bool(value)
+
+
+def _is_nullable_string(value: object) -> bool:
+    return value is None or type(value) is str
+
+
+def _is_exact_int(value: object) -> bool:
+    return type(value) is int
+
+
+def _is_nullable_int(value: object) -> bool:
+    return value is None or _is_exact_int(value)
+
+
+def _is_string_array(value: object) -> bool:
+    array = _array(value)
+    return array is not None and all(type(item) is str for item in array)
+
+
+def _is_extensions(value: object) -> bool:
+    return type(value) is dict
+
+
+def _is_application(value: object) -> bool:
+    application = _closed(value, _APPLICATION_FIELDS)
+    return application is not None and all(
+        (
+            _is_string(application["title"]),
+            _is_string(application["default_workspace_id"]),
+            _is_extensions(application["extensions"]),
+        )
+    )
+
+
+def _is_workspace(value: object) -> bool:
+    workspace = _closed(value, _WORKSPACE_FIELDS)
+    return workspace is not None and all(
+        (
+            _is_string(workspace["id"]),
+            _is_nonempty_string(workspace["name"]),
+            _is_string_array(workspace["tab_order"]),
+            _is_extensions(workspace["extensions"]),
+        )
+    )
+
+
+def _is_kanban_order(value: object) -> bool:
+    order = _closed(value, _KANBAN_FIELDS)
+    return order is not None and all(
+        _is_string_array(order[status]) for status in _WORKFLOW_STATUSES
+    )
+
+
+def _is_tab(value: object) -> bool:
+    tab = _closed(value, _TAB_FIELDS)
+    if tab is None:
+        return False
+    return all(
+        (
+            _is_string(tab["id"]),
+            _is_string(tab["workspace_id"]),
+            _is_nonempty_string(tab["name"]),
+            type(tab["visibility"]) is str
+            and tab["visibility"] in ("visible", "hidden"),
+            type(tab["lifecycle"]) is str
+            and tab["lifecycle"] in ("active", "archived"),
+            type(tab["view_mode"]) is str and tab["view_mode"] in ("display", "kanban"),
+            _is_string_array(tab["display_filter"]),
+            _is_string_array(tab["display_order"]),
+            _is_kanban_order(tab["kanban_order"]),
+            _is_extensions(tab["extensions"]),
+        )
+    )
+
+
+def _is_url_target(value: object) -> bool:
+    target = _closed(value, _URL_TARGET_FIELDS)
+    return target is not None and _is_string(target["url"])
+
+
+def _is_legacy_icon(value: object) -> bool:
+    icon = _closed(value, _LEGACY_ICON_FIELDS)
+    return (
+        icon is not None
+        and type(icon["kind"]) is str
+        and icon["kind"] == "legacy_string"
+        and _is_string(icon["value"])
+    )
+
+
+def _is_nullable_icon(value: object) -> bool:
+    return value is None or _is_legacy_icon(value)
+
+
+def _is_resource(value: object) -> bool:
+    resource = _closed(value, _RESOURCE_FIELDS)
+    return resource is not None and all(
+        (
+            _is_string(resource["id"]),
+            type(resource["kind"]) is str and resource["kind"] == "url",
+            _is_url_target(resource["target"]),
+            _is_string(resource["default_label"]),
+            _is_nullable_icon(resource["default_icon"]),
+            _is_extensions(resource["extensions"]),
+        )
+    )
+
+
+def _is_placement(value: object) -> bool:
+    placement = _closed(value, _PLACEMENT_FIELDS)
+    return placement is not None and all(
+        (
+            _is_string(placement["id"]),
+            _is_string(placement["resource_id"]),
+            _is_string(placement["tab_id"]),
+            _is_nullable_string(placement["label_override"]),
+            _is_nullable_icon(placement["icon_override"]),
+            _is_string(placement["background_color"]),
+            type(placement["workflow_status"]) is str
+            and placement["workflow_status"] in _WORKFLOW_STATUSES,
+            _is_extensions(placement["extensions"]),
+        )
+    )
+
+
+def _is_applicability(value: object) -> bool:
+    applicability = _object(value)
+    if applicability is None:
+        return False
+    kind = applicability.get("kind")
+    if type(kind) is not str:
+        return False
+    if kind == "portable_fallback":
+        return set(applicability) == _PORTABLE_FALLBACK_FIELDS
+    if kind == "device_specific":
+        return set(applicability) == _DEVICE_SPECIFIC_FIELDS and _is_nonempty_string(
+            applicability["device_key"]
+        )
+    return False
+
+
+def _is_window_settings(value: object) -> bool:
+    settings = _closed(value, _WINDOW_SETTINGS_FIELDS)
+    return settings is not None and all(
+        (
+            _is_exact_int(settings["columns"]),
+            type(settings["auto_fit"]) is bool,
+            _is_nullable_int(settings["window_x"]),
+            _is_nullable_int(settings["window_y"]),
+            _is_nullable_int(settings["window_w"]),
+            _is_nullable_int(settings["window_h"]),
+        )
+    )
+
+
+def _is_url_launch_settings(value: object) -> bool:
+    settings = _closed(value, _URL_LAUNCH_SETTINGS_FIELDS)
+    return settings is not None and all(
+        (
+            _is_nullable_string(settings["browser"]),
+            _is_nullable_string(settings["chrome_profile"]),
+            type(settings["open_target"]) is str
+            and settings["open_target"] in ("tab", "window"),
+        )
+    )
+
+
+def _is_device_binding(value: object) -> bool:
+    binding = _closed(value, _DEVICE_BINDING_FIELDS)
+    if binding is None or not all(
+        (
+            _is_string(binding["id"]),
+            _is_string(binding["subject_id"]),
+            _is_applicability(binding["applicability"]),
+            _is_extensions(binding["extensions"]),
+        )
+    ):
+        return False
+    subject_kind = binding["subject_kind"]
+    binding_kind = binding["binding_kind"]
+    if (
+        type(subject_kind) is str
+        and subject_kind == "workspace"
+        and type(binding_kind) is str
+        and binding_kind == "window"
+    ):
+        return _is_window_settings(binding["settings"])
+    if (
+        type(subject_kind) is str
+        and subject_kind == "placement"
+        and type(binding_kind) is str
+        and binding_kind == "launch"
+    ):
+        return _is_url_launch_settings(binding["settings"])
+    return False
+
+
+@dataclass(frozen=True, slots=True)
+class _LocalState:
+    root: dict[str, object]
+    application: dict[str, object]
+    workspaces: list[dict[str, object]]
+    tabs: list[dict[str, object]]
+    resources: list[dict[str, object]]
+    placements: list[dict[str, object]]
+    device_bindings: list[dict[str, object]]
+
+
+def _typed_objects(
+    value: object,
+    validator: Callable[[object], bool],
+) -> list[dict[str, object]] | None:
+    array = _array(value)
+    if array is None:
+        return None
+    if not all(validator(item) for item in array):
+        return None
+    return [cast(dict[str, object], item) for item in array]
+
+
+def _validate_local_shapes(document: object) -> _LocalState | None:
+    root = _closed(document, _ROOT_FIELDS)
+    if root is None:
+        return None
+    if (
+        not _is_exact_int(root["schema_version"])
+        or root["schema_version"] != SCHEMA_VERSION_V2
+        or not _is_application(root["application"])
+        or not _is_extensions(root["extensions"])
+    ):
+        return None
+    workspaces = _typed_objects(root["workspaces"], _is_workspace)
+    tabs = _typed_objects(root["tabs"], _is_tab)
+    resources = _typed_objects(root["resources"], _is_resource)
+    placements = _typed_objects(root["placements"], _is_placement)
+    device_bindings = _typed_objects(
+        root["device_bindings"],
+        _is_device_binding,
+    )
+    if (
+        workspaces is None
+        or not workspaces
+        or tabs is None
+        or not tabs
+        or resources is None
+        or placements is None
+        or device_bindings is None
+    ):
+        return None
+    return _LocalState(
+        root,
+        cast(dict[str, object], root["application"]),
+        workspaces,
+        tabs,
+        resources,
+        placements,
+        device_bindings,
+    )
+
+
+def _valid_display_filters(tabs: list[dict[str, object]]) -> bool:
+    return all(
+        tuple(cast(list[str], tab["display_filter"])) in _DISPLAY_FILTER_VALUES
+        for tab in tabs
+    )
+
+
+def _canonical_uuid(value: object) -> str | None:
+    if type(value) is not str:
+        return None
+    text = value
+    try:
+        parsed = UUID(text)
+    except ValueError:
+        return None
+    canonical = str(parsed)
+    return canonical if text == canonical else None
+
+
+@dataclass(frozen=True, slots=True)
+class _Indexes:
+    workspaces: dict[str, dict[str, object]]
+    tabs: dict[str, dict[str, object]]
+    resources: dict[str, dict[str, object]]
+    placements: dict[str, dict[str, object]]
+    device_bindings: dict[str, dict[str, object]]
+
+
+def _definition_index(
+    definitions: list[dict[str, object]],
+    used: set[str],
+) -> dict[str, dict[str, object]] | None:
+    index: dict[str, dict[str, object]] = {}
+    for definition in definitions:
+        entity_id = _canonical_uuid(definition["id"])
+        if entity_id is None or entity_id in used:
+            return None
+        used.add(entity_id)
+        index[entity_id] = definition
+    return index
+
+
+def _reference_values(state: _LocalState) -> list[object]:
+    values: list[object] = [state.application["default_workspace_id"]]
+    for workspace in state.workspaces:
+        values.extend(cast(list[object], workspace["tab_order"]))
+    for tab in state.tabs:
+        values.append(tab["workspace_id"])
+        values.extend(cast(list[object], tab["display_order"]))
+        kanban = cast(dict[str, object], tab["kanban_order"])
+        for status in _WORKFLOW_STATUSES:
+            values.extend(cast(list[object], kanban[status]))
+    for placement in state.placements:
+        values.extend((placement["resource_id"], placement["tab_id"]))
+    values.extend(binding["subject_id"] for binding in state.device_bindings)
+    return values
+
+
+def _validate_identities(state: _LocalState) -> _Indexes | None:
+    used: set[str] = set()
+    workspaces = _definition_index(state.workspaces, used)
+    tabs = _definition_index(state.tabs, used)
+    resources = _definition_index(state.resources, used)
+    placements = _definition_index(state.placements, used)
+    device_bindings = _definition_index(state.device_bindings, used)
+    if any(
+        index is None
+        for index in (workspaces, tabs, resources, placements, device_bindings)
+    ):
+        return None
+    if any(_canonical_uuid(value) is None for value in _reference_values(state)):
+        return None
+    return _Indexes(
+        cast(dict[str, dict[str, object]], workspaces),
+        cast(dict[str, dict[str, object]], tabs),
+        cast(dict[str, dict[str, object]], resources),
+        cast(dict[str, dict[str, object]], placements),
+        cast(dict[str, dict[str, object]], device_bindings),
+    )
+
+
+def _validate_references(state: _LocalState, indexes: _Indexes) -> bool:
+    if state.application["default_workspace_id"] not in indexes.workspaces:
+        return False
+    for tab in state.tabs:
+        if tab["workspace_id"] not in indexes.workspaces:
+            return False
+    for placement in state.placements:
+        if (
+            placement["tab_id"] not in indexes.tabs
+            or placement["resource_id"] not in indexes.resources
+        ):
+            return False
+    for binding in state.device_bindings:
+        subject_id = cast(str, binding["subject_id"])
+        subject_kind = binding["subject_kind"]
+        if subject_kind == "workspace":
+            if subject_id not in indexes.workspaces:
+                return False
+        elif subject_kind == "placement":
+            if subject_id not in indexes.placements:
+                return False
+        else:
+            return False
+    return True
+
+
+def _exact_unique_members(actual: list[str], expected: set[str]) -> bool:
+    return len(actual) == len(set(actual)) and set(actual) == expected
+
+
+def _validate_definition_orders(state: _LocalState) -> bool:
+    tabs_by_workspace: dict[str, set[str]] = {
+        cast(str, workspace["id"]): set() for workspace in state.workspaces
+    }
+    for tab in state.tabs:
+        tabs_by_workspace[cast(str, tab["workspace_id"])].add(cast(str, tab["id"]))
+    for workspace in state.workspaces:
+        workspace_id = cast(str, workspace["id"])
+        order = cast(list[str], workspace["tab_order"])
+        if not _exact_unique_members(order, tabs_by_workspace[workspace_id]):
+            return False
+
+    placements_by_tab: dict[str, set[str]] = {
+        cast(str, tab["id"]): set() for tab in state.tabs
+    }
+    for placement in state.placements:
+        placements_by_tab[cast(str, placement["tab_id"])].add(
+            cast(str, placement["id"])
+        )
+    for tab in state.tabs:
+        tab_id = cast(str, tab["id"])
+        order = cast(list[str], tab["display_order"])
+        if not _exact_unique_members(order, placements_by_tab[tab_id]):
+            return False
+    return True
+
+
+def _validate_names_and_default(state: _LocalState) -> bool:
+    workspace_names = [cast(str, workspace["name"]) for workspace in state.workspaces]
+    if len(workspace_names) != len(set(workspace_names)):
+        return False
+
+    tab_names_by_workspace: dict[str, set[str]] = {
+        cast(str, workspace["id"]): set() for workspace in state.workspaces
+    }
+    for tab in state.tabs:
+        owner_id = cast(str, tab["workspace_id"])
+        name = cast(str, tab["name"])
+        if name in tab_names_by_workspace[owner_id]:
+            return False
+        tab_names_by_workspace[owner_id].add(name)
+
+    default_workspace_id = state.application["default_workspace_id"]
+    return any(
+        tab["workspace_id"] == default_workspace_id
+        and tab["lifecycle"] == "active"
+        and tab["visibility"] == "visible"
+        for tab in state.tabs
+    )
+
+
+def _validate_kanban_references(
+    state: _LocalState,
+    indexes: _Indexes,
+) -> bool:
+    for tab in state.tabs:
+        tab_id = tab["id"]
+        kanban = cast(dict[str, object], tab["kanban_order"])
+        for status in _WORKFLOW_STATUSES:
+            for placement_id in cast(list[str], kanban[status]):
+                placement = indexes.placements.get(placement_id)
+                if placement is None or placement["tab_id"] != tab_id:
+                    return False
+    return True
+
+
+def _validate_kanban_membership(state: _LocalState) -> bool:
+    placements_by_tab: dict[str, set[str]] = {
+        cast(str, tab["id"]): set() for tab in state.tabs
+    }
+    placement_status: dict[str, str] = {}
+    for placement in state.placements:
+        placement_id = cast(str, placement["id"])
+        placements_by_tab[cast(str, placement["tab_id"])].add(placement_id)
+        placement_status[placement_id] = cast(str, placement["workflow_status"])
+
+    for tab in state.tabs:
+        tab_id = cast(str, tab["id"])
+        kanban = cast(dict[str, object], tab["kanban_order"])
+        represented: set[str] = set()
+        for status in _WORKFLOW_STATUSES:
+            queue = cast(list[str], kanban[status])
+            queue_set = set(queue)
+            if (
+                len(queue) != len(queue_set)
+                or represented.intersection(queue_set)
+                or any(placement_status[item] != status for item in queue)
+            ):
+                return False
+            represented.update(queue_set)
+        if represented != placements_by_tab[tab_id]:
+            return False
+    return True
+
+
+def _applicability_selector(applicability: dict[str, object]) -> tuple[str, str]:
+    kind = cast(str, applicability["kind"])
+    if kind == "portable_fallback":
+        return kind, ""
+    return kind, cast(str, applicability["device_key"])
+
+
+def _validate_binding_selectors(state: _LocalState) -> bool:
+    selectors: set[tuple[str, str, str, str, str]] = set()
+    for binding in state.device_bindings:
+        applicability = cast(dict[str, object], binding["applicability"])
+        applicability_kind, device_key = _applicability_selector(applicability)
+        selector = (
+            cast(str, binding["subject_kind"]),
+            cast(str, binding["subject_id"]),
+            cast(str, binding["binding_kind"]),
+            applicability_kind,
+            device_key,
+        )
+        if selector in selectors:
+            return False
+        selectors.add(selector)
+    return True
+
+
+def validate_v2(document: object) -> bool:
+    """Return whether *document* is the complete strict schema-v2 graph.
+
+    Validation is reject-only and does not normalize, repair, sort, deduplicate,
+    allocate, or mutate any value.
+    """
+
+    if not _is_strict_json(document):
+        return False
+    state = _validate_local_shapes(document)
+    if state is None or not _valid_display_filters(state.tabs):
+        return False
+    indexes = _validate_identities(state)
+    if indexes is None or not _validate_references(state, indexes):
+        return False
+    if not _validate_definition_orders(state):
+        return False
+    if not _validate_names_and_default(state):
+        return False
+    if not _validate_kanban_references(state, indexes):
+        return False
+    if not _validate_kanban_membership(state):
+        return False
+    return _validate_binding_selectors(state)
+
+
+__all__ = [
+    "Application",
+    "DeviceApplicability",
+    "DeviceBinding",
+    "DeviceSpecific",
+    "DuplicateJsonMemberError",
+    "EntityUUID",
+    "Extensions",
+    "ExternalDeviceKey",
+    "JsonObject",
+    "JsonScalar",
+    "KanbanOrder",
+    "LegacyStringIcon",
+    "Lifecycle",
+    "OpenTarget",
+    "Placement",
+    "PlacementLaunchBinding",
+    "PortableFallback",
+    "Resource",
+    "Root",
+    "SCHEMA_VERSION_V2",
+    "StrictJsonValue",
+    "Tab",
+    "UrlLaunchSettings",
+    "UrlTarget",
+    "ViewMode",
+    "Visibility",
+    "WindowSettings",
+    "WorkflowStatus",
+    "Workspace",
+    "WorkspaceWindowBinding",
+    "reject_duplicate_json_members",
+    "validate_v2",
+]

--- a/config_serialization_v2.py
+++ b/config_serialization_v2.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dormant canonical serialization for complete schema-version 2 candidates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Final, TypeAlias
+
+from config_migration import (
+    PureEngineFailureCategory as _PureEngineFailureCategory,
+    PureExecutionRejectionCategory as _PureExecutionRejectionCategory,
+    PureExecutionStage as _PureExecutionStage,
+)
+from config_schema_v2 import validate_v2
+
+MAX_V2_CANDIDATE_BYTES: Final = 4 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class SerializedV2Document:
+    """Canonical UTF-8 bytes admitted by the inclusive candidate ceiling."""
+
+    data: bytes = field(repr=False)
+    byte_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class V2SerializationRejected:
+    """A candidate failed without retaining or exposing its contents."""
+
+    category: _PureExecutionRejectionCategory | _PureEngineFailureCategory
+    stage: _PureExecutionStage
+
+
+V2SerializationResult: TypeAlias = SerializedV2Document | V2SerializationRejected
+
+
+def serialize_v2(
+    document: object,
+) -> V2SerializationResult:
+    """Validate and canonically serialize one complete schema-v2 candidate."""
+
+    if not validate_v2(document):
+        return V2SerializationRejected(
+            _PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE,
+            _PureExecutionStage.TARGET_VALIDATION,
+        )
+    try:
+        serialized = json.dumps(
+            document,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        ).encode("utf-8")
+    except Exception:
+        return V2SerializationRejected(
+            _PureEngineFailureCategory.SERIALIZATION_FAILURE,
+            _PureExecutionStage.SERIALIZATION,
+        )
+    if len(serialized) > MAX_V2_CANDIDATE_BYTES:
+        return V2SerializationRejected(
+            _PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED,
+            _PureExecutionStage.SERIALIZATION,
+        )
+    return SerializedV2Document(serialized, len(serialized))
+
+
+__all__ = [
+    "MAX_V2_CANDIDATE_BYTES",
+    "SerializedV2Document",
+    "V2SerializationRejected",
+    "V2SerializationResult",
+    "serialize_v2",
+]

--- a/tests/fixtures/schema_v2/minimal.json
+++ b/tests/fixtures/schema_v2/minimal.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 2,
+  "application": {
+    "title": "",
+    "default_workspace_id": "11111111-1111-4111-8111-111111111111",
+    "extensions": {}
+  },
+  "workspaces": [
+    {
+      "id": "11111111-1111-4111-8111-111111111111",
+      "name": "Default Workspace",
+      "tab_order": [
+        "22222222-2222-4222-8222-222222222222"
+      ],
+      "extensions": {}
+    }
+  ],
+  "tabs": [
+    {
+      "id": "22222222-2222-4222-8222-222222222222",
+      "workspace_id": "11111111-1111-4111-8111-111111111111",
+      "name": "Main",
+      "visibility": "visible",
+      "lifecycle": "active",
+      "view_mode": "display",
+      "display_filter": [],
+      "display_order": [],
+      "kanban_order": {
+        "new": [],
+        "in_use": [],
+        "archived": []
+      },
+      "extensions": {}
+    }
+  ],
+  "resources": [],
+  "placements": [],
+  "device_bindings": [],
+  "extensions": {}
+}

--- a/tests/fixtures/schema_v2/representative.json
+++ b/tests/fixtures/schema_v2/representative.json
@@ -1,0 +1,400 @@
+{
+  "schema_version": 2,
+  "application": {
+    "title": "Café 東京",
+    "default_workspace_id": "10000000-0000-4000-8000-000000000001",
+    "extensions": {
+      "app.example.test": {
+        "note": "synthetic"
+      }
+    }
+  },
+  "workspaces": [
+    {
+      "id": "10000000-0000-4000-8000-000000000001",
+      "name": "Primary",
+      "tab_order": [
+        "20000000-0000-4000-8000-000000000001",
+        "20000000-0000-4000-8000-000000000002",
+        "20000000-0000-4000-8000-000000000003",
+        "20000000-0000-4000-8000-000000000004"
+      ],
+      "extensions": {
+        "workspace.example.test": true
+      }
+    },
+    {
+      "id": "10000000-0000-4000-8000-000000000002",
+      "name": "Secondary",
+      "tab_order": [
+        "20000000-0000-4000-8000-000000000005"
+      ],
+      "extensions": {}
+    },
+    {
+      "id": "10000000-0000-4000-8000-000000000003",
+      "name": "Empty",
+      "tab_order": [],
+      "extensions": {}
+    }
+  ],
+  "tabs": [
+    {
+      "id": "20000000-0000-4000-8000-000000000001",
+      "workspace_id": "10000000-0000-4000-8000-000000000001",
+      "name": "Main",
+      "visibility": "visible",
+      "lifecycle": "active",
+      "view_mode": "display",
+      "display_filter": [
+        "new",
+        "in_use"
+      ],
+      "display_order": [
+        "40000000-0000-4000-8000-000000000002",
+        "40000000-0000-4000-8000-000000000001",
+        "40000000-0000-4000-8000-000000000003"
+      ],
+      "kanban_order": {
+        "new": [
+          "40000000-0000-4000-8000-000000000001"
+        ],
+        "in_use": [
+          "40000000-0000-4000-8000-000000000002"
+        ],
+        "archived": [
+          "40000000-0000-4000-8000-000000000003"
+        ]
+      },
+      "extensions": {
+        "tab.example.test": {
+          "selected": null
+        }
+      }
+    },
+    {
+      "id": "20000000-0000-4000-8000-000000000002",
+      "workspace_id": "10000000-0000-4000-8000-000000000001",
+      "name": "Archive Visible",
+      "visibility": "visible",
+      "lifecycle": "archived",
+      "view_mode": "kanban",
+      "display_filter": [
+        "archived"
+      ],
+      "display_order": [
+        "40000000-0000-4000-8000-000000000004"
+      ],
+      "kanban_order": {
+        "new": [
+          "40000000-0000-4000-8000-000000000004"
+        ],
+        "in_use": [],
+        "archived": []
+      },
+      "extensions": {}
+    },
+    {
+      "id": "20000000-0000-4000-8000-000000000003",
+      "workspace_id": "10000000-0000-4000-8000-000000000001",
+      "name": "Hidden Active",
+      "visibility": "hidden",
+      "lifecycle": "active",
+      "view_mode": "display",
+      "display_filter": [
+        "new",
+        "in_use",
+        "archived"
+      ],
+      "display_order": [],
+      "kanban_order": {
+        "new": [],
+        "in_use": [],
+        "archived": []
+      },
+      "extensions": {}
+    },
+    {
+      "id": "20000000-0000-4000-8000-000000000004",
+      "workspace_id": "10000000-0000-4000-8000-000000000001",
+      "name": "Hidden Archive",
+      "visibility": "hidden",
+      "lifecycle": "archived",
+      "view_mode": "kanban",
+      "display_filter": [
+        "new",
+        "archived"
+      ],
+      "display_order": [],
+      "kanban_order": {
+        "new": [],
+        "in_use": [],
+        "archived": []
+      },
+      "extensions": {}
+    },
+    {
+      "id": "20000000-0000-4000-8000-000000000005",
+      "workspace_id": "10000000-0000-4000-8000-000000000002",
+      "name": "Main",
+      "visibility": "visible",
+      "lifecycle": "active",
+      "view_mode": "display",
+      "display_filter": [
+        "in_use"
+      ],
+      "display_order": [
+        "40000000-0000-4000-8000-000000000005"
+      ],
+      "kanban_order": {
+        "new": [],
+        "in_use": [
+          "40000000-0000-4000-8000-000000000005"
+        ],
+        "archived": []
+      },
+      "extensions": {}
+    }
+  ],
+  "resources": [
+    {
+      "id": "30000000-0000-4000-8000-000000000001",
+      "kind": "url",
+      "target": {
+        "url": "https://shared.example.test/path"
+      },
+      "default_label": "Shared",
+      "default_icon": null,
+      "extensions": {
+        "resource.example.test": [
+          2,
+          1
+        ]
+      }
+    },
+    {
+      "id": "30000000-0000-4000-8000-000000000002",
+      "kind": "url",
+      "target": {
+        "url": "https://shared.example.test/path"
+      },
+      "default_label": "Shared",
+      "default_icon": null,
+      "extensions": {
+        "resource.example.test": [
+          2,
+          1
+        ]
+      }
+    },
+    {
+      "id": "30000000-0000-4000-8000-000000000003",
+      "kind": "url",
+      "target": {
+        "url": ""
+      },
+      "default_label": "",
+      "default_icon": {
+        "kind": "legacy_string",
+        "value": ""
+      },
+      "extensions": {
+        "orphan.example.test": "kept"
+      }
+    },
+    {
+      "id": "30000000-0000-4000-8000-000000000004",
+      "kind": "url",
+      "target": {
+        "url": "custom+demo://example.test/路径"
+      },
+      "default_label": "例",
+      "default_icon": {
+        "kind": "legacy_string",
+        "value": "opaque-icon-value"
+      },
+      "extensions": {}
+    }
+  ],
+  "placements": [
+    {
+      "id": "40000000-0000-4000-8000-000000000001",
+      "resource_id": "30000000-0000-4000-8000-000000000001",
+      "tab_id": "20000000-0000-4000-8000-000000000001",
+      "label_override": null,
+      "icon_override": null,
+      "background_color": "",
+      "workflow_status": "new",
+      "extensions": {}
+    },
+    {
+      "id": "40000000-0000-4000-8000-000000000002",
+      "resource_id": "30000000-0000-4000-8000-000000000001",
+      "tab_id": "20000000-0000-4000-8000-000000000001",
+      "label_override": "",
+      "icon_override": {
+        "kind": "legacy_string",
+        "value": ""
+      },
+      "background_color": "not-a-color",
+      "workflow_status": "in_use",
+      "extensions": {
+        "placement.example.test": {
+          "inheritance": false
+        }
+      }
+    },
+    {
+      "id": "40000000-0000-4000-8000-000000000003",
+      "resource_id": "30000000-0000-4000-8000-000000000002",
+      "tab_id": "20000000-0000-4000-8000-000000000001",
+      "label_override": "Archived",
+      "icon_override": null,
+      "background_color": "transparent-ish",
+      "workflow_status": "archived",
+      "extensions": {}
+    },
+    {
+      "id": "40000000-0000-4000-8000-000000000004",
+      "resource_id": "30000000-0000-4000-8000-000000000004",
+      "tab_id": "20000000-0000-4000-8000-000000000002",
+      "label_override": null,
+      "icon_override": null,
+      "background_color": "蓝色",
+      "workflow_status": "new",
+      "extensions": {}
+    },
+    {
+      "id": "40000000-0000-4000-8000-000000000005",
+      "resource_id": "30000000-0000-4000-8000-000000000001",
+      "tab_id": "20000000-0000-4000-8000-000000000005",
+      "label_override": "Secondary placement",
+      "icon_override": null,
+      "background_color": "#123456",
+      "workflow_status": "in_use",
+      "extensions": {}
+    }
+  ],
+  "device_bindings": [
+    {
+      "id": "50000000-0000-4000-8000-000000000001",
+      "subject_kind": "workspace",
+      "subject_id": "10000000-0000-4000-8000-000000000001",
+      "binding_kind": "window",
+      "applicability": {
+        "kind": "portable_fallback"
+      },
+      "settings": {
+        "columns": -1,
+        "auto_fit": true,
+        "window_x": -20,
+        "window_y": 0,
+        "window_w": null,
+        "window_h": 900
+      },
+      "extensions": {}
+    },
+    {
+      "id": "50000000-0000-4000-8000-000000000002",
+      "subject_kind": "workspace",
+      "subject_id": "10000000-0000-4000-8000-000000000001",
+      "binding_kind": "window",
+      "applicability": {
+        "kind": "device_specific",
+        "device_key": "device-A"
+      },
+      "settings": {
+        "columns": 0,
+        "auto_fit": false,
+        "window_x": null,
+        "window_y": null,
+        "window_w": null,
+        "window_h": null
+      },
+      "extensions": {
+        "binding.example.test": null
+      }
+    },
+    {
+      "id": "50000000-0000-4000-8000-000000000003",
+      "subject_kind": "workspace",
+      "subject_id": "10000000-0000-4000-8000-000000000002",
+      "binding_kind": "window",
+      "applicability": {
+        "kind": "device_specific",
+        "device_key": "   "
+      },
+      "settings": {
+        "columns": 5,
+        "auto_fit": true,
+        "window_x": 1,
+        "window_y": 2,
+        "window_w": 3,
+        "window_h": 4
+      },
+      "extensions": {}
+    },
+    {
+      "id": "50000000-0000-4000-8000-000000000004",
+      "subject_kind": "placement",
+      "subject_id": "40000000-0000-4000-8000-000000000001",
+      "binding_kind": "launch",
+      "applicability": {
+        "kind": "portable_fallback"
+      },
+      "settings": {
+        "browser": null,
+        "chrome_profile": "",
+        "open_target": "tab"
+      },
+      "extensions": {}
+    },
+    {
+      "id": "50000000-0000-4000-8000-000000000005",
+      "subject_kind": "placement",
+      "subject_id": "40000000-0000-4000-8000-000000000001",
+      "binding_kind": "launch",
+      "applicability": {
+        "kind": "device_specific",
+        "device_key": "device-A"
+      },
+      "settings": {
+        "browser": "Unsupported Browser",
+        "chrome_profile": "   ",
+        "open_target": "window"
+      },
+      "extensions": {}
+    },
+    {
+      "id": "50000000-0000-4000-8000-000000000006",
+      "subject_kind": "placement",
+      "subject_id": "40000000-0000-4000-8000-000000000005",
+      "binding_kind": "launch",
+      "applicability": {
+        "kind": "device_specific",
+        "device_key": "device-A"
+      },
+      "settings": {
+        "browser": "",
+        "chrome_profile": null,
+        "open_target": "tab"
+      },
+      "extensions": {}
+    }
+  ],
+  "extensions": {
+    "root.example.test": {
+      "nullable": null,
+      "ordered": [
+        2,
+        1
+      ],
+      "schema_version": 999,
+      "nested": {
+        "extensions": {
+          "opaque": true
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_config_schema_v2.py
+++ b/tests/unit/test_config_schema_v2.py
@@ -1,0 +1,1057 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+import unicodedata
+from copy import deepcopy
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import config_schema_v2 as schema
+
+pytestmark = pytest.mark.unit
+
+FIXTURE_ROOT = Path(__file__).parents[1] / "fixtures" / "schema_v2"
+
+WORKSPACE_1 = "10000000-0000-4000-8000-000000000001"
+WORKSPACE_2 = "10000000-0000-4000-8000-000000000002"
+TAB_1 = "20000000-0000-4000-8000-000000000001"
+TAB_2 = "20000000-0000-4000-8000-000000000002"
+TAB_3 = "20000000-0000-4000-8000-000000000003"
+TAB_4 = "20000000-0000-4000-8000-000000000004"
+TAB_5 = "20000000-0000-4000-8000-000000000005"
+RESOURCE_1 = "30000000-0000-4000-8000-000000000001"
+PLACEMENT_1 = "40000000-0000-4000-8000-000000000001"
+PLACEMENT_2 = "40000000-0000-4000-8000-000000000002"
+PLACEMENT_3 = "40000000-0000-4000-8000-000000000003"
+PLACEMENT_4 = "40000000-0000-4000-8000-000000000004"
+PLACEMENT_5 = "40000000-0000-4000-8000-000000000005"
+DANGLING_ID = "90000000-0000-4000-8000-000000000001"
+
+_JsonPath = tuple[str | int, ...]
+_JsonContainer = dict[str, object] | list[object]
+
+
+def _load_fixture(name: str) -> schema.JsonObject:
+    parsed = json.loads(
+        (FIXTURE_ROOT / name).read_text(encoding="utf-8"),
+        object_pairs_hook=schema.reject_duplicate_json_members,
+    )
+    if type(parsed) is not dict:
+        raise AssertionError("fixture root must be an object")
+    return cast(schema.JsonObject, parsed)
+
+
+def _minimal() -> schema.JsonObject:
+    return _load_fixture("minimal.json")
+
+
+def _representative() -> schema.JsonObject:
+    return _load_fixture("representative.json")
+
+
+def _json_container_references(
+    value: object,
+    path: _JsonPath = (),
+) -> dict[_JsonPath, _JsonContainer]:
+    references: dict[_JsonPath, _JsonContainer] = {}
+    if type(value) is dict:
+        container = cast(dict[str, object], value)
+        references[path] = container
+        for key, child in container.items():
+            references.update(_json_container_references(child, (*path, key)))
+    elif type(value) is list:
+        container = cast(list[object], value)
+        references[path] = container
+        for index, child in enumerate(container):
+            references.update(_json_container_references(child, (*path, index)))
+    return references
+
+
+def _assert_valid_unchanged(candidate: object) -> None:
+    before = deepcopy(candidate)
+    containers_before = _json_container_references(candidate)
+    result = schema.validate_v2(candidate)
+    assert result is True  # nosec B101
+    assert candidate == before  # nosec B101
+    containers_after = _json_container_references(candidate)
+    assert containers_after.keys() == containers_before.keys()  # nosec B101
+    for path, container in containers_before.items():
+        assert containers_after[path] is container  # nosec B101
+
+
+def _assert_invalid_unchanged(candidate: object) -> None:
+    before = deepcopy(candidate)
+    containers_before = _json_container_references(candidate)
+    result = schema.validate_v2(candidate)
+    assert result is False  # nosec B101
+    assert candidate == before  # nosec B101
+    containers_after = _json_container_references(candidate)
+    assert containers_after.keys() == containers_before.keys()  # nosec B101
+    for path, container in containers_before.items():
+        assert containers_after[path] is container  # nosec B101
+
+
+def _objects(document: schema.JsonObject, field: str) -> list[dict[str, object]]:
+    value = document[field]
+    if type(value) is not list or not all(type(item) is dict for item in value):
+        raise AssertionError(f"{field} must be an object array")
+    return cast(list[dict[str, object]], value)
+
+
+def _application(document: schema.JsonObject) -> dict[str, object]:
+    value = document["application"]
+    if type(value) is not dict:
+        raise AssertionError("application must be an object")
+    return cast(dict[str, object], value)
+
+
+def _kanban(tab: dict[str, object]) -> dict[str, object]:
+    value = tab["kanban_order"]
+    if type(value) is not dict:
+        raise AssertionError("kanban_order must be an object")
+    return cast(dict[str, object], value)
+
+
+def _container(document: schema.JsonObject, location: str) -> dict[str, object]:
+    workspaces = _objects(document, "workspaces")
+    tabs = _objects(document, "tabs")
+    resources = _objects(document, "resources")
+    placements = _objects(document, "placements")
+    bindings = _objects(document, "device_bindings")
+    containers: dict[str, dict[str, object]] = {
+        "root": cast(dict[str, object], document),
+        "application": _application(document),
+        "workspace": workspaces[0],
+        "tab": tabs[0],
+        "kanban": _kanban(tabs[0]),
+        "resource": resources[0],
+        "target": cast(dict[str, object], resources[0]["target"]),
+        "resource_icon": cast(dict[str, object], resources[2]["default_icon"]),
+        "placement": placements[0],
+        "placement_icon": cast(dict[str, object], placements[1]["icon_override"]),
+        "window_binding": bindings[0],
+        "portable_applicability": cast(dict[str, object], bindings[0]["applicability"]),
+        "window_settings": cast(dict[str, object], bindings[0]["settings"]),
+        "launch_binding": bindings[3],
+        "device_applicability": cast(dict[str, object], bindings[4]["applicability"]),
+        "launch_settings": cast(dict[str, object], bindings[3]["settings"]),
+    }
+    return containers[location]
+
+
+def _semantic_orders(
+    document: schema.JsonObject,
+) -> tuple[
+    dict[str, tuple[object, ...]],
+    dict[
+        str,
+        tuple[
+            tuple[object, ...],
+            tuple[object, ...],
+            tuple[object, ...],
+            tuple[object, ...],
+        ],
+    ],
+]:
+    workspace_orders = {
+        cast(str, workspace["id"]): tuple(cast(list[object], workspace["tab_order"]))
+        for workspace in _objects(document, "workspaces")
+    }
+    tab_orders = {
+        cast(str, tab["id"]): (
+            tuple(cast(list[object], tab["display_order"])),
+            tuple(cast(list[object], _kanban(tab)["new"])),
+            tuple(cast(list[object], _kanban(tab)["in_use"])),
+            tuple(cast(list[object], _kanban(tab)["archived"])),
+        )
+        for tab in _objects(document, "tabs")
+    }
+    return workspace_orders, tab_orders
+
+
+def test_valid_fixtures_cover_complete_graph_without_mutation() -> None:
+    for name in ("minimal.json", "representative.json"):
+        document = _load_fixture(name)
+        _assert_valid_unchanged(document)
+
+    representative = _representative()
+    workspaces = _objects(representative, "workspaces")
+    tabs = _objects(representative, "tabs")
+    resources = _objects(representative, "resources")
+    placements = _objects(representative, "placements")
+    assert workspaces[2]["tab_order"] == []  # nosec B101
+    assert {(tab["visibility"], tab["lifecycle"]) for tab in tabs[:4]} == {  # nosec B101
+        ("visible", "active"),
+        ("visible", "archived"),
+        ("hidden", "active"),
+        ("hidden", "archived"),
+    }
+    assert resources[2]["id"] not in {  # nosec B101
+        placement["resource_id"] for placement in placements
+    }
+    first = {key: value for key, value in resources[0].items() if key != "id"}
+    second = {key: value for key, value in resources[1].items() if key != "id"}
+    assert first == second  # nosec B101
+
+
+def test_exported_typed_dicts_are_total_and_have_exact_keys() -> None:
+    expected = {
+        schema.Root: {
+            "schema_version",
+            "application",
+            "workspaces",
+            "tabs",
+            "resources",
+            "placements",
+            "device_bindings",
+            "extensions",
+        },
+        schema.Application: {"title", "default_workspace_id", "extensions"},
+        schema.Workspace: {"id", "name", "tab_order", "extensions"},
+        schema.Tab: {
+            "id",
+            "workspace_id",
+            "name",
+            "visibility",
+            "lifecycle",
+            "view_mode",
+            "display_filter",
+            "display_order",
+            "kanban_order",
+            "extensions",
+        },
+        schema.KanbanOrder: {"new", "in_use", "archived"},
+        schema.UrlTarget: {"url"},
+        schema.LegacyStringIcon: {"kind", "value"},
+        schema.Resource: {
+            "id",
+            "kind",
+            "target",
+            "default_label",
+            "default_icon",
+            "extensions",
+        },
+        schema.Placement: {
+            "id",
+            "resource_id",
+            "tab_id",
+            "label_override",
+            "icon_override",
+            "background_color",
+            "workflow_status",
+            "extensions",
+        },
+        schema.PortableFallback: {"kind"},
+        schema.DeviceSpecific: {"kind", "device_key"},
+        schema.WindowSettings: {
+            "columns",
+            "auto_fit",
+            "window_x",
+            "window_y",
+            "window_w",
+            "window_h",
+        },
+        schema.UrlLaunchSettings: {"browser", "chrome_profile", "open_target"},
+        schema.WorkspaceWindowBinding: {
+            "id",
+            "subject_kind",
+            "subject_id",
+            "binding_kind",
+            "applicability",
+            "settings",
+            "extensions",
+        },
+        schema.PlacementLaunchBinding: {
+            "id",
+            "subject_kind",
+            "subject_id",
+            "binding_kind",
+            "applicability",
+            "settings",
+            "extensions",
+        },
+    }
+
+    for typed_dict, keys in expected.items():
+        assert typed_dict.__required_keys__ == frozenset(keys)  # nosec B101
+        assert typed_dict.__optional_keys__ == frozenset()  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("location", "field"),
+    [
+        ("root", "application"),
+        ("application", "title"),
+        ("workspace", "name"),
+        ("tab", "lifecycle"),
+        ("kanban", "new"),
+        ("resource", "default_label"),
+        ("target", "url"),
+        ("resource_icon", "value"),
+        ("placement", "background_color"),
+        ("placement_icon", "value"),
+        ("window_binding", "subject_kind"),
+        ("portable_applicability", "kind"),
+        ("window_settings", "columns"),
+        ("launch_binding", "binding_kind"),
+        ("device_applicability", "device_key"),
+        ("launch_settings", "browser"),
+    ],
+)
+def test_every_structural_shape_rejects_missing_and_extra_direct_keys(
+    location: str,
+    field: str,
+) -> None:
+    missing = _representative()
+    del _container(missing, location)[field]
+    _assert_invalid_unchanged(missing)
+
+    extra = _representative()
+    _container(extra, location)["unexpected"] = "not an extension"
+    _assert_invalid_unchanged(extra)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        b"bytes",
+        ("tuple",),
+        {"set"},
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        object(),
+    ],
+)
+def test_strict_json_rejects_non_json_and_nonfinite_extension_values(
+    bad_value: object,
+) -> None:
+    document = _minimal()
+    document["extensions"] = cast(schema.Extensions, {"bad": bad_value})
+
+    requires_focused_check = type(bad_value) is object or (
+        type(bad_value) is float and bad_value != bad_value
+    )
+    if not requires_focused_check:
+        _assert_invalid_unchanged(document)
+        return
+
+    extensions = cast(dict[str, object], document["extensions"])
+    root_keys = tuple(document)
+    extension_keys = tuple(extensions)
+    result = schema.validate_v2(document)
+
+    assert result is False  # nosec B101
+    assert tuple(document) == root_keys  # nosec B101
+    assert document["extensions"] is extensions  # nosec B101
+    assert tuple(extensions) == extension_keys  # nosec B101
+    assert extensions["bad"] is bad_value  # nosec B101
+
+
+def test_strict_json_rejects_nonstring_keys_lone_surrogates_and_cycles() -> None:
+    nonstring_key = _minimal()
+    nonstring_key["extensions"] = cast(schema.Extensions, {1: "value"})
+    _assert_invalid_unchanged(nonstring_key)
+
+    for surrogate in ("\ud800", "\udfff"):
+        bad_key = _minimal()
+        bad_key["extensions"] = {surrogate: "value"}
+        _assert_invalid_unchanged(bad_key)
+
+        bad_value = _minimal()
+        bad_value["extensions"] = {"key": surrogate}
+        _assert_invalid_unchanged(bad_value)
+
+    cyclic = _minimal()
+    payload: dict[str, object] = {}
+    payload["cycle"] = payload
+    cyclic["extensions"] = cast(schema.Extensions, payload)
+    acyclic_root = deepcopy(
+        {key: value for key, value in cyclic.items() if key != "extensions"}
+    )
+    root_keys = tuple(cyclic)
+    payload_keys = tuple(payload)
+    assert cyclic["extensions"] is payload  # nosec B101
+    assert payload["cycle"] is payload  # nosec B101
+
+    result = schema.validate_v2(cyclic)
+
+    assert result is False  # nosec B101
+    assert tuple(cyclic) == root_keys  # nosec B101
+    assert {  # nosec B101
+        key: value for key, value in cyclic.items() if key != "extensions"
+    } == acyclic_root
+    assert cyclic["extensions"] is payload  # nosec B101
+    assert tuple(payload) == payload_keys  # nosec B101
+    assert payload["cycle"] is payload  # nosec B101
+
+
+def test_extensions_are_opaque_finite_json_without_a_validation_depth_limit() -> None:
+    document = _minimal()
+    payload: dict[str, object] = {
+        "schema_version": 999,
+        "extensions": {"direct_field_name": None},
+        "finite": 1.5,
+    }
+    cursor = payload
+    for _ in range(2_000):
+        nested: dict[str, object] = {}
+        cursor["nested"] = nested
+        cursor = nested
+    document["extensions"] = cast(schema.Extensions, payload)
+
+    root_keys = tuple(document)
+    result = schema.validate_v2(document)
+
+    assert result is True  # nosec B101
+    assert tuple(document) == root_keys  # nosec B101
+    assert document["extensions"] is payload  # nosec B101
+    assert payload["schema_version"] == 999  # nosec B101
+    assert payload["extensions"] == {  # nosec B101
+        "direct_field_name": None
+    }
+    assert payload["finite"] == 1.5  # nosec B101
+    cursor_after = payload
+    for _ in range(2_000):
+        nested_after = cursor_after.get("nested")
+        assert type(nested_after) is dict  # nosec B101
+        cursor_after = cast(dict[str, object], nested_after)
+    assert cursor_after == {}  # nosec B101
+
+    cannot_supply_field = _minimal()
+    tab = _objects(cannot_supply_field, "tabs")[0]
+    del tab["name"]
+    cast(dict[str, object], tab["extensions"])["name"] = "Main"
+    _assert_invalid_unchanged(cannot_supply_field)
+
+
+def test_root_cardinality_exact_marker_and_exact_container_types() -> None:
+    for marker in (True, False, 0, 1, 3, 2.0, "2", None):
+        document = _minimal()
+        document["schema_version"] = cast(schema.StrictJsonValue, marker)
+        _assert_invalid_unchanged(document)
+
+    for field in ("workspaces", "tabs"):
+        document = _minimal()
+        document[field] = []
+        _assert_invalid_unchanged(document)
+
+    for field in ("resources", "placements", "device_bindings"):
+        document = _minimal()
+        document[field] = []
+        _assert_valid_unchanged(document)
+
+    tuple_array = _minimal()
+    tuple_array["resources"] = cast(schema.StrictJsonValue, ())
+    _assert_invalid_unchanged(tuple_array)
+
+
+def test_exact_string_boolean_integer_and_null_domains() -> None:
+    representative = _representative()
+    bindings = _objects(representative, "device_bindings")
+    window = cast(dict[str, object], bindings[0]["settings"])
+    window["columns"] = -(10**30)
+    window["window_w"] = 0
+    _assert_valid_unchanged(representative)
+
+    for field in ("columns", "window_x", "window_y", "window_w", "window_h"):
+        document = _representative()
+        settings = cast(
+            dict[str, object], _objects(document, "device_bindings")[0]["settings"]
+        )
+        settings[field] = True
+        _assert_invalid_unchanged(document)
+
+    wrong_auto_fit = _representative()
+    settings = cast(
+        dict[str, object],
+        _objects(wrong_auto_fit, "device_bindings")[0]["settings"],
+    )
+    settings["auto_fit"] = 1
+    _assert_invalid_unchanged(wrong_auto_fit)
+
+    nullable_mismatches = (
+        ("resource", "default_icon", False),
+        ("placement", "label_override", False),
+        ("placement", "icon_override", ""),
+        ("launch_settings", "browser", False),
+        ("launch_settings", "chrome_profile", 1),
+        ("window_settings", "window_x", 1.5),
+    )
+    for location, field, value in nullable_mismatches:
+        document = _representative()
+        _container(document, location)[field] = value
+        _assert_invalid_unchanged(document)
+
+
+@pytest.mark.parametrize(
+    "display_filter",
+    [
+        [],
+        ["new"],
+        ["in_use"],
+        ["archived"],
+        ["new", "in_use"],
+        ["new", "archived"],
+        ["in_use", "archived"],
+        ["new", "in_use", "archived"],
+    ],
+)
+def test_display_filter_accepts_exact_canonical_set_encodings(
+    display_filter: list[str],
+) -> None:
+    document = _minimal()
+    _objects(document, "tabs")[0]["display_filter"] = display_filter
+
+    _assert_valid_unchanged(document)
+
+
+@pytest.mark.parametrize(
+    "display_filter",
+    [
+        ["new", "new"],
+        ["in_use", "new"],
+        ["archived", "new"],
+        ["new", "archived", "in_use"],
+        ["unknown"],
+        [None],
+    ],
+)
+def test_display_filter_rejects_duplicates_ordering_and_unknowns(
+    display_filter: list[object],
+) -> None:
+    document = _minimal()
+    _objects(document, "tabs")[0]["display_filter"] = display_filter
+
+    _assert_invalid_unchanged(document)
+
+
+@pytest.mark.parametrize(
+    ("location", "field", "bad_value"),
+    [
+        ("tab", "visibility", "Visible"),
+        ("tab", "lifecycle", "deleted"),
+        ("tab", "view_mode", "grid"),
+        ("resource", "kind", "image"),
+        ("resource_icon", "kind", "path"),
+        ("placement", "workflow_status", "in-use"),
+        ("placement_icon", "kind", "url"),
+        ("portable_applicability", "kind", "not_applicable"),
+        ("launch_settings", "open_target", "default"),
+    ],
+)
+def test_exact_literals_reject_unknown_or_wrong_case_values(
+    location: str,
+    field: str,
+    bad_value: str,
+) -> None:
+    document = _representative()
+    _container(document, location)[field] = bad_value
+
+    _assert_invalid_unchanged(document)
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "97587F7C-CA79-5CB7-AD4D-C9E4CD08683D",
+        WORKSPACE_1.replace("-", ""),
+        f"{{{WORKSPACE_1}}}",
+        "not-a-uuid",
+        "",
+        None,
+        1,
+    ],
+)
+def test_every_identity_position_requires_canonical_uuid_text(
+    bad_id: object,
+) -> None:
+    candidates: list[schema.JsonObject] = []
+
+    definition = _representative()
+    _objects(definition, "resources")[0]["id"] = bad_id
+    candidates.append(definition)
+
+    default_reference = _representative()
+    _application(default_reference)["default_workspace_id"] = bad_id
+    candidates.append(default_reference)
+
+    owner_reference = _representative()
+    _objects(owner_reference, "tabs")[0]["workspace_id"] = bad_id
+    candidates.append(owner_reference)
+
+    resource_reference = _representative()
+    _objects(resource_reference, "placements")[0]["resource_id"] = bad_id
+    candidates.append(resource_reference)
+
+    tab_reference = _representative()
+    _objects(tab_reference, "placements")[0]["tab_id"] = bad_id
+    candidates.append(tab_reference)
+
+    tab_order = _representative()
+    cast(list[object], _objects(tab_order, "workspaces")[0]["tab_order"])[0] = bad_id
+    candidates.append(tab_order)
+
+    display_order = _representative()
+    cast(list[object], _objects(display_order, "tabs")[0]["display_order"])[0] = bad_id
+    candidates.append(display_order)
+
+    kanban_order = _representative()
+    cast(list[object], _kanban(_objects(kanban_order, "tabs")[0])["new"])[0] = bad_id
+    candidates.append(kanban_order)
+
+    binding_subject = _representative()
+    _objects(binding_subject, "device_bindings")[0]["subject_id"] = bad_id
+    candidates.append(binding_subject)
+
+    for candidate in candidates:
+        _assert_invalid_unchanged(candidate)
+
+
+@pytest.mark.parametrize(
+    "canonical_id",
+    [
+        "00000000-0000-0000-0000-000000000000",
+        "97587f7c-ca79-5cb7-ad4d-c9e4cd08683d",
+    ],
+)
+def test_canonical_uuid_versions_are_not_artificially_restricted(
+    canonical_id: str,
+) -> None:
+    document = _minimal()
+    workspace = _objects(document, "workspaces")[0]
+    old_id = cast(str, workspace["id"])
+    workspace["id"] = canonical_id
+    _application(document)["default_workspace_id"] = canonical_id
+    for tab in _objects(document, "tabs"):
+        if tab["workspace_id"] == old_id:
+            tab["workspace_id"] = canonical_id
+
+    _assert_valid_unchanged(document)
+
+
+def test_entity_ids_are_globally_unique_across_all_definition_families() -> None:
+    within_family = _representative()
+    resources = _objects(within_family, "resources")
+    resources[1]["id"] = resources[0]["id"]
+    _assert_invalid_unchanged(within_family)
+
+    cross_family = _representative()
+    _objects(cross_family, "device_bindings")[0]["id"] = PLACEMENT_1
+    _assert_invalid_unchanged(cross_family)
+
+    uuid_looking_device_key = _representative()
+    applicability = cast(
+        dict[str, object],
+        _objects(uuid_looking_device_key, "device_bindings")[1]["applicability"],
+    )
+    applicability["device_key"] = WORKSPACE_1
+    _assert_valid_unchanged(uuid_looking_device_key)
+
+
+def test_names_use_exact_decoded_string_equality_only() -> None:
+    duplicate_workspace = _representative()
+    workspaces = _objects(duplicate_workspace, "workspaces")
+    workspaces[1]["name"] = workspaces[0]["name"]
+    _assert_invalid_unchanged(duplicate_workspace)
+
+    case_variant_workspace = _representative()
+    workspaces = _objects(case_variant_workspace, "workspaces")
+    workspaces[1]["name"] = cast(str, workspaces[0]["name"]).lower()
+    workspaces[2]["name"] = "   "
+    _assert_valid_unchanged(case_variant_workspace)
+
+    duplicate_tab = _representative()
+    tabs = _objects(duplicate_tab, "tabs")
+    tabs[1]["name"] = tabs[0]["name"]
+    _assert_invalid_unchanged(duplicate_tab)
+
+    case_variant_tab = _representative()
+    tabs = _objects(case_variant_tab, "tabs")
+    tabs[1]["name"] = cast(str, tabs[0]["name"]).lower()
+    tabs[2]["name"] = "   "
+    _assert_valid_unchanged(case_variant_tab)
+
+    normalization_variants = _representative()
+    tabs = _objects(normalization_variants, "tabs")
+    tabs[0]["name"] = unicodedata.normalize("NFC", "Café")
+    tabs[1]["name"] = unicodedata.normalize("NFD", "Café")
+    assert tabs[0]["name"] != tabs[1]["name"]  # nosec B101
+    _assert_valid_unchanged(normalization_variants)
+
+    for location in ("workspace", "tab"):
+        empty = _representative()
+        _container(empty, location)["name"] = ""
+        _assert_invalid_unchanged(empty)
+
+
+def test_typed_references_and_complete_workspace_and_display_orders() -> None:
+    wrong_default_type = _representative()
+    _application(wrong_default_type)["default_workspace_id"] = RESOURCE_1
+    _assert_invalid_unchanged(wrong_default_type)
+
+    wrong_tab_owner_type = _representative()
+    _objects(wrong_tab_owner_type, "tabs")[0]["workspace_id"] = RESOURCE_1
+    _assert_invalid_unchanged(wrong_tab_owner_type)
+
+    wrong_resource_type = _representative()
+    _objects(wrong_resource_type, "placements")[0]["resource_id"] = TAB_1
+    _assert_invalid_unchanged(wrong_resource_type)
+
+    wrong_placement_owner_type = _representative()
+    _objects(wrong_placement_owner_type, "placements")[0]["tab_id"] = RESOURCE_1
+    _assert_invalid_unchanged(wrong_placement_owner_type)
+
+    wrong_binding_subject_type = _representative()
+    _objects(wrong_binding_subject_type, "device_bindings")[0]["subject_id"] = (
+        PLACEMENT_1
+    )
+    _assert_invalid_unchanged(wrong_binding_subject_type)
+
+    workspace_orders = (
+        [TAB_1, TAB_1, "20000000-0000-4000-8000-000000000003"],
+        [TAB_1],
+        [TAB_1, RESOURCE_1],
+        [TAB_1, DANGLING_ID],
+    )
+    for order in workspace_orders:
+        document = _representative()
+        _objects(document, "workspaces")[0]["tab_order"] = order
+        _assert_invalid_unchanged(document)
+
+    display_orders = (
+        [PLACEMENT_1, PLACEMENT_1, PLACEMENT_3],
+        [PLACEMENT_1],
+        [PLACEMENT_1, RESOURCE_1, PLACEMENT_3],
+        [PLACEMENT_1, DANGLING_ID, PLACEMENT_3],
+        [PLACEMENT_1, PLACEMENT_4, PLACEMENT_3],
+    )
+    for order in display_orders:
+        document = _representative()
+        _objects(document, "tabs")[0]["display_order"] = order
+        _assert_invalid_unchanged(document)
+
+
+def test_valid_nonlexical_workspace_tab_order_is_not_sorted_or_replaced() -> None:
+    document = _representative()
+    workspace = _objects(document, "workspaces")[0]
+    tab_order = cast(list[str], workspace["tab_order"])
+    stored_tab_ids = [
+        cast(str, tab["id"])
+        for tab in _objects(document, "tabs")
+        if tab["workspace_id"] == WORKSPACE_1
+    ]
+    expected_order = [TAB_3, TAB_1, TAB_4, TAB_2]
+    tab_order[:] = expected_order
+
+    assert sorted(tab_order) == sorted(stored_tab_ids)  # nosec B101
+    assert tab_order != stored_tab_ids  # nosec B101
+    assert tab_order != sorted(tab_order)  # nosec B101
+
+    _assert_valid_unchanged(document)
+
+    tab_order_after = _objects(document, "workspaces")[0]["tab_order"]
+    assert tab_order_after is tab_order  # nosec B101
+    assert tab_order_after == expected_order  # nosec B101
+
+
+def test_default_workspace_requires_active_visible_tab_only_in_default() -> None:
+    document = _representative()
+    default_tab = _objects(document, "tabs")[0]
+    default_tab["visibility"] = "hidden"
+
+    _assert_invalid_unchanged(document)
+
+    nondefault_empty_and_without_active_visible = _representative()
+    _assert_valid_unchanged(nondefault_empty_and_without_active_visible)
+
+
+@pytest.mark.parametrize(
+    ("visibility", "lifecycle"),
+    [
+        ("hidden", "active"),
+        ("visible", "archived"),
+        ("hidden", "archived"),
+    ],
+)
+def test_populated_nondefault_workspace_needs_no_active_visible_tab(
+    visibility: str,
+    lifecycle: str,
+) -> None:
+    document = _representative()
+    application = _application(document)
+    workspaces = _objects(document, "workspaces")
+    tabs = _objects(document, "tabs")
+    placements = _objects(document, "placements")
+    secondary = next(
+        workspace for workspace in workspaces if workspace["id"] == WORKSPACE_2
+    )
+    secondary_tabs = [tab for tab in tabs if tab["workspace_id"] == WORKSPACE_2]
+    assert application["default_workspace_id"] == WORKSPACE_1  # nosec B101
+    assert secondary["tab_order"] == [TAB_5]  # nosec B101
+    assert [tab["id"] for tab in secondary_tabs] == [TAB_5]  # nosec B101
+    assert any(placement["tab_id"] == TAB_5 for placement in placements)  # nosec B101
+    secondary_tabs[0]["visibility"] = visibility
+    secondary_tabs[0]["lifecycle"] = lifecycle
+    assert not any(  # nosec B101
+        tab["visibility"] == "visible" and tab["lifecycle"] == "active"
+        for tab in secondary_tabs
+    )
+    assert any(  # nosec B101
+        tab["workspace_id"] == WORKSPACE_1
+        and tab["visibility"] == "visible"
+        and tab["lifecycle"] == "active"
+        for tab in tabs
+    )
+
+    _assert_valid_unchanged(document)
+
+
+def test_empty_display_filter_is_valid_for_a_tab_that_owns_placements() -> None:
+    document = _representative()
+    tab = _objects(document, "tabs")[0]
+    owned_ids = [
+        placement["id"]
+        for placement in _objects(document, "placements")
+        if placement["tab_id"] == TAB_1
+    ]
+    assert owned_ids == [PLACEMENT_1, PLACEMENT_2, PLACEMENT_3]  # nosec B101
+    tab["display_filter"] = []
+    assert tab["display_order"] == [  # nosec B101
+        PLACEMENT_2,
+        PLACEMENT_1,
+        PLACEMENT_3,
+    ]
+
+    _assert_valid_unchanged(document)
+
+
+def test_equal_content_placements_keep_distinct_display_and_kanban_identities() -> None:
+    document = _representative()
+    tab = _objects(document, "tabs")[0]
+    placements = _objects(document, "placements")
+    equal_content = deepcopy(placements[0])
+    equal_content["id"] = PLACEMENT_2
+    placements[1] = equal_content
+    kanban = _kanban(tab)
+    kanban["new"] = [PLACEMENT_2, PLACEMENT_1]
+    kanban["in_use"] = []
+
+    first_without_id = {
+        key: value for key, value in placements[0].items() if key != "id"
+    }
+    second_without_id = {
+        key: value for key, value in placements[1].items() if key != "id"
+    }
+    assert placements[0]["id"] != placements[1]["id"]  # nosec B101
+    assert first_without_id == second_without_id  # nosec B101
+    display_order = cast(list[object], tab["display_order"])
+    kanban_order = [
+        item
+        for status in ("new", "in_use", "archived")
+        for item in cast(list[object], kanban[status])
+    ]
+    for placement_id in (PLACEMENT_1, PLACEMENT_2):
+        assert display_order.count(placement_id) == 1  # nosec B101
+        assert kanban_order.count(placement_id) == 1  # nosec B101
+
+    _assert_valid_unchanged(document)
+
+
+@pytest.mark.parametrize("field", ["workspaces", "tabs", "resources", "placements"])
+def test_definition_array_permutations_do_not_change_semantic_orders(
+    field: str,
+) -> None:
+    document = _representative()
+    definition_fields = ("workspaces", "tabs", "resources", "placements")
+    arrays_before = {name: deepcopy(document[name]) for name in definition_fields}
+    semantic_orders_before = _semantic_orders(document)
+    selected = _objects(document, field)
+    document[field] = cast(
+        list[schema.StrictJsonValue],
+        list(reversed(selected)),
+    )
+
+    assert document[field] != arrays_before[field]  # nosec B101
+    for other_field in definition_fields:
+        if other_field != field:
+            assert document[other_field] == arrays_before[other_field]  # nosec B101
+    assert _semantic_orders(document) == semantic_orders_before  # nosec B101
+
+    _assert_valid_unchanged(document)
+
+
+def test_resources_may_be_orphaned_shared_and_equal_without_deduplication() -> None:
+    document = _representative()
+    resources = _objects(document, "resources")
+    placements = _objects(document, "placements")
+
+    assert resources[0]["id"] != resources[1]["id"]  # nosec B101
+    assert [placement["resource_id"] for placement in placements].count(RESOURCE_1) == 3  # nosec B101
+    _assert_valid_unchanged(document)
+
+    opaque = _representative()
+    resource = _objects(opaque, "resources")[0]
+    placement = _objects(opaque, "placements")[0]
+    cast(dict[str, object], resource["target"])["url"] = (
+        "  https://opaque.example.test/Path  "
+    )
+    resource["default_label"] = ""
+    placement["background_color"] = "definitely not CSS"
+    _assert_valid_unchanged(opaque)
+
+
+@pytest.mark.parametrize(
+    ("queue", "replacement"),
+    [
+        ("duplicate", [PLACEMENT_1, PLACEMENT_1]),
+        ("cross_queue", [PLACEMENT_1]),
+        ("omitted", []),
+        ("cross_tab", [PLACEMENT_4]),
+        ("wrong_entity", [RESOURCE_1]),
+        ("dangling", [DANGLING_ID]),
+    ],
+)
+def test_kanban_rejects_duplicate_omitted_foreign_and_wrong_type_members(
+    queue: str,
+    replacement: list[str],
+) -> None:
+    document = _representative()
+    kanban = _kanban(_objects(document, "tabs")[0])
+    if queue == "cross_queue":
+        kanban["in_use"] = replacement
+    else:
+        kanban["new"] = replacement
+
+    _assert_invalid_unchanged(document)
+
+
+def test_kanban_status_must_match_and_orders_remain_independent() -> None:
+    wrong_status = _representative()
+    kanban = _kanban(_objects(wrong_status, "tabs")[0])
+    kanban["new"] = []
+    kanban["archived"] = [PLACEMENT_1, PLACEMENT_3]
+    _assert_invalid_unchanged(wrong_status)
+
+    independent = _representative()
+    tabs = _objects(independent, "tabs")
+    placements = _objects(independent, "placements")
+    placements[2]["workflow_status"] = "in_use"
+    _kanban(tabs[0])["in_use"] = [PLACEMENT_3, PLACEMENT_2]
+    _kanban(tabs[0])["archived"] = []
+    assert tabs[0]["display_order"] == [  # nosec B101
+        PLACEMENT_2,
+        PLACEMENT_1,
+        PLACEMENT_3,
+    ]
+    _assert_valid_unchanged(independent)
+
+    archived_tab_new_placement = _representative()
+    assert _objects(archived_tab_new_placement, "tabs")[1]["lifecycle"] == "archived"  # nosec B101
+    assert (
+        _objects(archived_tab_new_placement, "placements")[3][  # nosec B101
+            "workflow_status"
+        ]
+        == "new"
+    )
+    _assert_valid_unchanged(archived_tab_new_placement)
+
+
+def test_device_binding_variants_require_exact_pairings_and_subject_types() -> None:
+    invalid_mutations = (
+        ("window_binding", "subject_kind", "placement"),
+        ("window_binding", "binding_kind", "launch"),
+        ("launch_binding", "subject_kind", "workspace"),
+        ("launch_binding", "binding_kind", "window"),
+    )
+    for location, field, value in invalid_mutations:
+        document = _representative()
+        _container(document, location)[field] = value
+        _assert_invalid_unchanged(document)
+
+    workspace_with_launch_settings = _representative()
+    bindings = _objects(workspace_with_launch_settings, "device_bindings")
+    bindings[0]["settings"] = deepcopy(bindings[3]["settings"])
+    _assert_invalid_unchanged(workspace_with_launch_settings)
+
+    placement_with_window_settings = _representative()
+    bindings = _objects(placement_with_window_settings, "device_bindings")
+    bindings[3]["settings"] = deepcopy(bindings[0]["settings"])
+    _assert_invalid_unchanged(placement_with_window_settings)
+
+
+def test_device_applicability_and_setting_domains_are_exact_and_platform_free() -> None:
+    whitespace_key = _representative()
+    _assert_valid_unchanged(whitespace_key)
+
+    empty_key = _representative()
+    applicability = cast(
+        dict[str, object],
+        _objects(empty_key, "device_bindings")[1]["applicability"],
+    )
+    applicability["device_key"] = ""
+    _assert_invalid_unchanged(empty_key)
+
+    portable_with_key = _representative()
+    applicability = cast(
+        dict[str, object],
+        _objects(portable_with_key, "device_bindings")[0]["applicability"],
+    )
+    applicability["device_key"] = "device-A"
+    _assert_invalid_unchanged(portable_with_key)
+
+    unusual_launch_values = _representative()
+    settings = cast(
+        dict[str, object],
+        _objects(unusual_launch_values, "device_bindings")[3]["settings"],
+    )
+    settings["browser"] = "   "
+    settings["chrome_profile"] = "profile that need not exist"
+    _assert_valid_unchanged(unusual_launch_values)
+
+
+def test_device_binding_selector_uniqueness_ignores_id_settings_and_extensions() -> (
+    None
+):
+    duplicate_portable = _representative()
+    bindings = _objects(duplicate_portable, "device_bindings")
+    copied = deepcopy(bindings[0])
+    copied["id"] = "50000000-0000-4000-8000-000000000010"
+    copied["settings"] = {
+        "columns": 99,
+        "auto_fit": False,
+        "window_x": None,
+        "window_y": None,
+        "window_w": None,
+        "window_h": None,
+    }
+    copied["extensions"] = {"different": True}
+    bindings.append(copied)
+    _assert_invalid_unchanged(duplicate_portable)
+
+    duplicate_device = _representative()
+    bindings = _objects(duplicate_device, "device_bindings")
+    copied = deepcopy(bindings[1])
+    copied["id"] = "50000000-0000-4000-8000-000000000011"
+    cast(dict[str, object], copied["settings"])["columns"] = 123
+    bindings.append(copied)
+    _assert_invalid_unchanged(duplicate_device)
+
+    case_distinct_key = _representative()
+    bindings = _objects(case_distinct_key, "device_bindings")
+    copied = deepcopy(bindings[1])
+    copied["id"] = "50000000-0000-4000-8000-000000000012"
+    cast(dict[str, object], copied["applicability"])["device_key"] = "DEVICE-A"
+    bindings.append(copied)
+    _assert_valid_unchanged(case_distinct_key)
+
+    reversed_root_order = _representative()
+    bindings = _objects(reversed_root_order, "device_bindings")
+    reversed_root_order["device_bindings"] = cast(
+        list[schema.StrictJsonValue],
+        list(reversed(bindings)),
+    )
+    _assert_valid_unchanged(reversed_root_order)

--- a/tests/unit/test_config_schema_v2_boundary.py
+++ b/tests/unit/test_config_schema_v2_boundary.py
@@ -1,0 +1,886 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import ast
+import json
+import logging
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import config_migration
+import config_schema_v2 as schema
+import config_serialization_v2 as serialization
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).parents[2]
+FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "schema_v2"
+SCHEMA_PATH = REPO_ROOT / "config_schema_v2.py"
+SERIALIZATION_PATH = REPO_ROOT / "config_serialization_v2.py"
+PACKAGING_SPEC_PATH = REPO_ROOT / "DesktopTileLauncher.spec"
+PRODUCTION_ENTRY_PATH = REPO_ROOT / "tile_launcher.py"
+FORBIDDEN_V2_MODULES = frozenset({"config_schema_v2.py", "config_serialization_v2.py"})
+QT_IMPORT_ROOTS = frozenset({"PyQt5", "PyQt6", "PySide2", "PySide6"})
+
+SCHEMA_PUBLIC_FUNCTIONS = frozenset({"reject_duplicate_json_members", "validate_v2"})
+SCHEMA_PUBLIC_TYPED_DICTS = frozenset(
+    {
+        "Application",
+        "DeviceSpecific",
+        "KanbanOrder",
+        "LegacyStringIcon",
+        "Placement",
+        "PlacementLaunchBinding",
+        "PortableFallback",
+        "Resource",
+        "Root",
+        "Tab",
+        "UrlLaunchSettings",
+        "UrlTarget",
+        "WindowSettings",
+        "Workspace",
+        "WorkspaceWindowBinding",
+    }
+)
+SCHEMA_PUBLIC_EXCEPTIONS = frozenset({"DuplicateJsonMemberError"})
+SCHEMA_PUBLIC_TYPE_ALIASES = frozenset(
+    {
+        "DeviceApplicability",
+        "DeviceBinding",
+        "EntityUUID",
+        "Extensions",
+        "ExternalDeviceKey",
+        "JsonObject",
+        "JsonScalar",
+        "Lifecycle",
+        "OpenTarget",
+        "StrictJsonValue",
+        "ViewMode",
+        "Visibility",
+        "WorkflowStatus",
+    }
+)
+SCHEMA_PUBLIC_CONSTANTS = frozenset({"SCHEMA_VERSION_V2"})
+SCHEMA_PUBLIC_NAMES = (
+    SCHEMA_PUBLIC_FUNCTIONS
+    | SCHEMA_PUBLIC_TYPED_DICTS
+    | SCHEMA_PUBLIC_EXCEPTIONS
+    | SCHEMA_PUBLIC_TYPE_ALIASES
+    | SCHEMA_PUBLIC_CONSTANTS
+)
+SERIALIZATION_PUBLIC_FUNCTIONS = frozenset({"serialize_v2"})
+SERIALIZATION_PUBLIC_DATACLASSES = frozenset(
+    {"SerializedV2Document", "V2SerializationRejected"}
+)
+SERIALIZATION_PUBLIC_TYPE_ALIASES = frozenset({"V2SerializationResult"})
+SERIALIZATION_PUBLIC_CONSTANTS = frozenset({"MAX_V2_CANDIDATE_BYTES"})
+SERIALIZATION_PUBLIC_NAMES = (
+    SERIALIZATION_PUBLIC_FUNCTIONS
+    | SERIALIZATION_PUBLIC_DATACLASSES
+    | SERIALIZATION_PUBLIC_TYPE_ALIASES
+    | SERIALIZATION_PUBLIC_CONSTANTS
+)
+
+EXPECTED_SCHEMA_IMPORTS = frozenset(
+    {
+        "from __future__ import annotations",
+        "from collections.abc import Callable",
+        "from dataclasses import dataclass",
+        "from typing import Final",
+        "from typing import Literal",
+        "from typing import TypeAlias",
+        "from typing import TypedDict",
+        "from typing import cast",
+        "from uuid import UUID",
+        "import math",
+    }
+)
+EXPECTED_SERIALIZATION_IMPORTS = frozenset(
+    {
+        "from __future__ import annotations",
+        "from config_migration import PureEngineFailureCategory "
+        "as _PureEngineFailureCategory",
+        "from config_migration import PureExecutionRejectionCategory "
+        "as _PureExecutionRejectionCategory",
+        "from config_migration import PureExecutionStage as _PureExecutionStage",
+        "from config_schema_v2 import validate_v2",
+        "from dataclasses import dataclass",
+        "from dataclasses import field",
+        "from typing import Final",
+        "from typing import TypeAlias",
+        "import json",
+    }
+)
+
+
+def _parse_path(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _qualified_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _qualified_name(node.value)
+        if base is None and isinstance(node.value, ast.Subscript):
+            base = "<subscript>"
+        return None if base is None else f"{base}.{node.attr}"
+    if isinstance(node, ast.Call):
+        called = _qualified_name(node.func)
+        return None if called is None else f"{called}()"
+    return None
+
+
+def _literal_string_sequence(node: ast.AST, label: str) -> tuple[str, ...]:
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        raise AssertionError(f"{label} must be a literal string sequence")
+    values: list[str] = []
+    for item in node.elts:
+        if not isinstance(item, ast.Constant) or type(item.value) is not str:
+            raise AssertionError(f"{label} must contain only literal strings")
+        values.append(item.value)
+    return tuple(values)
+
+
+def _import_declarations(tree: ast.Module) -> tuple[str, ...]:
+    declarations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                suffix = "" if alias.asname is None else f" as {alias.asname}"
+                declarations.append(f"import {alias.name}{suffix}")
+        elif isinstance(node, ast.ImportFrom):
+            module = ("." * node.level) + (node.module or "")
+            for alias in node.names:
+                suffix = "" if alias.asname is None else f" as {alias.asname}"
+                declarations.append(f"from {module} import {alias.name}{suffix}")
+    return tuple(declarations)
+
+
+def _annotation_kind(node: ast.AnnAssign) -> str:
+    annotation = _qualified_name(node.annotation)
+    if annotation == "TypeAlias":
+        return "type_alias"
+    if annotation == "Final" or (
+        isinstance(node.annotation, ast.Subscript)
+        and _qualified_name(node.annotation.value) == "Final"
+    ):
+        return "constant"
+    return "other"
+
+
+def _public_annotated_names(tree: ast.Module, kind: str) -> set[str]:
+    return {
+        node.target.id
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and not node.target.id.startswith("_")
+        and _annotation_kind(node) == kind
+    }
+
+
+def _class_kind(node: ast.ClassDef) -> str:
+    bases = {_qualified_name(base) for base in node.bases}
+    decorators = {
+        _qualified_name(decorator.func)
+        if isinstance(decorator, ast.Call)
+        else _qualified_name(decorator)
+        for decorator in node.decorator_list
+    }
+    if "TypedDict" in bases:
+        return "typed_dict"
+    if "dataclass" in decorators:
+        return "dataclass"
+    if bases.intersection({"Enum", "IntEnum", "StrEnum"}):
+        return "enum"
+    if bases.intersection({"Exception", "ValueError"}):
+        return "exception"
+    return "other"
+
+
+def _public_classes(tree: ast.Module, kind: str) -> set[str]:
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and not node.name.startswith("_")
+        and _class_kind(node) == kind
+    }
+
+
+def _public_functions(tree: ast.Module) -> set[str]:
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not node.name.startswith("_")
+    }
+
+
+def _module_all(tree: ast.Module) -> set[str]:
+    declarations = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        )
+    ]
+    if len(declarations) != 1:
+        raise AssertionError("module must declare one literal __all__")
+    return set(_literal_string_sequence(declarations[0].value, "__all__"))
+
+
+def _assert_utf8_encode_calls(tree: ast.Module, expected_count: int) -> None:
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and (_qualified_name(node.func) or "").endswith(".encode")
+    ]
+    assert len(calls) == expected_count  # nosec B101
+    for call in calls:
+        assert len(call.args) == 1  # nosec B101
+        assert isinstance(call.args[0], ast.Constant)  # nosec B101
+        assert call.args[0].value == "utf-8"  # nosec B101
+        assert call.keywords == []  # nosec B101
+
+
+def _assert_serializer_json_surface(tree: ast.Module) -> None:
+    parents = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    json_attributes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "json"
+    ]
+    assert len(json_attributes) == 1  # nosec B101
+    attribute = json_attributes[0]
+    assert _qualified_name(attribute) == "json.dumps"  # nosec B101
+    parent = parents[attribute]
+    assert isinstance(parent, ast.Call)  # nosec B101
+    assert parent.func is attribute  # nosec B101
+
+
+def _raw_import_names(path: Path) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(_parse_path(path)):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names
+
+
+def _path_inside(root: Path, path: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_module(root: Path, module: str) -> Path | None:
+    parts = module.split(".")
+    if not parts or not all(part.isidentifier() for part in parts):
+        return None
+    stem = root.joinpath(*parts)
+    candidates = (stem / "__init__.py", stem.with_suffix(".py"))
+    resolved_root = root.resolve()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if _path_inside(resolved_root, resolved) and resolved.is_file():
+            return resolved
+    return None
+
+
+def _module_prefix_paths(root: Path, module: str) -> set[Path]:
+    parts = module.split(".")
+    paths: set[Path] = set()
+    for length in range(1, len(parts) + 1):
+        resolved = _resolve_module(root, ".".join(parts[:length]))
+        if resolved is not None:
+            paths.add(resolved)
+    return paths
+
+
+def _current_package_parts(root: Path, path: Path) -> tuple[str, ...]:
+    relative = path.resolve().relative_to(root.resolve())
+    return relative.parts[:-1]
+
+
+def _from_import_module(
+    root: Path,
+    current_path: Path,
+    node: ast.ImportFrom,
+) -> str | None:
+    module_parts = tuple((node.module or "").split(".")) if node.module else ()
+    if node.level == 0:
+        return ".".join(module_parts)
+    package_parts = _current_package_parts(root, current_path)
+    if not package_parts:
+        raise AssertionError(f"invalid relative import in {current_path}")
+    parents_to_drop = node.level - 1
+    if parents_to_drop > len(package_parts):
+        raise AssertionError(
+            f"relative import escapes repository package: {current_path}"
+        )
+    base_parts = package_parts[: len(package_parts) - parents_to_drop]
+    return ".".join((*base_parts, *module_parts))
+
+
+def _direct_local_imports(root: Path, path: Path) -> set[Path]:
+    imports: set[Path] = set()
+    for node in ast.walk(_parse_path(path)):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.update(_module_prefix_paths(root, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            module = _from_import_module(root, path, node)
+            if not module:
+                continue
+            imports.update(_module_prefix_paths(root, module))
+            for alias in node.names:
+                if alias.name != "*":
+                    imports.update(_module_prefix_paths(root, f"{module}.{alias.name}"))
+    return imports
+
+
+def _repository_local_import_closure(
+    root: Path,
+    roots: set[Path],
+) -> set[Path]:
+    resolved_root = root.resolve()
+    pending = [path.resolve() for path in roots]
+    closure: set[Path] = set()
+    while pending:
+        path = pending.pop()
+        if path in closure:
+            continue
+        if (
+            not _path_inside(resolved_root, path)
+            or not path.is_file()
+            or path.suffix not in {".py", ".pyw"}
+        ):
+            raise AssertionError(f"invalid production closure root: {path}")
+        closure.add(path)
+        pending.extend(_direct_local_imports(resolved_root, path) - closure)
+    return closure
+
+
+def _analysis_call(spec_tree: ast.Module) -> ast.Call:
+    calls = [
+        node
+        for node in ast.walk(spec_tree)
+        if isinstance(node, ast.Call)
+        and (_qualified_name(node.func) or "").split(".")[-1] == "Analysis"
+    ]
+    if len(calls) != 1:
+        raise AssertionError("packaging spec must contain exactly one Analysis call")
+    return calls[0]
+
+
+def _analysis_keyword(call: ast.Call, name: str) -> ast.AST:
+    if any(keyword.arg is None for keyword in call.keywords):
+        raise AssertionError("Analysis declarations must not use **kwargs")
+    matches = [keyword.value for keyword in call.keywords if keyword.arg == name]
+    if len(matches) != 1:
+        raise AssertionError(f"Analysis must declare one literal {name}")
+    return matches[0]
+
+
+def _packaging_roots(root: Path, spec_path: Path) -> set[Path]:
+    call = _analysis_call(_parse_path(spec_path))
+    if len(call.args) != 1:
+        raise AssertionError(
+            "Analysis entry scripts must be its sole positional argument"
+        )
+    script_names = _literal_string_sequence(call.args[0], "Analysis entry scripts")
+    hidden_names = _literal_string_sequence(
+        _analysis_keyword(call, "hiddenimports"),
+        "Analysis hidden imports",
+    )
+
+    resolved_root = root.resolve()
+    roots: set[Path] = set()
+    for script_name in script_names:
+        candidate = (resolved_root / script_name).resolve()
+        if (
+            not _path_inside(resolved_root, candidate)
+            or not candidate.is_file()
+            or candidate.suffix not in {".py", ".pyw"}
+            or "tests" in candidate.relative_to(resolved_root).parts
+        ):
+            raise AssertionError(
+                f"invalid literal Analysis entry script: {script_name}"
+            )
+        roots.add(candidate)
+    for hidden_name in hidden_names:
+        roots.update(_module_prefix_paths(resolved_root, hidden_name))
+    return roots
+
+
+def _production_and_packaging_closure(
+    root: Path,
+    primary_entry: Path,
+    spec_path: Path,
+) -> set[Path]:
+    roots = {primary_entry.resolve()} | _packaging_roots(root, spec_path)
+    return _repository_local_import_closure(root, roots)
+
+
+def _relative_paths(root: Path, paths: set[Path]) -> set[Path]:
+    resolved_root = root.resolve()
+    return {path.relative_to(resolved_root) for path in paths}
+
+
+def _write_synthetic(root: Path, relative_path: str, source: str) -> None:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _assert_silent_and_private(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+    sentinels: tuple[str, ...],
+) -> None:
+    captured = capsys.readouterr()
+    assert captured.out == ""  # nosec B101
+    assert captured.err == ""  # nosec B101
+    for record in caplog.records:
+        rendered = repr((record.msg, record.args, vars(record)))
+        for sentinel in sentinels:
+            assert sentinel not in rendered  # nosec B101
+
+
+def test_object_pairs_callback_preserves_unique_decoded_members() -> None:
+    pairs: list[tuple[str, object]] = [
+        ("first", 1),
+        ("second", {"nested": True}),
+    ]
+
+    result = schema.reject_duplicate_json_members(pairs)
+
+    assert result == {"first": 1, "second": {"nested": True}}  # nosec B101
+    assert list(result) == ["first", "second"]  # nosec B101
+
+
+def test_direct_duplicate_rejection_is_fixed_private_and_silent(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinels = (
+        "duplicate-key-7c889511",
+        "duplicate-value-first-1593a0bd",
+        "duplicate-value-second-20c1f26d",
+    )
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    with pytest.raises(schema.DuplicateJsonMemberError) as exc_info:
+        schema.reject_duplicate_json_members(
+            [
+                (sentinels[0], sentinels[1]),
+                (sentinels[0], sentinels[2]),
+            ]
+        )
+
+    error = exc_info.value
+    assert type(error) is schema.DuplicateJsonMemberError  # nosec B101
+    assert error.args == ("malformed_json",)  # nosec B101
+    assert str(error) == "malformed_json"  # nosec B101
+    assert repr(error) == "DuplicateJsonMemberError('malformed_json')"  # nosec B101
+    assert vars(error) == {}  # nosec B101
+    assert error.__cause__ is None  # nosec B101
+    assert error.__context__ is None  # nosec B101
+    rendered = f"{error!s} {error!r} {error.args!r} {vars(error)!r}"
+    for sentinel in sentinels:
+        assert sentinel not in rendered  # nosec B101
+    _assert_silent_and_private(capsys, caplog, sentinels)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"private-root":1,"private-root":2}',
+        '{"application":{"private-title":"one","private-title":"two"}}',
+        '{"items":[{"private-id":"one","private-id":"two"}]}',
+        '{"extensions":{"nested":{"private-secret":"one","private-secret":"two"}}}',
+        '{"decoded-name":1,"\\u0064ecoded-name":2}',
+    ],
+)
+def test_standard_decoder_callback_rejects_duplicates_at_every_nesting_depth(
+    payload: str,
+) -> None:
+    with pytest.raises(schema.DuplicateJsonMemberError) as exc_info:
+        json.loads(payload, object_pairs_hook=schema.reject_duplicate_json_members)
+
+    rendered = f"{exc_info.value!s} {exc_info.value!r}"
+    assert rendered == "malformed_json DuplicateJsonMemberError('malformed_json')"  # nosec B101
+    for forbidden in ("private", "decoded-name", "one", "two"):
+        assert forbidden not in rendered  # nosec B101
+
+
+def test_valid_fixture_decodes_through_dormant_callback_then_validates() -> None:
+    parsed = json.loads(
+        (FIXTURE_ROOT / "representative.json").read_text(encoding="utf-8"),
+        object_pairs_hook=schema.reject_duplicate_json_members,
+    )
+
+    assert schema.validate_v2(parsed)  # nosec B101
+
+
+def test_validation_failure_exposes_no_candidate_content_or_side_channel(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinels = (
+        "https://validation-private-72ec1727.example.test/path",
+        "validation-title-45bed5ea",
+        "90000000-0000-4000-8000-000000007711",
+        "extension-key-validation-1dc76257",
+        "extension-value-validation-ac81d9d5",
+    )
+    document = cast(
+        schema.JsonObject,
+        {
+            "schema_version": 2,
+            "application": {
+                "title": sentinels[1],
+                "default_workspace_id": sentinels[2],
+                "extensions": {sentinels[3]: sentinels[4]},
+            },
+            "private_url": sentinels[0],
+        },
+    )
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    result = schema.validate_v2(document)
+
+    assert result is False  # nosec B101
+    rendered = repr(result)
+    for sentinel in sentinels:
+        assert sentinel not in rendered  # nosec B101
+    _assert_silent_and_private(capsys, caplog, sentinels)
+
+
+def test_public_structural_result_and_behavioral_surfaces_are_exact() -> None:
+    schema_tree = _parse_path(SCHEMA_PATH)
+    serialization_tree = _parse_path(SERIALIZATION_PATH)
+
+    assert _public_functions(schema_tree) == SCHEMA_PUBLIC_FUNCTIONS  # nosec B101
+    assert {  # nosec B101
+        node.name
+        for node in schema_tree.body
+        if isinstance(node, ast.ClassDef) and not node.name.startswith("_")
+    } == SCHEMA_PUBLIC_TYPED_DICTS | SCHEMA_PUBLIC_EXCEPTIONS
+    assert (  # nosec B101
+        _public_classes(schema_tree, "typed_dict") == SCHEMA_PUBLIC_TYPED_DICTS
+    )
+    assert (  # nosec B101
+        _public_classes(schema_tree, "exception") == SCHEMA_PUBLIC_EXCEPTIONS
+    )
+    assert _public_classes(schema_tree, "dataclass") == set()  # nosec B101
+    assert _public_classes(schema_tree, "enum") == set()  # nosec B101
+    assert (  # nosec B101
+        _public_annotated_names(schema_tree, "type_alias") == SCHEMA_PUBLIC_TYPE_ALIASES
+    )
+    assert (  # nosec B101
+        _public_annotated_names(schema_tree, "constant") == SCHEMA_PUBLIC_CONSTANTS
+    )
+    assert _module_all(schema_tree) == SCHEMA_PUBLIC_NAMES  # nosec B101
+
+    assert (  # nosec B101
+        _public_functions(serialization_tree) == SERIALIZATION_PUBLIC_FUNCTIONS
+    )
+    assert {  # nosec B101
+        node.name
+        for node in serialization_tree.body
+        if isinstance(node, ast.ClassDef) and not node.name.startswith("_")
+    } == SERIALIZATION_PUBLIC_DATACLASSES
+    assert (  # nosec B101
+        _public_classes(serialization_tree, "dataclass")
+        == SERIALIZATION_PUBLIC_DATACLASSES
+    )
+    assert _public_classes(serialization_tree, "typed_dict") == set()  # nosec B101
+    assert _public_classes(serialization_tree, "enum") == set()  # nosec B101
+    assert _public_classes(serialization_tree, "exception") == set()  # nosec B101
+    assert (  # nosec B101
+        _public_annotated_names(serialization_tree, "type_alias")
+        == SERIALIZATION_PUBLIC_TYPE_ALIASES
+    )
+    assert (  # nosec B101
+        _public_annotated_names(serialization_tree, "constant")
+        == SERIALIZATION_PUBLIC_CONSTANTS
+    )
+    assert _module_all(serialization_tree) == SERIALIZATION_PUBLIC_NAMES  # nosec B101
+    assert not hasattr(serialization, "V2SerializationFailureCategory")  # nosec B101
+    assert all(  # nosec B101
+        not (
+            isinstance(node, (ast.Name, ast.ClassDef, ast.FunctionDef, ast.Constant))
+            and (
+                getattr(node, "id", None)
+                or getattr(node, "name", None)
+                or getattr(node, "value", None)
+            )
+            == "V2SerializationFailureCategory"
+        )
+        for node in ast.walk(serialization_tree)
+    )
+
+
+def test_exact_imports_and_focused_json_ast_contracts() -> None:
+    schema_tree = _parse_path(SCHEMA_PATH)
+    serialization_tree = _parse_path(SERIALIZATION_PATH)
+
+    schema_imports = _import_declarations(schema_tree)
+    serialization_imports = _import_declarations(serialization_tree)
+    assert len(schema_imports) == len(EXPECTED_SCHEMA_IMPORTS)  # nosec B101
+    assert set(schema_imports) == EXPECTED_SCHEMA_IMPORTS  # nosec B101
+    assert len(serialization_imports) == len(  # nosec B101
+        EXPECTED_SERIALIZATION_IMPORTS
+    )
+    assert set(serialization_imports) == EXPECTED_SERIALIZATION_IMPORTS  # nosec B101
+
+    # These assertions describe direct JSON-related syntax, not general capabilities.
+    assert not any(  # nosec B101
+        isinstance(node, ast.Attribute)
+        and (_qualified_name(node) or "").startswith("json.")
+        for node in ast.walk(schema_tree)
+    )
+    _assert_serializer_json_surface(serialization_tree)
+    _assert_utf8_encode_calls(schema_tree, 1)
+    _assert_utf8_encode_calls(serialization_tree, 1)
+    assert [  # nosec B101
+        _qualified_name(node.type)
+        for node in ast.walk(serialization_tree)
+        if isinstance(node, ast.ExceptHandler) and node.type is not None
+    ] == ["Exception"]
+
+
+def test_vocabulary_dependency_is_symbol_only_one_way_and_qt_free() -> None:
+    migration_path = REPO_ROOT / "config_migration.py"
+    dependency_closure = _repository_local_import_closure(
+        REPO_ROOT,
+        {migration_path},
+    )
+    relative = _relative_paths(REPO_ROOT, dependency_closure)
+
+    assert {  # nosec B101
+        Path("config_migration.py"),
+        Path("config_persistence.py"),
+        Path("config_recovery.py"),
+        Path("config_schema.py"),
+    }.issubset(relative)
+    assert not {path.name for path in relative}.intersection(  # nosec B101
+        FORBIDDEN_V2_MODULES
+    )
+    for path in dependency_closure:
+        import_roots = {
+            name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)
+        }
+        assert import_roots.isdisjoint(QT_IMPORT_ROOTS), path  # nosec B101
+
+
+def test_real_production_and_packaging_closure_excludes_v2() -> None:
+    closure = _production_and_packaging_closure(
+        REPO_ROOT,
+        PRODUCTION_ENTRY_PATH,
+        PACKAGING_SPEC_PATH,
+    )
+    relative = _relative_paths(REPO_ROOT, closure)
+
+    assert Path("url_import.py") in relative  # nosec B101
+    assert Path("config_migration.py") in relative  # nosec B101
+    assert not {path.name for path in relative}.intersection(  # nosec B101
+        FORBIDDEN_V2_MODULES
+    )
+
+
+def test_transitive_entry_import_of_v2_is_detected(tmp_path: Path) -> None:
+    _write_synthetic(tmp_path, "entry.py", "import bridge\n")
+    _write_synthetic(tmp_path, "bridge.py", "import config_schema_v2\n")
+    _write_synthetic(tmp_path, "config_schema_v2.py", "VALUE = 2\n")
+    _write_synthetic(
+        tmp_path,
+        "app.spec",
+        "a = Analysis(['entry.py'], hiddenimports=[])\n",
+    )
+
+    closure = _production_and_packaging_closure(
+        tmp_path,
+        tmp_path / "entry.py",
+        tmp_path / "app.spec",
+    )
+
+    assert Path("config_schema_v2.py") in _relative_paths(  # nosec B101
+        tmp_path, closure
+    )
+
+
+def test_package_wins_over_same_name_module_during_resolution(
+    tmp_path: Path,
+) -> None:
+    _write_synthetic(tmp_path, "entry.py", "import bridge\n")
+    _write_synthetic(tmp_path, "bridge.py", "VALUE = 1\n")
+    _write_synthetic(
+        tmp_path,
+        "bridge/__init__.py",
+        "import config_schema_v2\n",
+    )
+    _write_synthetic(tmp_path, "config_schema_v2.py", "VALUE = 2\n")
+    _write_synthetic(
+        tmp_path,
+        "app.spec",
+        "a = Analysis(['entry.py'], hiddenimports=[])\n",
+    )
+
+    closure = _production_and_packaging_closure(
+        tmp_path,
+        tmp_path / "entry.py",
+        tmp_path / "app.spec",
+    )
+
+    relative = _relative_paths(tmp_path, closure)
+    assert Path("bridge/__init__.py") in relative  # nosec B101
+    assert Path("bridge.py") not in relative  # nosec B101
+    assert Path("config_schema_v2.py") in relative  # nosec B101
+
+
+def test_reachable_module_under_tests_directory_still_reaches_v2(
+    tmp_path: Path,
+) -> None:
+    _write_synthetic(tmp_path, "entry.py", "import application.tests.bridge\n")
+    _write_synthetic(tmp_path, "application/__init__.py", "VALUE = 1\n")
+    _write_synthetic(tmp_path, "application/tests/__init__.py", "VALUE = 1\n")
+    _write_synthetic(
+        tmp_path,
+        "application/tests/bridge.py",
+        "import config_schema_v2\n",
+    )
+    _write_synthetic(tmp_path, "config_schema_v2.py", "VALUE = 2\n")
+    _write_synthetic(
+        tmp_path,
+        "app.spec",
+        "a = Analysis(['entry.py'], hiddenimports=[])\n",
+    )
+
+    closure = _production_and_packaging_closure(
+        tmp_path,
+        tmp_path / "entry.py",
+        tmp_path / "app.spec",
+    )
+
+    relative = _relative_paths(tmp_path, closure)
+    assert Path("application/tests/bridge.py") in relative  # nosec B101
+    assert Path("config_schema_v2.py") in relative  # nosec B101
+
+
+def test_packaging_hidden_import_that_reaches_v2_is_detected(tmp_path: Path) -> None:
+    _write_synthetic(tmp_path, "entry.py", "VALUE = 1\n")
+    _write_synthetic(
+        tmp_path,
+        "packaging_bridge.py",
+        "import config_serialization_v2\n",
+    )
+    _write_synthetic(tmp_path, "config_serialization_v2.py", "VALUE = 2\n")
+    _write_synthetic(
+        tmp_path,
+        "app.spec",
+        "a = Analysis(['entry.py'], hiddenimports=['packaging_bridge'])\n",
+    )
+
+    closure = _production_and_packaging_closure(
+        tmp_path,
+        tmp_path / "entry.py",
+        tmp_path / "app.spec",
+    )
+
+    relative = _relative_paths(tmp_path, closure)
+    assert Path("packaging_bridge.py") in relative  # nosec B101
+    assert Path("config_serialization_v2.py") in relative  # nosec B101
+
+
+def test_unreachable_v2_import_is_not_a_production_root(tmp_path: Path) -> None:
+    _write_synthetic(tmp_path, "entry.py", "import reachable\n")
+    _write_synthetic(tmp_path, "reachable.py", "VALUE = 1\n")
+    _write_synthetic(tmp_path, "unrelated.py", "import config_schema_v2\n")
+    _write_synthetic(tmp_path, "config_schema_v2.py", "VALUE = 2\n")
+    _write_synthetic(
+        tmp_path,
+        "app.spec",
+        "a = Analysis(['entry.py'], hiddenimports=[])\n",
+    )
+
+    closure = _production_and_packaging_closure(
+        tmp_path,
+        tmp_path / "entry.py",
+        tmp_path / "app.spec",
+    )
+
+    relative = _relative_paths(tmp_path, closure)
+    assert relative == {Path("entry.py"), Path("reachable.py")}  # nosec B101
+    assert Path("unrelated.py") not in relative  # nosec B101
+    assert Path("config_schema_v2.py") not in relative  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "spec_source",
+    [
+        "scripts = ['entry.py']\na = Analysis(scripts, hiddenimports=[])\n",
+        "hidden = []\na = Analysis(['entry.py'], hiddenimports=hidden)\n",
+        "a = Analysis(['entry.py'])\n",
+        "kwargs = {'hiddenimports': []}\na = Analysis(['entry.py'], **kwargs)\n",
+    ],
+)
+def test_packaging_declarations_fail_closed_when_nonliteral(
+    tmp_path: Path,
+    spec_source: str,
+) -> None:
+    _write_synthetic(tmp_path, "entry.py", "VALUE = 1\n")
+    _write_synthetic(tmp_path, "app.spec", spec_source)
+
+    with pytest.raises(AssertionError):
+        _production_and_packaging_closure(
+            tmp_path,
+            tmp_path / "entry.py",
+            tmp_path / "app.spec",
+        )
+
+
+def test_production_registry_remains_exactly_v0_to_v1_and_rejects_v2() -> None:
+    spec = config_migration.PRODUCTION_REGISTRY_SPEC
+    assert spec.oldest_supported_version == 0  # nosec B101
+    assert spec.current_version == 1  # nosec B101
+    assert [(step.source_version, step.target_version) for step in spec.steps] == [  # nosec B101
+        (0, 1)
+    ]
+    assert [validator.version for validator in spec.validators] == [0, 1]  # nosec B101
+
+    parsed = json.loads(
+        (FIXTURE_ROOT / "minimal.json").read_text(encoding="utf-8"),
+        object_pairs_hook=schema.reject_duplicate_json_members,
+    )
+    result = config_migration.prepare_migration(
+        cast(config_migration.JsonObject, parsed),
+        config_migration.PRODUCTION_REGISTRY,
+    )
+
+    assert isinstance(result, config_migration.VersionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.category is config_migration.VersionRejectionCategory.UNSUPPORTED_NEWER
+    )
+    assert result.version == 2  # nosec B101

--- a/tests/unit/test_config_serialization_v2.py
+++ b/tests/unit/test_config_serialization_v2.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import gc
+import json
+import logging
+import weakref
+from copy import deepcopy
+from dataclasses import fields
+from pathlib import Path
+from typing import NoReturn, cast
+from unittest.mock import Mock
+
+import pytest
+
+import config_migration as migration
+import config_schema_v2 as schema
+import config_serialization_v2 as serialization
+
+pytestmark = pytest.mark.unit
+
+FIXTURE_ROOT = Path(__file__).parents[1] / "fixtures" / "schema_v2"
+
+
+class _InjectedSerializationError(Exception):
+    """Weak-referenceable private failure used to prove exception disposal."""
+
+
+class _FailingUtf8Text(str):
+    """A dumps result whose UTF-8 conversion exercises the encoder failure route."""
+
+    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
+        raise _InjectedSerializationError(str(self))
+
+
+def _load_fixture(name: str) -> schema.JsonObject:
+    parsed = json.loads(
+        (FIXTURE_ROOT / name).read_text(encoding="utf-8"),
+        object_pairs_hook=schema.reject_duplicate_json_members,
+    )
+    if type(parsed) is not dict:
+        raise AssertionError("fixture root must be an object")
+    return cast(schema.JsonObject, parsed)
+
+
+def _minimal() -> schema.JsonObject:
+    return _load_fixture("minimal.json")
+
+
+def _representative() -> schema.JsonObject:
+    return _load_fixture("representative.json")
+
+
+def _canonical_bytes(document: object) -> bytes:
+    return json.dumps(
+        document,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _reverse_object_insertions(value: object) -> object:
+    if type(value) is dict:
+        mapping = cast(dict[str, object], value)
+        return {
+            key: _reverse_object_insertions(item)
+            for key, item in reversed(list(mapping.items()))
+        }
+    if type(value) is list:
+        return [_reverse_object_insertions(item) for item in cast(list[object], value)]
+    return value
+
+
+def _candidate_with_canonical_size(size: int) -> schema.JsonObject:
+    document = _minimal()
+    document["extensions"] = {"padding": ""}
+    baseline = _canonical_bytes(document)
+    delta = size - len(baseline)
+    if delta < 2:
+        raise AssertionError("target must leave room for Unicode padding")
+    padding = ("é" * (delta // 2)) + ("x" if delta % 2 else "")
+    document["extensions"] = {"padding": padding}
+    actual = _canonical_bytes(document)
+    if len(actual) != size:
+        raise AssertionError("candidate size construction is not exact")
+    return document
+
+
+def _assert_rejected(
+    result: object,
+    expected_category: (
+        migration.PureExecutionRejectionCategory | migration.PureEngineFailureCategory
+    ),
+    expected_stage: migration.PureExecutionStage,
+    sentinels: tuple[str, ...] = (),
+) -> serialization.V2SerializationRejected:
+    assert type(result) is serialization.V2SerializationRejected  # nosec B101
+    rejection = cast(serialization.V2SerializationRejected, result)
+    assert tuple(field.name for field in fields(rejection)) == (  # nosec B101
+        "category",
+        "stage",
+    )
+    assert type(rejection).__slots__ == ("category", "stage")  # nosec B101
+    assert not hasattr(rejection, "__dict__")  # nosec B101
+    assert {  # nosec B101
+        name for name in dir(rejection) if not name.startswith("__")
+    } == {"category", "stage"}
+    assert rejection.category is expected_category  # nosec B101
+    assert rejection.stage is expected_stage  # nosec B101
+    rendered = f"{rejection!s} {rejection!r}"
+    for sentinel in sentinels:
+        assert sentinel not in rendered  # nosec B101
+    return rejection
+
+
+def _assert_silent_and_private(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+    sentinels: tuple[str, ...],
+) -> None:
+    captured = capsys.readouterr()
+    assert captured.out == ""  # nosec B101
+    assert captured.err == ""  # nosec B101
+    for sentinel in sentinels:
+        assert sentinel not in caplog.text  # nosec B101
+    for record in caplog.records:
+        rendered = repr((record.msg, record.args, vars(record)))
+        for sentinel in sentinels:
+            assert sentinel not in rendered  # nosec B101
+
+
+def test_validation_precedes_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinel = "validation-rejection-private-4d76e94a"
+    document = _minimal()
+    document["unexpected"] = sentinel
+
+    def forbidden_dumps(*_args: object, **_kwargs: object) -> NoReturn:
+        raise AssertionError("json.dumps must not receive an invalid candidate")
+
+    monkeypatch.setattr(serialization.json, "dumps", forbidden_dumps)
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    result = serialization.serialize_v2(document)
+
+    _assert_rejected(
+        result,
+        migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE,
+        migration.PureExecutionStage.TARGET_VALIDATION,
+        (sentinel,),
+    )
+    _assert_silent_and_private(capsys, caplog, (sentinel,))
+
+
+def test_serializer_uses_exact_dumps_call_and_utf8_framing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    document = _representative()
+    original = deepcopy(document)
+    expected = _canonical_bytes(document)
+    real_dumps = serialization.json.dumps
+    dumps_spy = Mock(wraps=real_dumps)
+    monkeypatch.setattr(serialization.json, "dumps", dumps_spy)
+
+    result = serialization.serialize_v2(document)
+
+    assert dumps_spy.call_count == 1  # nosec B101
+    call = dumps_spy.call_args
+    assert call is not None  # nosec B101
+    assert call.args == (document,)  # nosec B101
+    assert call.args[0] is document  # nosec B101
+    assert call.kwargs == {  # nosec B101
+        "ensure_ascii": False,
+        "sort_keys": True,
+        "indent": 2,
+        "allow_nan": False,
+    }
+    assert isinstance(result, serialization.SerializedV2Document)  # nosec B101
+    assert result.data == expected  # nosec B101
+    assert result.byte_count == len(result.data)  # nosec B101
+    assert result.data.startswith(b"{\n")  # nosec B101
+    assert not result.data.startswith(b"\xef\xbb\xbf")  # nosec B101
+    assert b"\r" not in result.data  # nosec B101
+    assert not result.data.endswith(b"\n")  # nosec B101
+    assert "Café 東京".encode() in result.data  # nosec B101
+    assert document == original  # nosec B101
+
+
+def test_repeated_and_equivalent_object_insertions_are_byte_deterministic() -> None:
+    first = _representative()
+    second = deepcopy(first)
+    third = cast(schema.JsonObject, _reverse_object_insertions(deepcopy(first)))
+    fourth = cast(
+        schema.JsonObject,
+        json.loads(
+            json.dumps(first, ensure_ascii=False),
+            object_pairs_hook=schema.reject_duplicate_json_members,
+        ),
+    )
+
+    results = [
+        serialization.serialize_v2(candidate)
+        for candidate in (first, first, second, third, fourth)
+    ]
+
+    assert all(  # nosec B101
+        isinstance(result, serialization.SerializedV2Document) for result in results
+    )
+    data = [cast(serialization.SerializedV2Document, result).data for result in results]
+    assert len(set(data)) == 1  # nosec B101
+
+
+def test_canonical_serialization_preserves_every_array_order_and_extension_value() -> (
+    None
+):
+    document = _representative()
+
+    result = serialization.serialize_v2(document)
+
+    assert isinstance(result, serialization.SerializedV2Document)  # nosec B101
+    decoded = json.loads(
+        result.data,
+        object_pairs_hook=schema.reject_duplicate_json_members,
+    )
+    assert decoded == document  # nosec B101
+    assert decoded["extensions"]["root.example.test"]["ordered"] == [2, 1]  # nosec B101
+    assert decoded["tabs"][0]["display_order"] == [  # nosec B101
+        "40000000-0000-4000-8000-000000000002",
+        "40000000-0000-4000-8000-000000000001",
+        "40000000-0000-4000-8000-000000000003",
+    ]
+    assert decoded["tabs"][0]["kanban_order"]["new"] == [  # nosec B101
+        "40000000-0000-4000-8000-000000000001"
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["missing", "extra", "nonfinite", "wrong_version", "dangling"],
+)
+def test_malformed_candidates_are_validation_rejections(mutation: str) -> None:
+    document = _minimal()
+    if mutation == "missing":
+        del document["application"]
+    elif mutation == "extra":
+        document["unexpected"] = True
+    elif mutation == "nonfinite":
+        document["extensions"] = {"bad": float("nan")}
+    elif mutation == "wrong_version":
+        document["schema_version"] = 1
+    else:
+        cast(dict[str, object], document["application"])["default_workspace_id"] = (
+            "90000000-0000-4000-8000-000000000001"
+        )
+
+    result = serialization.serialize_v2(document)
+
+    _assert_rejected(
+        result,
+        migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE,
+        migration.PureExecutionStage.TARGET_VALIDATION,
+    )
+
+
+def test_deep_valid_extension_has_sanitized_encoder_failure() -> None:
+    secret = "private-payload-fragment.example.test"
+    document = _minimal()
+    payload: dict[str, object] = {"leaf": secret}
+    for _ in range(2_000):
+        payload = {"nested": payload}
+    document["extensions"] = cast(schema.Extensions, payload)
+    assert schema.validate_v2(document)  # nosec B101
+
+    result = serialization.serialize_v2(document)
+
+    _assert_rejected(
+        result,
+        migration.PureEngineFailureCategory.SERIALIZATION_FAILURE,
+        migration.PureExecutionStage.SERIALIZATION,
+        (secret,),
+    )
+
+
+def test_injected_encoder_exception_is_sanitized_silent_and_not_retained(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinels = (
+        "injected-exception-private-7ea43bbf",
+        "injected-candidate-title-3c2eaa58",
+        "https://injected-candidate-6cc8c73c.example.test/path",
+        "injected-extension-key-0b7c29ef",
+        "injected-extension-value-7e5b3391",
+    )
+    document = _representative()
+    cast(dict[str, object], document["application"])["title"] = sentinels[1]
+    resource = cast(list[dict[str, object]], document["resources"])[0]
+    cast(dict[str, object], resource["target"])["url"] = sentinels[2]
+    document["extensions"] = {sentinels[3]: sentinels[4]}
+    exception_ref: weakref.ReferenceType[_InjectedSerializationError] | None = None
+
+    def raising_dumps(*_args: object, **_kwargs: object) -> NoReturn:
+        nonlocal exception_ref
+        error = _InjectedSerializationError(sentinels[0])
+        exception_ref = weakref.ref(error)
+        raise error
+
+    monkeypatch.setattr(serialization.json, "dumps", raising_dumps)
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    result = serialization.serialize_v2(document)
+    gc.collect()
+
+    _assert_rejected(
+        result,
+        migration.PureEngineFailureCategory.SERIALIZATION_FAILURE,
+        migration.PureExecutionStage.SERIALIZATION,
+        sentinels,
+    )
+    assert exception_ref is not None  # nosec B101
+    assert exception_ref() is None  # nosec B101
+    _assert_silent_and_private(capsys, caplog, sentinels)
+
+
+def test_utf8_encoding_exception_uses_serialization_failure_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinel = "utf8-encoding-private-00f0540f"
+    document = _representative()
+
+    def unencodable_dumps(*_args: object, **_kwargs: object) -> str:
+        return _FailingUtf8Text(sentinel)
+
+    monkeypatch.setattr(serialization.json, "dumps", unencodable_dumps)
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    result = serialization.serialize_v2(document)
+
+    _assert_rejected(
+        result,
+        migration.PureEngineFailureCategory.SERIALIZATION_FAILURE,
+        migration.PureExecutionStage.SERIALIZATION,
+        (sentinel,),
+    )
+    _assert_silent_and_private(capsys, caplog, (sentinel,))
+
+
+def test_exact_four_mib_unicode_candidate_is_accepted_by_encoded_byte_count() -> None:
+    document = _candidate_with_canonical_size(serialization.MAX_V2_CANDIDATE_BYTES)
+    canonical = _canonical_bytes(document)
+    assert len(canonical.decode("utf-8")) < len(canonical)  # nosec B101
+
+    result = serialization.serialize_v2(document)
+
+    assert isinstance(result, serialization.SerializedV2Document)  # nosec B101
+    assert result.byte_count == 4 * 1024 * 1024  # nosec B101
+    assert len(result.data) == serialization.MAX_V2_CANDIDATE_BYTES  # nosec B101
+
+
+def test_four_mib_plus_one_unicode_candidate_is_rejected() -> None:
+    document = _candidate_with_canonical_size(serialization.MAX_V2_CANDIDATE_BYTES + 1)
+    private_padding = cast(
+        str, cast(dict[str, object], document["extensions"])["padding"]
+    )
+    assert len(private_padding) < len(private_padding.encode("utf-8"))  # nosec B101
+
+    result = serialization.serialize_v2(document)
+
+    _assert_rejected(
+        result,
+        migration.PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED,
+        migration.PureExecutionStage.SERIALIZATION,
+        ("ééé", "padding"),
+    )
+
+
+def test_rejections_and_success_repr_do_not_expose_candidate_content(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinels = (
+        "https://private.example.test/secret",
+        "Private launcher title",
+        "private-extension-content",
+        "private-payload-fragment",
+        "90000000-0000-4000-8000-000000008812",
+        "private-extension-key-f05a52a2",
+    )
+    invalid = _minimal()
+    application = cast(dict[str, object], invalid["application"])
+    application["title"] = sentinels[1]
+    application["default_workspace_id"] = sentinels[4]
+    invalid["extensions"] = {
+        sentinels[5]: {
+            "url": sentinels[0],
+            "extension": sentinels[2],
+            "payload": sentinels[3],
+        }
+    }
+    invalid["unexpected"] = sentinels[3]
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    rejection = serialization.serialize_v2(invalid)
+    success = serialization.serialize_v2(_representative())
+
+    _assert_rejected(
+        rejection,
+        migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE,
+        migration.PureExecutionStage.TARGET_VALIDATION,
+        sentinels,
+    )
+    assert isinstance(success, serialization.SerializedV2Document)  # nosec B101
+    rendered = f"{rejection!r} {rejection!s} {success!r}"
+    for sentinel in sentinels:
+        assert sentinel not in rendered  # nosec B101
+    assert "Café" not in repr(success)  # nosec B101
+    assert "example.test" not in repr(success)  # nosec B101
+    _assert_silent_and_private(capsys, caplog, sentinels)


### PR DESCRIPTION
## Summary

- Add dormant, Qt-free schema-v2 types and the complete persisted validator.
- Add the canonical schema-v2 serializer, representative fixtures, and invariant and rejection tests.
- Keep schema v2 unregistered and unreachable from production startup; current runtime behavior and persisted-state behavior are unchanged.
- Exclude the transformer, runtime adapters, parser/registry/startup integration, activation, UI, dependencies, packaging, and release work.

## Evidence

- `make format-check` passed
- `make lint` passed
- `make lint_tests` passed
- `.venv/Scripts/python.exe -m ruff check tests` passed
- `make typecheck` passed
- `make test_unit` passed: 718 collected, 17 deselected, 701 selected and passed
- Final bounded rereview passed for accepted findings 1, 2, 3, 6, and 7

Closes #123
