### PR TITLE
feat: add dormant schema-v1-to-v2 transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   explicit preserve-and-reset flow before the launcher mutates configuration state.
 - Add a Qt-free, schema-versioned migration harness and activate its pure deterministic
   v0-to-v1 step for the Workspace/Tab identity schema.
+- Add a dormant, deterministic, Qt-free schema-v1-to-v2 transformer that constructs and
+  checks the complete URL Resource/Placement/DeviceBinding graph while keeping schema v2
+  unregistered and unreachable from production startup and persistence.
 - Persist one `Default Workspace`, stable Workspace and Tab identities, ID-based Tile
   membership, and an independent `application.title` while retaining flat Tile behavior and
   existing launcher settings.

--- a/config_migration_v2.py
+++ b/config_migration_v2.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dormant, pure schema-version 1 to schema-version 2 transformation.
+
+This module constructs one complete URL-only schema-v2 candidate from an
+already detached strict schema-v1 logical graph.  It deliberately performs no
+parsing, registration, target validation, serialization, persistence, platform
+discovery, or Qt work.  Complete target validation, canonical serialization,
+and the inclusive candidate-size ceiling remain the responsibility of the
+existing downstream migration boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Final, TypeAlias, TypedDict, cast
+from uuid import UUID, uuid5
+
+import config_schema as v1
+import config_schema_v2 as v2
+
+MIGRATION_NAMESPACE_V1_TO_V2: Final = UUID("8cdeb2d4-8211-5078-9c60-90d397366383")
+V1_TO_V2_ID_ALLOCATION_ATTEMPTS: Final = 32
+
+_Locator: TypeAlias = tuple[str, int]
+
+
+class _V1Application(TypedDict):
+    title: str
+    default_workspace_id: str
+    extensions: v1.JsonObject
+
+
+class _V1Workspace(TypedDict):
+    id: str
+    name: str
+    tab_order: list[str]
+    extensions: v1.JsonObject
+
+
+class _V1Tab(TypedDict):
+    id: str
+    workspace_id: str
+    name: str
+    visibility: v2.Visibility
+    extensions: v1.JsonObject
+
+
+class _V1Tile(TypedDict):
+    name: str
+    url: str
+    tab_id: str
+    icon: str | None
+    bg: str
+    browser: str | None
+    chrome_profile: str | None
+    open_target: v2.OpenTarget
+
+
+class _V1Root(TypedDict):
+    schema_version: int
+    application: _V1Application
+    workspaces: list[_V1Workspace]
+    tabs: list[_V1Tab]
+    tiles: list[_V1Tile]
+    columns: int
+    auto_fit: bool
+    window_x: int | None
+    window_y: int | None
+    window_w: int | None
+    window_h: int | None
+    extensions: v1.JsonObject
+
+
+def _clone_json(value: v1.JsonValue) -> v2.StrictJsonValue:
+    if type(value) is list:
+        return [_clone_json(item) for item in value]
+    if type(value) is dict:
+        return {key: _clone_json(item) for key, item in value.items()}
+    return value
+
+
+def _clone_extensions(value: v1.JsonObject) -> v2.Extensions:
+    return {key: _clone_json(item) for key, item in value.items()}
+
+
+def _generated_uuid(
+    name: str,
+    uuid5_factory: v1.Uuid5Factory,
+) -> str | None:
+    result: object = uuid5_factory(MIGRATION_NAMESPACE_V1_TO_V2, name)
+    if isinstance(result, UUID):
+        parsed = result
+        candidate = str(result)
+    elif type(result) is str:
+        candidate = result
+        try:
+            parsed = UUID(candidate)
+        except (AttributeError, ValueError):
+            return None
+    else:
+        return None
+    if parsed.version != 5 or candidate != str(parsed):
+        return None
+    return candidate
+
+
+def _allocate_id(
+    name_prefix: str,
+    used_ids: set[str],
+    uuid5_factory: v1.Uuid5Factory,
+) -> str | None:
+    for retry in range(V1_TO_V2_ID_ALLOCATION_ATTEMPTS):
+        candidate = _generated_uuid(
+            f"{name_prefix}:retry:{retry}",
+            uuid5_factory,
+        )
+        if candidate is None:
+            return None
+        if candidate in used_ids:
+            continue
+        used_ids.add(candidate)
+        return candidate
+    return None
+
+
+def _group_tiles(source: _V1Root) -> dict[str, list[_V1Tile]]:
+    grouped: dict[str, list[_V1Tile]] = {tab["id"]: [] for tab in source["tabs"]}
+    for tile in source["tiles"]:
+        grouped[tile["tab_id"]].append(tile)
+    return grouped
+
+
+def _allocation_order(grouped: Mapping[str, list[_V1Tile]]) -> list[_Locator]:
+    return sorted(
+        (tab_id, ordinal)
+        for tab_id, tiles in grouped.items()
+        for ordinal in range(len(tiles))
+    )
+
+
+def _emission_order(
+    tab_order: list[str],
+    grouped: Mapping[str, list[_V1Tile]],
+) -> list[_Locator]:
+    return [
+        (tab_id, ordinal)
+        for tab_id in tab_order
+        for ordinal in range(len(grouped[tab_id]))
+    ]
+
+
+def _allocate_entity_ids(
+    source: _V1Root,
+    grouped: Mapping[str, list[_V1Tile]],
+    uuid5_factory: v1.Uuid5Factory,
+) -> (
+    tuple[
+        dict[_Locator, str],
+        dict[_Locator, str],
+        str,
+        dict[_Locator, str],
+    ]
+    | None
+):
+    workspace = source["workspaces"][0]
+    priority = _allocation_order(grouped)
+    used_ids = {workspace["id"], *(tab["id"] for tab in source["tabs"])}
+
+    resource_ids: dict[_Locator, str] = {}
+    for tab_id, ordinal in priority:
+        resource_id = _allocate_id(
+            f"dtl:migration:v1-to-v2:entity:resource:tab:{tab_id}:ordinal:{ordinal}",
+            used_ids,
+            uuid5_factory,
+        )
+        if resource_id is None:
+            return None
+        resource_ids[(tab_id, ordinal)] = resource_id
+
+    placement_ids: dict[_Locator, str] = {}
+    for tab_id, ordinal in priority:
+        placement_id = _allocate_id(
+            f"dtl:migration:v1-to-v2:entity:placement:tab:{tab_id}:ordinal:{ordinal}",
+            used_ids,
+            uuid5_factory,
+        )
+        if placement_id is None:
+            return None
+        placement_ids[(tab_id, ordinal)] = placement_id
+
+    workspace_binding_id = _allocate_id(
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"workspace-window:workspace:{workspace['id']}",
+        used_ids,
+        uuid5_factory,
+    )
+    if workspace_binding_id is None:
+        return None
+
+    launch_binding_ids: dict[_Locator, str] = {}
+    for locator in priority:
+        placement_id = placement_ids[locator]
+        binding_id = _allocate_id(
+            "dtl:migration:v1-to-v2:entity:device-binding:"
+            f"placement-launch:placement:{placement_id}",
+            used_ids,
+            uuid5_factory,
+        )
+        if binding_id is None:
+            return None
+        launch_binding_ids[locator] = binding_id
+
+    return (
+        resource_ids,
+        placement_ids,
+        workspace_binding_id,
+        launch_binding_ids,
+    )
+
+
+def _migrated_tabs(
+    source: _V1Root,
+    grouped: Mapping[str, list[_V1Tile]],
+    placement_ids: Mapping[_Locator, str],
+) -> list[v2.Tab]:
+    source_tabs = {tab["id"]: tab for tab in source["tabs"]}
+    tab_order = source["workspaces"][0]["tab_order"]
+    migrated: list[v2.Tab] = []
+    for tab_id in tab_order:
+        source_tab = source_tabs[tab_id]
+        display_order = [
+            placement_ids[(tab_id, ordinal)] for ordinal in range(len(grouped[tab_id]))
+        ]
+        in_use_order = [
+            placement_ids[(tab_id, ordinal)] for ordinal in range(len(grouped[tab_id]))
+        ]
+        migrated.append(
+            v2.Tab(
+                id=source_tab["id"],
+                workspace_id=source_tab["workspace_id"],
+                name=source_tab["name"],
+                visibility=source_tab["visibility"],
+                lifecycle="active",
+                view_mode="display",
+                display_filter=["new", "in_use"],
+                display_order=display_order,
+                kanban_order=v2.KanbanOrder(
+                    new=[],
+                    in_use=in_use_order,
+                    archived=[],
+                ),
+                extensions={},
+            )
+        )
+    return migrated
+
+
+def _migrated_resources(
+    grouped: Mapping[str, list[_V1Tile]],
+    emission_order: list[_Locator],
+    resource_ids: Mapping[_Locator, str],
+) -> list[v2.Resource]:
+    resources: list[v2.Resource] = []
+    for locator in emission_order:
+        tab_id, ordinal = locator
+        tile = grouped[tab_id][ordinal]
+        icon = tile["icon"]
+        default_icon = (
+            None
+            if icon is None
+            else v2.LegacyStringIcon(kind="legacy_string", value=icon)
+        )
+        resources.append(
+            v2.Resource(
+                id=resource_ids[locator],
+                kind="url",
+                target=v2.UrlTarget(url=tile["url"]),
+                default_label=tile["name"],
+                default_icon=default_icon,
+                extensions={},
+            )
+        )
+    return resources
+
+
+def _migrated_placements(
+    grouped: Mapping[str, list[_V1Tile]],
+    emission_order: list[_Locator],
+    resource_ids: Mapping[_Locator, str],
+    placement_ids: Mapping[_Locator, str],
+) -> list[v2.Placement]:
+    placements: list[v2.Placement] = []
+    for locator in emission_order:
+        tab_id, ordinal = locator
+        tile = grouped[tab_id][ordinal]
+        placements.append(
+            v2.Placement(
+                id=placement_ids[locator],
+                resource_id=resource_ids[locator],
+                tab_id=tab_id,
+                label_override=None,
+                icon_override=None,
+                background_color=tile["bg"],
+                workflow_status="in_use",
+                extensions={},
+            )
+        )
+    return placements
+
+
+def _migrated_bindings(
+    source: _V1Root,
+    grouped: Mapping[str, list[_V1Tile]],
+    emission_order: list[_Locator],
+    placement_ids: Mapping[_Locator, str],
+    workspace_binding_id: str,
+    launch_binding_ids: Mapping[_Locator, str],
+) -> list[v2.DeviceBinding]:
+    workspace = source["workspaces"][0]
+    bindings: list[v2.DeviceBinding] = [
+        v2.WorkspaceWindowBinding(
+            id=workspace_binding_id,
+            subject_kind="workspace",
+            subject_id=workspace["id"],
+            binding_kind="window",
+            applicability=v2.PortableFallback(kind="portable_fallback"),
+            settings=v2.WindowSettings(
+                columns=source["columns"],
+                auto_fit=source["auto_fit"],
+                window_x=source["window_x"],
+                window_y=source["window_y"],
+                window_w=source["window_w"],
+                window_h=source["window_h"],
+            ),
+            extensions={},
+        )
+    ]
+    for locator in emission_order:
+        tab_id, ordinal = locator
+        tile = grouped[tab_id][ordinal]
+        bindings.append(
+            v2.PlacementLaunchBinding(
+                id=launch_binding_ids[locator],
+                subject_kind="placement",
+                subject_id=placement_ids[locator],
+                binding_kind="launch",
+                applicability=v2.PortableFallback(kind="portable_fallback"),
+                settings=v2.UrlLaunchSettings(
+                    browser=tile["browser"],
+                    chrome_profile=tile["chrome_profile"],
+                    open_target=tile["open_target"],
+                ),
+                extensions={},
+            )
+        )
+    return bindings
+
+
+def migrate_v1_to_v2(
+    document: Mapping[str, v1.JsonValue],
+    *,
+    uuid5_factory: v1.Uuid5Factory = uuid5,
+) -> v2.Root | None:
+    """Construct one complete deterministic schema-v2 candidate or reject the step."""
+
+    if not v1.validate_v1(document):
+        return None
+    source = cast(_V1Root, document)
+    grouped = _group_tiles(source)
+    allocated = _allocate_entity_ids(source, grouped, uuid5_factory)
+    if allocated is None:
+        return None
+    resource_ids, placement_ids, workspace_binding_id, launch_binding_ids = allocated
+
+    source_workspace = source["workspaces"][0]
+    emission_order = _emission_order(source_workspace["tab_order"], grouped)
+    candidate = v2.Root(
+        schema_version=2,
+        application=v2.Application(
+            title=source["application"]["title"],
+            default_workspace_id=source["application"]["default_workspace_id"],
+            extensions={},
+        ),
+        workspaces=[
+            v2.Workspace(
+                id=source_workspace["id"],
+                name=source_workspace["name"],
+                tab_order=list(source_workspace["tab_order"]),
+                extensions={},
+            )
+        ],
+        tabs=_migrated_tabs(source, grouped, placement_ids),
+        resources=_migrated_resources(grouped, emission_order, resource_ids),
+        placements=_migrated_placements(
+            grouped,
+            emission_order,
+            resource_ids,
+            placement_ids,
+        ),
+        device_bindings=_migrated_bindings(
+            source,
+            grouped,
+            emission_order,
+            placement_ids,
+            workspace_binding_id,
+            launch_binding_ids,
+        ),
+        extensions=_clone_extensions(source["extensions"]),
+    )
+    return candidate
+
+
+__all__ = [
+    "MIGRATION_NAMESPACE_V1_TO_V2",
+    "V1_TO_V2_ID_ALLOCATION_ATTEMPTS",
+    "migrate_v1_to_v2",
+]

--- a/config_transform_v1_to_v2.py
+++ b/config_transform_v1_to_v2.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Checked dormant composition of the pure schema-v1-to-v2 transform.
+
+Logical candidate construction remains isolated in :mod:`config_migration_v2`
+for the future migration-engine adapter.  This module composes that stage with
+the existing complete schema-v2 validator, canonical serializer, and inclusive
+candidate-size ceiling without registering or persisting schema version 2.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeAlias
+
+import config_migration_v2 as construction
+import config_schema as v1
+import config_schema_v2 as v2
+import config_serialization_v2 as serialization
+
+V1ToV2TransformResult: TypeAlias = (
+    v2.Root | serialization.V2SerializationRejected | None
+)
+
+
+def transform_v1_to_v2(
+    document: Mapping[str, v1.JsonValue],
+) -> V1ToV2TransformResult:
+    """Return one serializer-admissible candidate or a content-free rejection."""
+
+    candidate = construction.migrate_v1_to_v2(document)
+    if candidate is None:
+        return None
+    serialized = serialization.serialize_v2(candidate)
+    if isinstance(serialized, serialization.V2SerializationRejected):
+        return serialized
+    return candidate
+
+
+__all__ = ["V1ToV2TransformResult", "transform_v1_to_v2"]

--- a/tests/unit/test_config_migration_v2.py
+++ b/tests/unit/test_config_migration_v2.py
@@ -1,0 +1,1086 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from typing import NoReturn, cast
+from uuid import UUID, uuid5
+
+import pytest
+
+import config_migration as engine
+import config_migration_v2 as migration
+import config_schema as v1
+import config_schema_v2 as v2
+import config_serialization_v2 as serialization
+import config_transform_v1_to_v2 as checked
+
+pytestmark = pytest.mark.unit
+
+WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+MAIN_TAB_ID = "22222222-2222-4222-8222-222222222222"
+LOW_TAB_ID = "00000000-0000-4000-8000-000000000001"
+HIGH_TAB_ID = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+RESOURCE_ID = "f6c4f407-1e69-55a9-b68d-1e509b5ed9e3"
+PLACEMENT_ID = "c58596f5-047d-543a-b39c-33c2c366d364"
+WORKSPACE_BINDING_ID = "3f99d908-f507-5905-9d68-e664e6a8a25e"
+LAUNCH_BINDING_ID = "a8f543e0-fdb2-5033-b8ca-7982d96a5399"
+
+
+def _tile(
+    name: str,
+    url: str,
+    tab_id: str,
+    *,
+    icon: str | None = None,
+    bg: str = "#F5F6FA",
+    browser: str | None = None,
+    chrome_profile: str | None = None,
+    open_target: str = "tab",
+) -> v1.JsonObject:
+    return {
+        "name": name,
+        "url": url,
+        "tab_id": tab_id,
+        "icon": icon,
+        "bg": bg,
+        "browser": browser,
+        "chrome_profile": chrome_profile,
+        "open_target": open_target,
+    }
+
+
+def _one_tile_source() -> v1.JsonObject:
+    return {
+        "schema_version": 1,
+        "application": {
+            "title": "My Launcher",
+            "default_workspace_id": WORKSPACE_ID,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": WORKSPACE_ID,
+                "name": "Default Workspace",
+                "tab_order": [MAIN_TAB_ID],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": MAIN_TAB_ID,
+                "workspace_id": WORKSPACE_ID,
+                "name": "Main",
+                "visibility": "visible",
+                "extensions": {},
+            }
+        ],
+        "tiles": [
+            _tile(
+                "ChatGPT",
+                "https://chat.openai.com",
+                MAIN_TAB_ID,
+            )
+        ],
+        "columns": 5,
+        "auto_fit": True,
+        "window_x": None,
+        "window_y": None,
+        "window_w": None,
+        "window_h": None,
+        "extensions": {},
+    }
+
+
+def _two_tab_source() -> v1.JsonObject:
+    return {
+        "schema_version": 1,
+        "application": {
+            "title": "Ordering",
+            "default_workspace_id": WORKSPACE_ID,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": WORKSPACE_ID,
+                "name": "Current Workspace Name",
+                "tab_order": [HIGH_TAB_ID, LOW_TAB_ID],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": LOW_TAB_ID,
+                "workspace_id": WORKSPACE_ID,
+                "name": "Low",
+                "visibility": "hidden",
+                "extensions": {},
+            },
+            {
+                "id": HIGH_TAB_ID,
+                "workspace_id": WORKSPACE_ID,
+                "name": "High",
+                "visibility": "visible",
+                "extensions": {},
+            },
+        ],
+        "tiles": [
+            _tile("low-0", "https://low.example/0", LOW_TAB_ID),
+            _tile("high-0", "https://high.example/0", HIGH_TAB_ID),
+            _tile("low-1", "https://low.example/1", LOW_TAB_ID),
+            _tile("high-1", "https://high.example/1", HIGH_TAB_ID),
+        ],
+        "columns": -2,
+        "auto_fit": True,
+        "window_x": 0,
+        "window_y": -40,
+        "window_w": None,
+        "window_h": 900,
+        "extensions": {},
+    }
+
+
+def _candidate(source: v1.JsonObject) -> v2.Root:
+    result = migration.migrate_v1_to_v2(source)
+    assert result is not None  # nosec B101
+    return result
+
+
+def _canonical_bytes(document: object) -> bytes:
+    return json.dumps(
+        document,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _reverse_object_insertions(value: object) -> object:
+    if type(value) is dict:
+        return {
+            key: _reverse_object_insertions(item)
+            for key, item in reversed(list(cast(dict[str, object], value).items()))
+        }
+    if type(value) is list:
+        return [_reverse_object_insertions(item) for item in cast(list[object], value)]
+    return value
+
+
+def _generated_ids(candidate: v2.Root) -> tuple[str, ...]:
+    return tuple(
+        [resource["id"] for resource in candidate["resources"]]
+        + [placement["id"] for placement in candidate["placements"]]
+        + [binding["id"] for binding in candidate["device_bindings"]]
+    )
+
+
+def _replace_workspace_id(source: v1.JsonObject, replacement: str) -> None:
+    application = cast(dict[str, v1.JsonValue], source["application"])
+    workspaces = cast(list[dict[str, v1.JsonValue]], source["workspaces"])
+    tabs = cast(list[dict[str, v1.JsonValue]], source["tabs"])
+    application["default_workspace_id"] = replacement
+    workspaces[0]["id"] = replacement
+    for tab in tabs:
+        tab["workspace_id"] = replacement
+
+
+def _test_registry(
+    *,
+    uuid5_factory: v1.Uuid5Factory = uuid5,
+    target_accepts: bool = True,
+) -> engine.ValidatedMigrationRegistry:
+    def validate_source(
+        document: Mapping[str, engine.JsonValue],
+    ) -> engine.ValidationDecision:
+        if v1.validate_v1(document):
+            return engine.ValidationAccepted()
+        return engine.ValidationRejected()
+
+    def transform_source(
+        document: Mapping[str, engine.JsonValue],
+    ) -> engine.StepDecision:
+        candidate = migration.migrate_v1_to_v2(
+            document,
+            uuid5_factory=uuid5_factory,
+        )
+        if candidate is None:
+            return engine.StepRejected()
+        return engine.StepApplied(cast(engine.JsonObject, candidate))
+
+    def validate_target(
+        document: Mapping[str, engine.JsonValue],
+    ) -> engine.ValidationDecision:
+        if target_accepts and v2.validate_v2(document):
+            return engine.ValidationAccepted()
+        return engine.ValidationRejected()
+
+    result = engine.validate_registry(
+        engine.RegistrySpec(
+            1,
+            2,
+            (engine.MigrationStep(1, 2, "v1_to_v2", transform_source),),
+            (
+                engine.VersionValidator(1, validate_source),
+                engine.VersionValidator(2, validate_target),
+            ),
+        )
+    )
+    if not isinstance(result, engine.RegistryReady):
+        raise AssertionError("test registry must be valid")
+    return result.registry
+
+
+def _execute_test_migration(
+    source: v1.JsonObject,
+    *,
+    uuid5_factory: v1.Uuid5Factory = uuid5,
+    target_accepts: bool = True,
+) -> engine.ExecutionResult:
+    prepared = engine.prepare_migration(
+        source,
+        _test_registry(
+            uuid5_factory=uuid5_factory,
+            target_accepts=target_accepts,
+        ),
+    )
+    if not isinstance(prepared, engine.PreparedMigration):
+        raise AssertionError("test source must prepare a migration")
+    return engine.execute_prepared_migration(prepared)
+
+
+def test_adr_oracle_builds_the_exact_complete_graph_and_canonical_bytes() -> None:
+    source = _one_tile_source()
+    original = deepcopy(source)
+
+    candidate = _candidate(source)
+
+    expected: v2.Root = {
+        "schema_version": 2,
+        "application": {
+            "title": "My Launcher",
+            "default_workspace_id": WORKSPACE_ID,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": WORKSPACE_ID,
+                "name": "Default Workspace",
+                "tab_order": [MAIN_TAB_ID],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": MAIN_TAB_ID,
+                "workspace_id": WORKSPACE_ID,
+                "name": "Main",
+                "visibility": "visible",
+                "lifecycle": "active",
+                "view_mode": "display",
+                "display_filter": ["new", "in_use"],
+                "display_order": [PLACEMENT_ID],
+                "kanban_order": {
+                    "new": [],
+                    "in_use": [PLACEMENT_ID],
+                    "archived": [],
+                },
+                "extensions": {},
+            }
+        ],
+        "resources": [
+            {
+                "id": RESOURCE_ID,
+                "kind": "url",
+                "target": {"url": "https://chat.openai.com"},
+                "default_label": "ChatGPT",
+                "default_icon": None,
+                "extensions": {},
+            }
+        ],
+        "placements": [
+            {
+                "id": PLACEMENT_ID,
+                "resource_id": RESOURCE_ID,
+                "tab_id": MAIN_TAB_ID,
+                "label_override": None,
+                "icon_override": None,
+                "background_color": "#F5F6FA",
+                "workflow_status": "in_use",
+                "extensions": {},
+            }
+        ],
+        "device_bindings": [
+            {
+                "id": WORKSPACE_BINDING_ID,
+                "subject_kind": "workspace",
+                "subject_id": WORKSPACE_ID,
+                "binding_kind": "window",
+                "applicability": {"kind": "portable_fallback"},
+                "settings": {
+                    "columns": 5,
+                    "auto_fit": True,
+                    "window_x": None,
+                    "window_y": None,
+                    "window_w": None,
+                    "window_h": None,
+                },
+                "extensions": {},
+            },
+            {
+                "id": LAUNCH_BINDING_ID,
+                "subject_kind": "placement",
+                "subject_id": PLACEMENT_ID,
+                "binding_kind": "launch",
+                "applicability": {"kind": "portable_fallback"},
+                "settings": {
+                    "browser": None,
+                    "chrome_profile": None,
+                    "open_target": "tab",
+                },
+                "extensions": {},
+            },
+        ],
+        "extensions": {},
+    }
+    assert candidate == expected  # nosec B101
+    assert source == original  # nosec B101
+    assert v2.validate_v2(candidate)  # nosec B101
+
+    serialized = serialization.serialize_v2(candidate)
+    assert isinstance(  # nosec B101
+        serialized,
+        serialization.SerializedV2Document,
+    )
+    assert serialized.byte_count == 2499  # nosec B101
+    assert hashlib.sha256(serialized.data).hexdigest() == (  # nosec B101
+        "2ee1c4fb68ca530d77de90cac72ed6beff654c1f79f34550281ebf48f21dd6ff"
+    )
+    assert serialized.data == _canonical_bytes(candidate)  # nosec B101
+    assert not serialized.data.endswith(b"\n")  # nosec B101
+
+
+def test_zero_tiles_preserve_empty_tabs_and_create_only_window_binding() -> None:
+    source = _two_tab_source()
+    source["tiles"] = []
+
+    candidate = _candidate(source)
+
+    assert candidate["resources"] == []  # nosec B101
+    assert candidate["placements"] == []  # nosec B101
+    assert len(candidate["device_bindings"]) == 1  # nosec B101
+    assert candidate["device_bindings"][0]["binding_kind"] == "window"  # nosec B101
+    assert [tab["id"] for tab in candidate["tabs"]] == [  # nosec B101
+        HIGH_TAB_ID,
+        LOW_TAB_ID,
+    ]
+    for tab in candidate["tabs"]:
+        assert tab["display_order"] == []  # nosec B101
+        assert tab["kanban_order"] == {  # nosec B101
+            "new": [],
+            "in_use": [],
+            "archived": [],
+        }
+    assert v2.validate_v2(candidate)  # nosec B101
+
+
+def test_duplicate_tiles_remain_distinct_and_icon_values_remain_exact() -> None:
+    source = _two_tab_source()
+    duplicate = _tile(
+        "same",
+        "https://duplicate.example",
+        HIGH_TAB_ID,
+        icon="",
+        bg=" ",
+        browser="",
+        chrome_profile=" ",
+        open_target="window",
+    )
+    source["tiles"] = [
+        deepcopy(duplicate),
+        deepcopy(duplicate),
+        _tile(
+            "same",
+            "https://duplicate.example",
+            LOW_TAB_ID,
+            icon=" ",
+            bg=" ",
+            browser="unsupported browser",
+            chrome_profile=None,
+        ),
+        _tile("null-icon", "", LOW_TAB_ID, icon=None),
+    ]
+
+    candidate = _candidate(source)
+
+    assert len(candidate["resources"]) == 4  # nosec B101
+    assert len(candidate["placements"]) == 4  # nosec B101
+    assert len(candidate["device_bindings"]) == 5  # nosec B101
+    assert len({resource["id"] for resource in candidate["resources"]}) == 4  # nosec B101
+    assert len({placement["id"] for placement in candidate["placements"]}) == 4  # nosec B101
+    assert (
+        len(  # nosec B101
+            {binding["id"] for binding in candidate["device_bindings"]}
+        )
+        == 5
+    )
+    assert [resource["default_icon"] for resource in candidate["resources"]] == [  # nosec B101
+        {"kind": "legacy_string", "value": ""},
+        {"kind": "legacy_string", "value": ""},
+        {"kind": "legacy_string", "value": " "},
+        None,
+    ]
+    assert all(  # nosec B101
+        resource["target"]["url"] == "https://duplicate.example"
+        for resource in candidate["resources"][:3]
+    )
+    assert candidate["resources"][3]["target"]["url"] == ""  # nosec B101
+    assert [placement["background_color"] for placement in candidate["placements"]] == [  # nosec B101
+        " ",
+        " ",
+        " ",
+        "#F5F6FA",
+    ]
+    window_settings = candidate["device_bindings"][0]["settings"]
+    assert window_settings == {  # nosec B101
+        "columns": -2,
+        "auto_fit": True,
+        "window_x": 0,
+        "window_y": -40,
+        "window_w": None,
+        "window_h": 900,
+    }
+    assert (
+        [  # nosec B101
+            binding["settings"] for binding in candidate["device_bindings"][1:]
+        ]
+        == [
+            {
+                "browser": "",
+                "chrome_profile": " ",
+                "open_target": "window",
+            },
+            {
+                "browser": "",
+                "chrome_profile": " ",
+                "open_target": "window",
+            },
+            {
+                "browser": "unsupported browser",
+                "chrome_profile": None,
+                "open_target": "tab",
+            },
+            {
+                "browser": None,
+                "chrome_profile": None,
+                "open_target": "tab",
+            },
+        ]
+    )
+    assert v2.validate_v2(candidate)  # nosec B101
+
+
+def test_allocation_priority_and_candidate_emission_order_are_independent() -> None:
+    source = _two_tab_source()
+    calls: list[tuple[UUID, str]] = []
+
+    def recording_uuid5(namespace: UUID, name: str) -> UUID:
+        calls.append((namespace, name))
+        return uuid5(namespace, name)
+
+    candidate = migration.migrate_v1_to_v2(
+        source,
+        uuid5_factory=recording_uuid5,
+    )
+
+    assert candidate is not None  # nosec B101
+    expected_resource_names = [
+        f"dtl:migration:v1-to-v2:entity:resource:tab:{tab_id}:ordinal:{ordinal}:retry:0"
+        for tab_id in (LOW_TAB_ID, HIGH_TAB_ID)
+        for ordinal in range(2)
+    ]
+    expected_placement_names = [
+        "dtl:migration:v1-to-v2:entity:placement:"
+        f"tab:{tab_id}:ordinal:{ordinal}:retry:0"
+        for tab_id in (LOW_TAB_ID, HIGH_TAB_ID)
+        for ordinal in range(2)
+    ]
+    placement_ids_by_priority = [
+        str(uuid5(migration.MIGRATION_NAMESPACE_V1_TO_V2, name))
+        for name in expected_placement_names
+    ]
+    expected_binding_names = [
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"placement-launch:placement:{placement_id}:retry:0"
+        for placement_id in placement_ids_by_priority
+    ]
+    assert [namespace for namespace, _ in calls] == [  # nosec B101
+        migration.MIGRATION_NAMESPACE_V1_TO_V2
+    ] * 13
+    assert [name for _, name in calls] == (  # nosec B101
+        expected_resource_names
+        + expected_placement_names
+        + [
+            "dtl:migration:v1-to-v2:entity:device-binding:"
+            f"workspace-window:workspace:{WORKSPACE_ID}:retry:0"
+        ]
+        + expected_binding_names
+    )
+    assert [tab["id"] for tab in candidate["tabs"]] == [  # nosec B101
+        HIGH_TAB_ID,
+        LOW_TAB_ID,
+    ]
+    assert candidate["workspaces"][0]["name"] == "Current Workspace Name"  # nosec B101
+    assert [tab["visibility"] for tab in candidate["tabs"]] == [  # nosec B101
+        "visible",
+        "hidden",
+    ]
+    assert [resource["default_label"] for resource in candidate["resources"]] == [  # nosec B101
+        "high-0",
+        "high-1",
+        "low-0",
+        "low-1",
+    ]
+    placement_ids = [placement["id"] for placement in candidate["placements"]]
+    assert candidate["tabs"][0]["display_order"] == placement_ids[:2]  # nosec B101
+    assert candidate["tabs"][0]["kanban_order"]["in_use"] == placement_ids[:2]  # nosec B101
+    assert candidate["tabs"][1]["display_order"] == placement_ids[2:]  # nosec B101
+    assert candidate["tabs"][1]["kanban_order"]["in_use"] == placement_ids[2:]  # nosec B101
+    assert (
+        [  # nosec B101
+            binding["subject_id"] for binding in candidate["device_bindings"][1:]
+        ]
+        == placement_ids
+    )
+    assert v2.validate_v2(candidate)  # nosec B101
+
+
+def test_workspace_tab_order_changes_emission_but_not_locator_identities() -> None:
+    first_source = _two_tab_source()
+    second_source = deepcopy(first_source)
+    second_workspace = cast(
+        list[dict[str, v1.JsonValue]],
+        second_source["workspaces"],
+    )[0]
+    second_workspace["tab_order"] = [LOW_TAB_ID, HIGH_TAB_ID]
+
+    first = _candidate(first_source)
+    second = _candidate(second_source)
+
+    def identities_by_label(candidate: v2.Root) -> dict[str, tuple[str, str, str]]:
+        placement_by_resource = {
+            placement["resource_id"]: placement for placement in candidate["placements"]
+        }
+        launch_by_placement = {
+            binding["subject_id"]: binding
+            for binding in candidate["device_bindings"][1:]
+        }
+        return {
+            resource["default_label"]: (
+                resource["id"],
+                placement_by_resource[resource["id"]]["id"],
+                launch_by_placement[placement_by_resource[resource["id"]]["id"]]["id"],
+            )
+            for resource in candidate["resources"]
+        }
+
+    assert identities_by_label(first) == identities_by_label(second)  # nosec B101
+    assert first["device_bindings"][0]["id"] == second["device_bindings"][0]["id"]  # nosec B101
+    assert [tab["id"] for tab in first["tabs"]] == [HIGH_TAB_ID, LOW_TAB_ID]  # nosec B101
+    assert [tab["id"] for tab in second["tabs"]] == [LOW_TAB_ID, HIGH_TAB_ID]  # nosec B101
+    assert [resource["default_label"] for resource in first["resources"]] == [  # nosec B101
+        "high-0",
+        "high-1",
+        "low-0",
+        "low-1",
+    ]
+    assert [resource["default_label"] for resource in second["resources"]] == [  # nosec B101
+        "low-0",
+        "low-1",
+        "high-0",
+        "high-1",
+    ]
+    assert _canonical_bytes(first) != _canonical_bytes(second)  # nosec B101
+
+
+def test_fixed_namespace_and_retry_zero_identity_vectors_are_exact() -> None:
+    calls: list[str] = []
+
+    def recording_uuid5(namespace: UUID, name: str) -> UUID:
+        assert namespace == UUID(  # nosec B101
+            "8cdeb2d4-8211-5078-9c60-90d397366383"
+        )
+        calls.append(name)
+        return uuid5(namespace, name)
+
+    candidate = migration.migrate_v1_to_v2(
+        _one_tile_source(),
+        uuid5_factory=recording_uuid5,
+    )
+
+    assert candidate is not None  # nosec B101
+    assert calls == [  # nosec B101
+        f"dtl:migration:v1-to-v2:entity:resource:tab:{MAIN_TAB_ID}:ordinal:0:retry:0",
+        f"dtl:migration:v1-to-v2:entity:placement:tab:{MAIN_TAB_ID}:ordinal:0:retry:0",
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"workspace-window:workspace:{WORKSPACE_ID}:retry:0",
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"placement-launch:placement:{PLACEMENT_ID}:retry:0",
+    ]
+    assert _generated_ids(candidate) == (  # nosec B101
+        RESOURCE_ID,
+        PLACEMENT_ID,
+        WORKSPACE_BINDING_ID,
+        LAUNCH_BINDING_ID,
+    )
+
+
+def test_reserved_and_cross_family_collisions_use_the_exact_retry_name() -> None:
+    reserved_source = _one_tile_source()
+    _replace_workspace_id(reserved_source, RESOURCE_ID)
+    reserved_calls: list[str] = []
+
+    def reserved_recording_uuid5(namespace: UUID, name: str) -> UUID:
+        reserved_calls.append(name)
+        return uuid5(namespace, name)
+
+    reserved_candidate = migration.migrate_v1_to_v2(
+        reserved_source,
+        uuid5_factory=reserved_recording_uuid5,
+    )
+
+    assert reserved_candidate is not None  # nosec B101
+    assert reserved_calls[:2] == [  # nosec B101
+        f"dtl:migration:v1-to-v2:entity:resource:tab:{MAIN_TAB_ID}:ordinal:0:retry:0",
+        f"dtl:migration:v1-to-v2:entity:resource:tab:{MAIN_TAB_ID}:ordinal:0:retry:1",
+    ]
+    assert reserved_candidate["resources"][0]["id"] == (  # nosec B101
+        "d9ba4755-c072-584f-b174-22c5fd018be8"
+    )
+
+    resource_retry_zero = UUID(RESOURCE_ID)
+    placement_calls: list[str] = []
+
+    def cross_family_collision(namespace: UUID, name: str) -> UUID:
+        placement_calls.append(name)
+        if ":entity:placement:" in name and name.endswith(":retry:0"):
+            return resource_retry_zero
+        return uuid5(namespace, name)
+
+    cross_family_candidate = migration.migrate_v1_to_v2(
+        _one_tile_source(),
+        uuid5_factory=cross_family_collision,
+    )
+
+    assert cross_family_candidate is not None  # nosec B101
+    assert any(name.endswith(":retry:1") for name in placement_calls)  # nosec B101
+    expected_retry_one = uuid5(
+        migration.MIGRATION_NAMESPACE_V1_TO_V2,
+        f"dtl:migration:v1-to-v2:entity:placement:tab:{MAIN_TAB_ID}:ordinal:0:retry:1",
+    )
+    assert cross_family_candidate["placements"][0]["id"] == str(  # nosec B101
+        expected_retry_one
+    )
+    assert (  # nosec B101
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"placement-launch:placement:{expected_retry_one}:retry:0" in placement_calls
+    )
+
+
+def test_both_device_binding_families_retry_against_the_global_id_set() -> None:
+    calls: list[str] = []
+
+    def collide_bindings(namespace: UUID, name: str) -> UUID:
+        calls.append(name)
+        if "workspace-window" in name and name.endswith(":retry:0"):
+            return UUID(RESOURCE_ID)
+        if "placement-launch" in name and name.endswith(":retry:0"):
+            return UUID(PLACEMENT_ID)
+        return uuid5(namespace, name)
+
+    candidate = migration.migrate_v1_to_v2(
+        _one_tile_source(),
+        uuid5_factory=collide_bindings,
+    )
+
+    assert candidate is not None  # nosec B101
+    workspace_retry_one_name = (
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"workspace-window:workspace:{WORKSPACE_ID}:retry:1"
+    )
+    launch_retry_one_name = (
+        "dtl:migration:v1-to-v2:entity:device-binding:"
+        f"placement-launch:placement:{PLACEMENT_ID}:retry:1"
+    )
+    assert workspace_retry_one_name in calls  # nosec B101
+    assert launch_retry_one_name in calls  # nosec B101
+    assert candidate["device_bindings"][0]["id"] == str(  # nosec B101
+        uuid5(migration.MIGRATION_NAMESPACE_V1_TO_V2, workspace_retry_one_name)
+    )
+    assert candidate["device_bindings"][1]["id"] == str(  # nosec B101
+        uuid5(migration.MIGRATION_NAMESPACE_V1_TO_V2, launch_retry_one_name)
+    )
+
+
+def test_collision_exhaustion_uses_exactly_retries_zero_through_thirty_one() -> None:
+    source = _one_tile_source()
+    _replace_workspace_id(source, RESOURCE_ID)
+    calls: list[str] = []
+
+    def always_reserved(_namespace: UUID, name: str) -> UUID:
+        calls.append(name)
+        return UUID(RESOURCE_ID)
+
+    candidate = migration.migrate_v1_to_v2(
+        source,
+        uuid5_factory=always_reserved,
+    )
+
+    assert candidate is None  # nosec B101
+    assert migration.V1_TO_V2_ID_ALLOCATION_ATTEMPTS == 32  # nosec B101
+    assert calls == [  # nosec B101
+        "dtl:migration:v1-to-v2:entity:resource:"
+        f"tab:{MAIN_TAB_ID}:ordinal:0:retry:{retry}"
+        for retry in range(32)
+    ]
+    assert not any(name.endswith(":retry:32") for name in calls)  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "invalid_result",
+    (
+        UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+        RESOURCE_ID.upper(),
+        "not-a-uuid",
+        object(),
+    ),
+)
+def test_invalid_generated_uuid_output_fails_closed(invalid_result: object) -> None:
+    def invalid_factory(_namespace: UUID, _name: str) -> object:
+        return invalid_result
+
+    result = migration.migrate_v1_to_v2(
+        _one_tile_source(),
+        uuid5_factory=cast(v1.Uuid5Factory, invalid_factory),
+    )
+
+    assert result is None  # nosec B101
+
+
+def test_canonical_uuid5_string_factory_output_is_accepted() -> None:
+    def string_factory(namespace: UUID, name: str) -> str:
+        return str(uuid5(namespace, name))
+
+    candidate = migration.migrate_v1_to_v2(
+        _one_tile_source(),
+        uuid5_factory=string_factory,
+    )
+
+    assert candidate is not None  # nosec B101
+    assert _generated_ids(candidate) == (  # nosec B101
+        RESOURCE_ID,
+        PLACEMENT_ID,
+        WORKSPACE_BINDING_ID,
+        LAUNCH_BINDING_ID,
+    )
+
+
+def test_factory_exception_is_silent_private_and_returns_no_partial_graph(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinel = "private-factory-failure-25a0af0d"
+
+    def raising_factory(_namespace: UUID, _name: str) -> NoReturn:
+        raise RuntimeError(sentinel)
+
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    result = _execute_test_migration(
+        _one_tile_source(),
+        uuid5_factory=raising_factory,
+    )
+
+    captured = capsys.readouterr()
+    assert isinstance(result, engine.PureEngineDefect)  # nosec B101
+    assert result.category is engine.PureEngineDefectCategory.CALLBACK_EXCEPTION  # nosec B101
+    assert result.stage is engine.PureExecutionStage.STEP  # nosec B101
+    assert captured.out == ""  # nosec B101
+    assert captured.err == ""  # nosec B101
+    assert sentinel not in caplog.text  # nosec B101
+    assert sentinel not in repr(result)  # nosec B101
+
+
+def test_identity_inputs_are_locator_only_and_never_include_source_values() -> None:
+    first = _one_tile_source()
+    first["extensions"] = {
+        v1.LEGACY_EXTENSION_NAMESPACE: {"private-extension-a": [1, 2]}
+    }
+    second = deepcopy(first)
+    second_tile = cast(list[dict[str, v1.JsonValue]], second["tiles"])[0]
+    second_tile.update(
+        {
+            "name": "private-label-b",
+            "url": "https://private-url-b.example/secret",
+            "icon": "private-icon-b",
+            "bg": "private-color-b",
+            "browser": "private-browser-b",
+            "chrome_profile": "private-profile-b",
+            "open_target": "window",
+        }
+    )
+    second["extensions"] = {
+        v1.LEGACY_EXTENSION_NAMESPACE: {"private-extension-b": [2, 1]}
+    }
+    first_names: list[str] = []
+    second_names: list[str] = []
+
+    def first_factory(namespace: UUID, name: str) -> UUID:
+        first_names.append(name)
+        return uuid5(namespace, name)
+
+    def second_factory(namespace: UUID, name: str) -> UUID:
+        second_names.append(name)
+        return uuid5(namespace, name)
+
+    first_candidate = migration.migrate_v1_to_v2(
+        first,
+        uuid5_factory=first_factory,
+    )
+    second_candidate = migration.migrate_v1_to_v2(
+        second,
+        uuid5_factory=second_factory,
+    )
+
+    assert first_candidate is not None  # nosec B101
+    assert second_candidate is not None  # nosec B101
+    assert first_names == second_names  # nosec B101
+    assert _generated_ids(first_candidate) == _generated_ids(  # nosec B101
+        second_candidate
+    )
+    rendered_names = " ".join(first_names + second_names)
+    for sentinel in (
+        "private-label",
+        "private-url",
+        "private-icon",
+        "private-color",
+        "private-browser",
+        "private-profile",
+        "private-extension",
+    ):
+        assert sentinel not in rendered_names  # nosec B101
+
+
+def test_logically_equivalent_sources_replay_to_identical_graph_and_bytes() -> None:
+    first = _two_tab_source()
+    first["extensions"] = {
+        v1.LEGACY_EXTENSION_NAMESPACE: {
+            "object": {"b": 2, "a": 1},
+            "ordered": [2, 1],
+        }
+    }
+    second = deepcopy(first)
+    second["tiles"] = [
+        cast(list[v1.JsonValue], first["tiles"])[1],
+        cast(list[v1.JsonValue], first["tiles"])[0],
+        cast(list[v1.JsonValue], first["tiles"])[3],
+        cast(list[v1.JsonValue], first["tiles"])[2],
+    ]
+    second_tabs = cast(list[v1.JsonValue], second["tabs"])
+    second["tabs"] = list(reversed(second_tabs))
+    third = cast(
+        v1.JsonObject,
+        _reverse_object_insertions(deepcopy(second)),
+    )
+
+    candidates = [_candidate(source) for source in (first, second, third)]
+    serialized = [serialization.serialize_v2(candidate) for candidate in candidates]
+
+    assert candidates[0] == candidates[1] == candidates[2]  # nosec B101
+    assert all(  # nosec B101
+        isinstance(result, serialization.SerializedV2Document) for result in serialized
+    )
+    assert (
+        len(  # nosec B101
+            {
+                cast(serialization.SerializedV2Document, result).data
+                for result in serialized
+            }
+        )
+        == 1
+    )
+
+
+def test_extensions_and_all_constructed_collections_are_detached() -> None:
+    source = _two_tab_source()
+    source["extensions"] = {
+        v1.LEGACY_EXTENSION_NAMESPACE: {
+            "schema_version": 99,
+            "nested": {"ordered": [None, True, -1, 1.5, "秘密"]},
+        }
+    }
+    source_before = deepcopy(source)
+
+    candidate = _candidate(source)
+
+    assert candidate["extensions"] == source["extensions"]  # nosec B101
+    assert candidate["extensions"] is not source["extensions"]  # nosec B101
+    candidate_legacy = cast(
+        dict[str, object],
+        candidate["extensions"][v1.LEGACY_EXTENSION_NAMESPACE],
+    )
+    source_legacy = cast(
+        dict[str, object],
+        source["extensions"][v1.LEGACY_EXTENSION_NAMESPACE],
+    )
+    assert candidate_legacy is not source_legacy  # nosec B101
+    assert candidate_legacy["nested"] is not source_legacy["nested"]  # nosec B101
+
+    source_workspace = cast(list[dict[str, object]], source["workspaces"])[0]
+    assert (
+        candidate["workspaces"][0]["tab_order"]
+        is not (  # nosec B101
+            source_workspace["tab_order"]
+        )
+    )
+    for tab in candidate["tabs"]:
+        assert tab["display_order"] is not tab["kanban_order"]["in_use"]  # nosec B101
+
+    extension_objects = [
+        candidate["application"]["extensions"],
+        candidate["workspaces"][0]["extensions"],
+        *(tab["extensions"] for tab in candidate["tabs"]),
+        *(resource["extensions"] for resource in candidate["resources"]),
+        *(placement["extensions"] for placement in candidate["placements"]),
+        *(binding["extensions"] for binding in candidate["device_bindings"]),
+    ]
+    assert all(value == {} for value in extension_objects)  # nosec B101
+    assert len({id(value) for value in extension_objects}) == len(  # nosec B101
+        extension_objects
+    )
+
+    source_nested = cast(dict[str, list[object]], source_legacy["nested"])
+    source_nested["ordered"].append("source-only")
+    assert "source-only" not in repr(candidate["extensions"])  # nosec B101
+    candidate_legacy["candidate-only"] = True
+    assert "candidate-only" not in repr(source["extensions"])  # nosec B101
+    assert source_before != source  # nosec B101
+    assert v2.validate_v2(candidate)  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda source: source.update({"schema_version": 2}),
+        lambda source: source.update({"unexpected": "private"}),
+        lambda source: source.update({"extensions": {"unexpected": {"private": True}}}),
+    ),
+)
+def test_invalid_strict_v1_source_returns_no_candidate(
+    mutation: Callable[[v1.JsonObject], None],
+) -> None:
+    source = _one_tile_source()
+    mutation(source)
+
+    result = migration.migrate_v1_to_v2(source)
+
+    assert result is None  # nosec B101
+
+
+def test_checked_transform_expected_rejection_is_silent_and_private(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinel = "private-invalid-source-4e19e9ac"
+    source = _one_tile_source()
+    source["unexpected"] = sentinel
+    caplog.set_level(logging.DEBUG)
+
+    result = checked.transform_v1_to_v2(source)
+
+    captured = capsys.readouterr()
+    assert result is None  # nosec B101
+    assert captured.out == ""  # nosec B101
+    assert captured.err == ""  # nosec B101
+    assert sentinel not in caplog.text  # nosec B101
+    assert sentinel not in repr(result)  # nosec B101
+
+
+def test_downstream_target_validation_failure_remains_distinct() -> None:
+    result = _execute_test_migration(
+        _one_tile_source(),
+        target_accepts=False,
+    )
+
+    assert isinstance(result, engine.PureExecutionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.category
+        is engine.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+    )
+    assert result.stage is engine.PureExecutionStage.TARGET_VALIDATION  # nosec B101
+
+
+def test_checked_transform_returns_content_free_target_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(serialization, "validate_v2", lambda _candidate: False)
+
+    result = checked.transform_v1_to_v2(_one_tile_source())
+
+    assert isinstance(result, serialization.V2SerializationRejected)  # nosec B101
+    assert (  # nosec B101
+        result.category
+        is engine.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+    )
+    assert result.stage is engine.PureExecutionStage.TARGET_VALIDATION  # nosec B101
+    assert "chat.openai.com" not in repr(result)  # nosec B101
+
+
+def _source_with_serialized_size(size: int) -> v1.JsonObject:
+    source = _one_tile_source()
+    source["tiles"] = []
+    source["extensions"] = {v1.LEGACY_EXTENSION_NAMESPACE: {"padding": ""}}
+    baseline = _canonical_bytes(_candidate(source))
+    delta = size - len(baseline)
+    if delta < 2:
+        raise AssertionError("target size must leave room for UTF-8 padding")
+    padding = ("é" * (delta // 2)) + ("x" if delta % 2 else "")
+    source["extensions"] = {v1.LEGACY_EXTENSION_NAMESPACE: {"padding": padding}}
+    candidate = _candidate(source)
+    if len(_canonical_bytes(candidate)) != size:
+        raise AssertionError("candidate size construction is not exact")
+    return source
+
+
+def test_transformed_candidate_composes_with_inclusive_four_mib_ceiling() -> None:
+    exact_source = _source_with_serialized_size(serialization.MAX_V2_CANDIDATE_BYTES)
+    oversize_source = _source_with_serialized_size(
+        serialization.MAX_V2_CANDIDATE_BYTES + 1
+    )
+
+    exact = checked.transform_v1_to_v2(exact_source)
+    oversize = checked.transform_v1_to_v2(oversize_source)
+
+    assert type(exact) is dict  # nosec B101
+    exact_serialized = serialization.serialize_v2(exact)
+    assert isinstance(  # nosec B101
+        exact_serialized,
+        serialization.SerializedV2Document,
+    )
+    assert (  # nosec B101
+        exact_serialized.byte_count == serialization.MAX_V2_CANDIDATE_BYTES
+    )
+    assert isinstance(oversize, serialization.V2SerializationRejected)  # nosec B101
+    assert (  # nosec B101
+        oversize.category
+        is engine.PureEngineFailureCategory.CANDIDATE_SIZE_LIMIT_EXCEEDED
+    )
+    assert oversize.stage is engine.PureExecutionStage.SERIALIZATION  # nosec B101
+    rendered = f"{oversize!r} {oversize!s}"
+    assert "padding" not in rendered  # nosec B101
+    assert "é" not in rendered  # nosec B101

--- a/tests/unit/test_config_schema_v2_boundary.py
+++ b/tests/unit/test_config_schema_v2_boundary.py
@@ -19,9 +19,19 @@ REPO_ROOT = Path(__file__).parents[2]
 FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "schema_v2"
 SCHEMA_PATH = REPO_ROOT / "config_schema_v2.py"
 SERIALIZATION_PATH = REPO_ROOT / "config_serialization_v2.py"
+MIGRATION_V2_PATH = REPO_ROOT / "config_migration_v2.py"
+TRANSFORM_V1_TO_V2_PATH = REPO_ROOT / "config_transform_v1_to_v2.py"
+PERSISTENCE_PATH = REPO_ROOT / "config_persistence.py"
 PACKAGING_SPEC_PATH = REPO_ROOT / "DesktopTileLauncher.spec"
 PRODUCTION_ENTRY_PATH = REPO_ROOT / "tile_launcher.py"
-FORBIDDEN_V2_MODULES = frozenset({"config_schema_v2.py", "config_serialization_v2.py"})
+FORBIDDEN_V2_MODULES = frozenset(
+    {
+        "config_migration_v2.py",
+        "config_schema_v2.py",
+        "config_serialization_v2.py",
+        "config_transform_v1_to_v2.py",
+    }
+)
 QT_IMPORT_ROOTS = frozenset({"PyQt5", "PyQt6", "PySide2", "PySide6"})
 
 SCHEMA_PUBLIC_FUNCTIONS = frozenset({"reject_duplicate_json_members", "validate_v2"})
@@ -82,6 +92,18 @@ SERIALIZATION_PUBLIC_NAMES = (
     | SERIALIZATION_PUBLIC_TYPE_ALIASES
     | SERIALIZATION_PUBLIC_CONSTANTS
 )
+MIGRATION_V2_PUBLIC_FUNCTIONS = frozenset({"migrate_v1_to_v2"})
+MIGRATION_V2_PUBLIC_CONSTANTS = frozenset(
+    {"MIGRATION_NAMESPACE_V1_TO_V2", "V1_TO_V2_ID_ALLOCATION_ATTEMPTS"}
+)
+MIGRATION_V2_PUBLIC_NAMES = (
+    MIGRATION_V2_PUBLIC_FUNCTIONS | MIGRATION_V2_PUBLIC_CONSTANTS
+)
+TRANSFORM_V1_TO_V2_PUBLIC_FUNCTIONS = frozenset({"transform_v1_to_v2"})
+TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES = frozenset({"V1ToV2TransformResult"})
+TRANSFORM_V1_TO_V2_PUBLIC_NAMES = (
+    TRANSFORM_V1_TO_V2_PUBLIC_FUNCTIONS | TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES
+)
 
 EXPECTED_SCHEMA_IMPORTS = frozenset(
     {
@@ -111,6 +133,31 @@ EXPECTED_SERIALIZATION_IMPORTS = frozenset(
         "from typing import Final",
         "from typing import TypeAlias",
         "import json",
+    }
+)
+EXPECTED_MIGRATION_V2_IMPORTS = frozenset(
+    {
+        "from __future__ import annotations",
+        "from collections.abc import Mapping",
+        "from typing import Final",
+        "from typing import TypeAlias",
+        "from typing import TypedDict",
+        "from typing import cast",
+        "from uuid import UUID",
+        "from uuid import uuid5",
+        "import config_schema as v1",
+        "import config_schema_v2 as v2",
+    }
+)
+EXPECTED_TRANSFORM_V1_TO_V2_IMPORTS = frozenset(
+    {
+        "from __future__ import annotations",
+        "from collections.abc import Mapping",
+        "from typing import TypeAlias",
+        "import config_migration_v2 as construction",
+        "import config_schema as v1",
+        "import config_schema_v2 as v2",
+        "import config_serialization_v2 as serialization",
     }
 )
 
@@ -580,6 +627,8 @@ def test_validation_failure_exposes_no_candidate_content_or_side_channel(
 def test_public_structural_result_and_behavioral_surfaces_are_exact() -> None:
     schema_tree = _parse_path(SCHEMA_PATH)
     serialization_tree = _parse_path(SERIALIZATION_PATH)
+    migration_v2_tree = _parse_path(MIGRATION_V2_PATH)
+    transform_v1_to_v2_tree = _parse_path(TRANSFORM_V1_TO_V2_PATH)
 
     assert _public_functions(schema_tree) == SCHEMA_PUBLIC_FUNCTIONS  # nosec B101
     assert {  # nosec B101
@@ -641,19 +690,74 @@ def test_public_structural_result_and_behavioral_surfaces_are_exact() -> None:
         for node in ast.walk(serialization_tree)
     )
 
+    assert (  # nosec B101
+        _public_functions(migration_v2_tree) == MIGRATION_V2_PUBLIC_FUNCTIONS
+    )
+    assert {  # nosec B101
+        node.name
+        for node in migration_v2_tree.body
+        if isinstance(node, ast.ClassDef) and not node.name.startswith("_")
+    } == set()
+    assert _public_classes(migration_v2_tree, "typed_dict") == set()  # nosec B101
+    assert _public_classes(migration_v2_tree, "dataclass") == set()  # nosec B101
+    assert _public_classes(migration_v2_tree, "enum") == set()  # nosec B101
+    assert _public_classes(migration_v2_tree, "exception") == set()  # nosec B101
+    assert (  # nosec B101
+        _public_annotated_names(migration_v2_tree, "type_alias") == set()
+    )
+    assert (  # nosec B101
+        _public_annotated_names(migration_v2_tree, "constant")
+        == MIGRATION_V2_PUBLIC_CONSTANTS
+    )
+    assert _module_all(migration_v2_tree) == MIGRATION_V2_PUBLIC_NAMES  # nosec B101
+
+    assert (  # nosec B101
+        _public_functions(transform_v1_to_v2_tree)
+        == TRANSFORM_V1_TO_V2_PUBLIC_FUNCTIONS
+    )
+    assert {  # nosec B101
+        node.name
+        for node in transform_v1_to_v2_tree.body
+        if isinstance(node, ast.ClassDef) and not node.name.startswith("_")
+    } == set()
+    assert (  # nosec B101
+        _public_annotated_names(transform_v1_to_v2_tree, "type_alias")
+        == TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES
+    )
+    assert (  # nosec B101
+        _public_annotated_names(transform_v1_to_v2_tree, "constant") == set()
+    )
+    assert (  # nosec B101
+        _module_all(transform_v1_to_v2_tree) == TRANSFORM_V1_TO_V2_PUBLIC_NAMES
+    )
+
 
 def test_exact_imports_and_focused_json_ast_contracts() -> None:
     schema_tree = _parse_path(SCHEMA_PATH)
     serialization_tree = _parse_path(SERIALIZATION_PATH)
+    migration_v2_tree = _parse_path(MIGRATION_V2_PATH)
+    transform_v1_to_v2_tree = _parse_path(TRANSFORM_V1_TO_V2_PATH)
 
     schema_imports = _import_declarations(schema_tree)
     serialization_imports = _import_declarations(serialization_tree)
+    migration_v2_imports = _import_declarations(migration_v2_tree)
+    transform_v1_to_v2_imports = _import_declarations(transform_v1_to_v2_tree)
     assert len(schema_imports) == len(EXPECTED_SCHEMA_IMPORTS)  # nosec B101
     assert set(schema_imports) == EXPECTED_SCHEMA_IMPORTS  # nosec B101
     assert len(serialization_imports) == len(  # nosec B101
         EXPECTED_SERIALIZATION_IMPORTS
     )
     assert set(serialization_imports) == EXPECTED_SERIALIZATION_IMPORTS  # nosec B101
+    assert len(migration_v2_imports) == len(  # nosec B101
+        EXPECTED_MIGRATION_V2_IMPORTS
+    )
+    assert set(migration_v2_imports) == EXPECTED_MIGRATION_V2_IMPORTS  # nosec B101
+    assert len(transform_v1_to_v2_imports) == len(  # nosec B101
+        EXPECTED_TRANSFORM_V1_TO_V2_IMPORTS
+    )
+    assert (  # nosec B101
+        set(transform_v1_to_v2_imports) == EXPECTED_TRANSFORM_V1_TO_V2_IMPORTS
+    )
 
     # These assertions describe direct JSON-related syntax, not general capabilities.
     assert not any(  # nosec B101
@@ -693,6 +797,61 @@ def test_vocabulary_dependency_is_symbol_only_one_way_and_qt_free() -> None:
             name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)
         }
         assert import_roots.isdisjoint(QT_IMPORT_ROOTS), path  # nosec B101
+
+
+def test_transformer_dependency_closure_is_qt_free_and_not_runtime_rooted() -> None:
+    dependency_closure = _repository_local_import_closure(
+        REPO_ROOT,
+        {MIGRATION_V2_PATH},
+    )
+    relative = _relative_paths(REPO_ROOT, dependency_closure)
+
+    assert {  # nosec B101
+        Path("config_migration_v2.py"),
+        Path("config_schema.py"),
+        Path("config_schema_v2.py"),
+    }.issubset(relative)
+    assert Path("config_migration.py") not in relative  # nosec B101
+    assert Path("tile_launcher.py") not in relative  # nosec B101
+    for path in dependency_closure:
+        import_roots = {
+            name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)
+        }
+        assert import_roots.isdisjoint(QT_IMPORT_ROOTS), path  # nosec B101
+
+
+def test_checked_transform_dependency_closure_is_qt_free_and_excludes_startup() -> None:
+    dependency_closure = _repository_local_import_closure(
+        REPO_ROOT,
+        {TRANSFORM_V1_TO_V2_PATH},
+    )
+    relative = _relative_paths(REPO_ROOT, dependency_closure)
+
+    assert {  # nosec B101
+        Path("config_migration_v2.py"),
+        Path("config_schema_v2.py"),
+        Path("config_serialization_v2.py"),
+        Path("config_transform_v1_to_v2.py"),
+    }.issubset(relative)
+    assert Path("tile_launcher.py") not in relative  # nosec B101
+    for path in dependency_closure:
+        import_roots = {
+            name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)
+        }
+        assert import_roots.isdisjoint(QT_IMPORT_ROOTS), path  # nosec B101
+
+
+def test_persistence_dependency_closure_excludes_dormant_v2() -> None:
+    dependency_closure = _repository_local_import_closure(
+        REPO_ROOT,
+        {PERSISTENCE_PATH},
+    )
+    relative = _relative_paths(REPO_ROOT, dependency_closure)
+
+    assert Path("config_persistence.py") in relative  # nosec B101
+    assert not {path.name for path in relative}.intersection(  # nosec B101
+        FORBIDDEN_V2_MODULES
+    )
 
 
 def test_real_production_and_packaging_closure_excludes_v2() -> None:


### PR DESCRIPTION
## Summary

- add a pure, Qt-free strict schema-v1-to-v2 transformer that constructs the complete schema-v2 graph
- preserve Workspace and Tab identities, per-Tab ordering, URL presentation and launch behavior, extension data, and portable-fallback DeviceBindings
- allocate deterministic UUIDv5 identities with the ADR-defined namespace, locator names, global collision handling, and bounded retries
- compose construction with complete schema-v2 validation, canonical serialization, and the inclusive 4 MiB candidate ceiling
- extend focused unit and dependency-boundary coverage while keeping schema v2 dormant and unreachable from production startup and persistence

## Why

This implements the second dependency-ordered schema-v2 slice defined by ADR-0001. Runtime adapters and schema-v2 activation remain deliberately separate future work.

## Impact

There is no runtime, UI, persistence, packaging, or network behavior change. The new transformer remains unregistered and production-inaccessible.

## Validation

- `make format-check`
- `make lint`
- `make lint_tests`
- `.venv/Scripts/python.exe -m ruff check tests`
- `make typecheck`
- `make test_unit`
- `git diff --check`

Closes #125