### PR TITLE
Add dormant schema-v2 runtime adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ ruff check tests
 mypy .
 
 # Unit tests only (see §2)
-pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"
+make test_unit
 ```
 
 These gates intentionally duplicate Ruff linting over the whole repo and over `tests/` to guarantee `tests/**/*.py` are included, independent of configuration.
@@ -52,16 +52,18 @@ make test_unit
 
 which must resolve to:
 ```bash
-pytest -q   -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)"   -k "not multi_window and not tray and not lazy_refresh"
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests   -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)"   -k "not multi_window and not tray and not lazy_refresh"
 ```
 
 - Never invoke `pytest` without the selector above.  
 - Never run targeted GUI/Qt/libGL tests by name.  
 - If you add tests, place unit tests in `tests/unit/` and mark them `@pytest.mark.unit`.  
-- Classify every `test_*.py` exactly once in `tests/unit_collection_guard.py`: genuinely
-  Qt-free modules belong in `QT_FREE_UNIT_TEST_PATHS`; all others belong in
-  `QUARANTINED_TEST_PATHS`. Unclassified tests are excluded before import and fail the
-  boundary regression instead of being collected.
+- Classify every pytest-discoverable `test_*.py` and `*_test.py` under `tests/` exactly once
+  in `tests/unit_collection_guard.py`: genuinely Qt-free modules belong in
+  `QT_FREE_UNIT_TEST_PATHS`; all others belong in `QUARANTINED_TEST_PATHS`. Unclassified
+  tests are excluded before import and fail the boundary regression instead of being collected.
+- Keep `make test_unit` scoped explicitly to `tests/` so the nested collection guard is active
+  for every path pytest can collect during the unit gate.
 - Do not weaken the pre-collection allowlist, forbidden-import finder, or
   `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`; marker deselection alone happens after imports and is
   not a safe Qt boundary.
@@ -163,8 +165,9 @@ markers =
 **`tests/conftest.py` and `tests/unit_collection_guard.py` — fail-closed unit collection**
 
 - Disable third-party pytest plugin autoload for `make test_unit`.
-- Under the exact unit marker expression, ignore every `test_*.py` before import unless it
-  appears in `QT_FREE_UNIT_TEST_PATHS`.
+- Under the exact unit marker expression, ignore every pytest-discoverable `test_*.py` and
+  `*_test.py` under `tests/` before import unless it appears in `QT_FREE_UNIT_TEST_PATHS`.
+- Scope `make test_unit` explicitly to `tests/`, where this collection guard is active.
 - Install the forbidden-import finder before collection so PySide6, Qt bindings, and
   Qt-coupled launcher modules fail before loading.
 - Keep `tests/unit/test_unit_collection_boundary.py` in the safe allowlist. It verifies that
@@ -194,7 +197,7 @@ types:
 	mypy .
 
 test_unit:
-	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"
 
 cov_unit:
 	pytest --cov=src --cov-report=term-missing -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,13 @@ pytest -q   -m "unit and not (integration or e2e or slow or network or gui or qt
 - Never invoke `pytest` without the selector above.  
 - Never run targeted GUI/Qt/libGL tests by name.  
 - If you add tests, place unit tests in `tests/unit/` and mark them `@pytest.mark.unit`.  
+- Classify every `test_*.py` exactly once in `tests/unit_collection_guard.py`: genuinely
+  Qt-free modules belong in `QT_FREE_UNIT_TEST_PATHS`; all others belong in
+  `QUARANTINED_TEST_PATHS`. Unclassified tests are excluded before import and fail the
+  boundary regression instead of being collected.
+- Do not weaken the pre-collection allowlist, forbidden-import finder, or
+  `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`; marker deselection alone happens after imports and is
+  not a safe Qt boundary.
 - If you must edit non‑unit tests (e.g., under `tests/integration/`), **do not** execute them; rely on CI/humans.
 - Static edits to Qt/PySide6 tests are allowed only when they can be reviewed from source without importing or executing Qt; any needed Qt/GUI validation must be reported as **NOT RUN** and assigned to CI/humans.
 
@@ -135,7 +142,7 @@ If the files below already exist, update them; if not, add them at the repo root
 **`pytest.ini` — explicit markers & hermetic defaults**
 ```ini
 [pytest]
-addopts = -q
+addopts = -q --basetemp=.pytest_cache/test-runtime/pytest-tmp
 markers =
     unit: fast, hermetic tests with no external deps or GUI/Qt/GL
     integration: may touch DBs, services, or the OS
@@ -153,35 +160,17 @@ markers =
     flaky: nondeterministic
 ```
 
-**`conftest.py` — proactively skip GUI/Qt/GL when not available**
-```python
-import importlib.util
-import os
-import pytest
+**`tests/conftest.py` and `tests/unit_collection_guard.py` — fail-closed unit collection**
 
-def _has_qt() -> bool:
-    return importlib.util.find_spec("PySide6") is not None
-
-def _headless() -> bool:
-    # No display detected (common in agent environments)
-    return os.environ.get("DISPLAY") in (None, "",) and os.environ.get("WAYLAND_DISPLAY") in (None, "",)
-
-def pytest_collection_modifyitems(config, items):
-    skip_reasons = []
-    if not _has_qt():
-        skip_qt = pytest.mark.skip(reason="PySide6/Qt not available in agent environment")
-        for it in items:
-            if any(m.name in {"qt", "gui"} for m in it.iter_markers()):
-                it.add_marker(skip_qt)
-        skip_reasons.append("qt/gui")
-    if _headless():
-        skip_headless = pytest.mark.skip(reason="Headless environment; GUI/GL tests disabled")
-        for it in items:
-            if any(m.name in {"gui", "gl", "x11", "wayland"} for m in it.iter_markers()):
-                it.add_marker(skip_headless)
-        skip_reasons.append("gui/gl")
-    config.hook.pytest_deselected(items=[it for it in items if any(m.name in {"skip"} for m in it.own_markers)])
-```
+- Disable third-party pytest plugin autoload for `make test_unit`.
+- Under the exact unit marker expression, ignore every `test_*.py` before import unless it
+  appears in `QT_FREE_UNIT_TEST_PATHS`.
+- Install the forbidden-import finder before collection so PySide6, Qt bindings, and
+  Qt-coupled launcher modules fail before loading.
+- Keep `tests/unit/test_unit_collection_boundary.py` in the safe allowlist. It verifies that
+  the safe and quarantined sets are disjoint, exhaustive, correctly marked, and Qt-free.
+- Return `None`, not `False`, for allowed or non-unit paths so full/GUI collection behavior is
+  unchanged.
 
 **`Makefile` — standardized local commands**
 ```make
@@ -205,7 +194,7 @@ types:
 	mypy .
 
 test_unit:
-	pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"
 
 cov_unit:
 	pytest --cov=src --cov-report=term-missing -m "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)" -k "not multi_window and not tray and not lazy_refresh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Add a dormant, deterministic, Qt-free schema-v1-to-v2 transformer that constructs and
   checks the complete URL Resource/Placement/DeviceBinding graph while keeping schema v2
   unregistered and unreachable from production startup and persistence.
+- Add dormant, Qt-free schema-v2 runtime adapters that preserve existing URL presentation,
+  launch, window, tab-order, and metadata-refresh behavior without activating schema v2.
+- Make the unit-test gate fail closed before collection, block Qt-coupled imports, and fail
+  instead of silently succeeding when pytest is unavailable.
 - Persist one `Default Workspace`, stable Workspace and Tab identities, ID-based Tile
   membership, and an independent `application.title` while retaining flat Tile behavior and
   existing launcher settings.

--- a/Makefile
+++ b/Makefile
@@ -86,20 +86,16 @@ test: install-dev ## Run the full test suite (default)
 	  echo "[test] Offline detected: skipping full test suite"; \
 	fi
 
-# Exact unit-only filter you used successfully:
+# Exact fail-closed unit-only filter:
 test_unit: install-dev ensure-test-deps ## Run unit tests only (exclude slow/integration/e2e/etc.)
 	@set -euo pipefail; \
 	if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
 	  echo "[test_unit] running pytest (unit filter)"; \
-	  $(PY) -m pytest -q \
+	  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q \
 	    -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' \
 	    -k 'not multi_window and not tray and not lazy_refresh'; \
 	else \
-	  if [ "$(ONLINE)" = "0" ]; then \
-	    echo "[test_unit] offline/proxy and pytest unavailable → skipping unit tests (exit 0)"; \
-	    exit 0; \
-	  fi; \
-	  echo "[test_unit] pytest missing but network available → aborting"; \
+	  echo "[test_unit] pytest unavailable after dependency setup → aborting"; \
 	  exit 1; \
 	fi
 
@@ -125,4 +121,3 @@ reassemble_wheels:
 # One-liner that mirrors the Codex task: reassemble + force offline install + run tests
 test_unit_offline: reassemble_wheels
 	@PIP_NO_INDEX=1 PIP_FIND_LINKS="vendor/wheelhouse-linux" $(MAKE) ONLINE=1 test_unit
-

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,12 @@ test: install-dev ## Run the full test suite (default)
 	fi
 
 # Exact fail-closed unit-only filter:
+.PHONY: test_unit
 test_unit: install-dev ensure-test-deps ## Run unit tests only (exclude slow/integration/e2e/etc.)
 	@set -euo pipefail; \
 	if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
 	  echo "[test_unit] running pytest (unit filter)"; \
-	  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q \
+	  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q tests \
 	    -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' \
 	    -k 'not multi_window and not tray and not lazy_refresh'; \
 	else \

--- a/config_runtime_v2.py
+++ b/config_runtime_v2.py
@@ -1,0 +1,438 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dormant, Qt-free runtime projections for validated schema-version 2 state.
+
+This module resolves the complete persisted graph into immutable values needed
+by the existing URL launcher and metadata-refresh behavior.  It performs no
+schema registration, startup integration, persistence, discovery, platform,
+filesystem, network, or GUI work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias, cast
+
+import config_schema_v2 as v2
+
+RuntimeAdapterFailureCategory: TypeAlias = Literal[
+    "invalid_graph",
+    "invalid_device_key",
+    "subject_not_found",
+    "refresh_failure",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeAdapterRejected:
+    """A content-free rejection from a runtime-adapter boundary."""
+
+    category: RuntimeAdapterFailureCategory
+
+
+@dataclass(frozen=True, slots=True)
+class WindowSettingsProjection:
+    """One selected Workspace/window settings object."""
+
+    columns: int = field(repr=False)
+    auto_fit: bool = field(repr=False)
+    window_x: int | None = field(repr=False)
+    window_y: int | None = field(repr=False)
+    window_w: int | None = field(repr=False)
+    window_h: int | None = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchSettingsProjection:
+    """One selected Placement/launch settings object."""
+
+    browser: str | None = field(repr=False)
+    chrome_profile: str | None = field(repr=False)
+    open_target: v2.OpenTarget = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class PlacementProjection:
+    """Resolved URL presentation and optional launch settings for a Placement."""
+
+    id: v2.EntityUUID = field(repr=False)
+    resource_id: v2.EntityUUID = field(repr=False)
+    tab_id: v2.EntityUUID = field(repr=False)
+    url: str = field(repr=False)
+    label: str = field(repr=False)
+    icon: str | None = field(repr=False)
+    background_color: str = field(repr=False)
+    workflow_status: v2.WorkflowStatus = field(repr=False)
+    launch_settings: LaunchSettingsProjection | None = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class TabProjection:
+    """One Tab with complete Display membership and its filtered projection."""
+
+    id: v2.EntityUUID = field(repr=False)
+    workspace_id: v2.EntityUUID = field(repr=False)
+    name: str = field(repr=False)
+    visibility: v2.Visibility = field(repr=False)
+    lifecycle: v2.Lifecycle = field(repr=False)
+    view_mode: v2.ViewMode = field(repr=False)
+    display_filter: tuple[v2.WorkflowStatus, ...] = field(repr=False)
+    placements: tuple[PlacementProjection, ...] = field(repr=False)
+    displayed_placements: tuple[PlacementProjection, ...] = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceProjection:
+    """One Workspace in semantic Tab order with normal-bar membership."""
+
+    application_title: str = field(repr=False)
+    id: v2.EntityUUID = field(repr=False)
+    name: str = field(repr=False)
+    tabs: tuple[TabProjection, ...] = field(repr=False)
+    normal_tabs: tuple[TabProjection, ...] = field(repr=False)
+    window_settings: WindowSettingsProjection | None = field(repr=False)
+
+
+WorkspaceProjectionResult: TypeAlias = WorkspaceProjection | RuntimeAdapterRejected
+MetadataRefreshResult: TypeAlias = v2.Root | RuntimeAdapterRejected
+_JsonContainer: TypeAlias = list[v2.StrictJsonValue] | dict[str, v2.StrictJsonValue]
+
+
+@dataclass(frozen=True, slots=True)
+class _BindingIndexes:
+    window_fallbacks: dict[v2.EntityUUID, v2.WindowSettings] = field(repr=False)
+    window_devices: dict[
+        tuple[v2.EntityUUID, v2.ExternalDeviceKey], v2.WindowSettings
+    ] = field(repr=False)
+    launch_fallbacks: dict[v2.EntityUUID, v2.UrlLaunchSettings] = field(repr=False)
+    launch_devices: dict[
+        tuple[v2.EntityUUID, v2.ExternalDeviceKey], v2.UrlLaunchSettings
+    ] = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class _Graph:
+    root: v2.Root = field(repr=False)
+    workspaces: dict[v2.EntityUUID, v2.Workspace] = field(repr=False)
+    tabs: dict[v2.EntityUUID, v2.Tab] = field(repr=False)
+    resources: dict[v2.EntityUUID, v2.Resource] = field(repr=False)
+    placements: dict[v2.EntityUUID, v2.Placement] = field(repr=False)
+    bindings: _BindingIndexes = field(repr=False)
+
+
+def _index_bindings(root: v2.Root) -> _BindingIndexes:
+    window_fallbacks: dict[v2.EntityUUID, v2.WindowSettings] = {}
+    window_devices: dict[
+        tuple[v2.EntityUUID, v2.ExternalDeviceKey], v2.WindowSettings
+    ] = {}
+    launch_fallbacks: dict[v2.EntityUUID, v2.UrlLaunchSettings] = {}
+    launch_devices: dict[
+        tuple[v2.EntityUUID, v2.ExternalDeviceKey], v2.UrlLaunchSettings
+    ] = {}
+    for binding in root["device_bindings"]:
+        applicability = binding["applicability"]
+        if binding["subject_kind"] == "workspace":
+            if applicability["kind"] == "portable_fallback":
+                window_fallbacks[binding["subject_id"]] = binding["settings"]
+            else:
+                window_devices[(binding["subject_id"], applicability["device_key"])] = (
+                    binding["settings"]
+                )
+        elif applicability["kind"] == "portable_fallback":
+            launch_fallbacks[binding["subject_id"]] = binding["settings"]
+        else:
+            launch_devices[(binding["subject_id"], applicability["device_key"])] = (
+                binding["settings"]
+            )
+    return _BindingIndexes(
+        window_fallbacks,
+        window_devices,
+        launch_fallbacks,
+        launch_devices,
+    )
+
+
+def _validated_graph(document: object) -> _Graph | None:
+    if not v2.validate_v2(document):
+        return None
+    root = cast(v2.Root, document)
+    return _Graph(
+        root=root,
+        workspaces={item["id"]: item for item in root["workspaces"]},
+        tabs={item["id"]: item for item in root["tabs"]},
+        resources={item["id"]: item for item in root["resources"]},
+        placements={item["id"]: item for item in root["placements"]},
+        bindings=_index_bindings(root),
+    )
+
+
+def _is_utf8_text(value: str) -> bool:
+    try:
+        value.encode("utf-8")
+    except UnicodeError:
+        return False
+    return True
+
+
+def _clone_strict_json(value: v2.StrictJsonValue) -> v2.StrictJsonValue:
+    """Clone an exact built-in JSON tree without using the Python call stack."""
+
+    if type(value) is list:
+        cloned: _JsonContainer = []
+    elif type(value) is dict:
+        cloned = {}
+    else:
+        return value
+
+    pending: list[tuple[_JsonContainer, _JsonContainer]] = [(value, cloned)]
+    while pending:
+        source, target = pending.pop()
+        if type(source) is list:
+            target_items = cast(list[v2.StrictJsonValue], target)
+            for item in source:
+                if type(item) is list:
+                    child_items: list[v2.StrictJsonValue] = []
+                    target_items.append(child_items)
+                    pending.append((item, child_items))
+                elif type(item) is dict:
+                    child_object: dict[str, v2.StrictJsonValue] = {}
+                    target_items.append(child_object)
+                    pending.append((item, child_object))
+                else:
+                    target_items.append(item)
+            continue
+
+        source_object = cast(dict[str, v2.StrictJsonValue], source)
+        target_object = cast(dict[str, v2.StrictJsonValue], target)
+        for key, item in source_object.items():
+            if type(item) is list:
+                child_items = []
+                target_object[key] = child_items
+                pending.append((item, child_items))
+            elif type(item) is dict:
+                child_object = {}
+                target_object[key] = child_object
+                pending.append((item, child_object))
+            else:
+                target_object[key] = item
+    return cloned
+
+
+def _valid_external_device_key(value: object) -> bool:
+    return type(value) is str and bool(value) and _is_utf8_text(value)
+
+
+def _window_projection(settings: v2.WindowSettings) -> WindowSettingsProjection:
+    return WindowSettingsProjection(
+        columns=settings["columns"],
+        auto_fit=settings["auto_fit"],
+        window_x=settings["window_x"],
+        window_y=settings["window_y"],
+        window_w=settings["window_w"],
+        window_h=settings["window_h"],
+    )
+
+
+def _launch_projection(settings: v2.UrlLaunchSettings) -> LaunchSettingsProjection:
+    return LaunchSettingsProjection(
+        browser=settings["browser"],
+        chrome_profile=settings["chrome_profile"],
+        open_target=settings["open_target"],
+    )
+
+
+def _selected_window_settings(
+    graph: _Graph,
+    workspace_id: v2.EntityUUID,
+    external_device_key: str | None,
+) -> WindowSettingsProjection | None:
+    selected = (
+        None
+        if external_device_key is None
+        else graph.bindings.window_devices.get(
+            (workspace_id, external_device_key),
+        )
+    )
+    if selected is None:
+        selected = graph.bindings.window_fallbacks.get(workspace_id)
+    return None if selected is None else _window_projection(selected)
+
+
+def _selected_launch_settings(
+    graph: _Graph,
+    placement_id: v2.EntityUUID,
+    external_device_key: str | None,
+) -> LaunchSettingsProjection | None:
+    selected = (
+        None
+        if external_device_key is None
+        else graph.bindings.launch_devices.get(
+            (placement_id, external_device_key),
+        )
+    )
+    if selected is None:
+        selected = graph.bindings.launch_fallbacks.get(placement_id)
+    return None if selected is None else _launch_projection(selected)
+
+
+def _icon_value(icon: v2.LegacyStringIcon | None) -> str | None:
+    return None if icon is None else icon["value"]
+
+
+def _project_placement(
+    graph: _Graph,
+    placement: v2.Placement,
+    external_device_key: str | None,
+) -> PlacementProjection:
+    resource = graph.resources[placement["resource_id"]]
+    label_override = placement["label_override"]
+    icon_override = placement["icon_override"]
+    return PlacementProjection(
+        id=placement["id"],
+        resource_id=resource["id"],
+        tab_id=placement["tab_id"],
+        url=resource["target"]["url"],
+        label=(resource["default_label"] if label_override is None else label_override),
+        icon=_icon_value(
+            resource["default_icon"] if icon_override is None else icon_override
+        ),
+        background_color=placement["background_color"],
+        workflow_status=placement["workflow_status"],
+        launch_settings=_selected_launch_settings(
+            graph,
+            placement["id"],
+            external_device_key,
+        ),
+    )
+
+
+def _project_tab(
+    graph: _Graph,
+    tab: v2.Tab,
+    external_device_key: str | None,
+) -> TabProjection:
+    placements = tuple(
+        _project_placement(
+            graph,
+            graph.placements[placement_id],
+            external_device_key,
+        )
+        for placement_id in tab["display_order"]
+    )
+    display_filter = tuple(tab["display_filter"])
+    displayed = tuple(
+        placement
+        for placement in placements
+        if placement.workflow_status in display_filter
+    )
+    return TabProjection(
+        id=tab["id"],
+        workspace_id=tab["workspace_id"],
+        name=tab["name"],
+        visibility=tab["visibility"],
+        lifecycle=tab["lifecycle"],
+        view_mode=tab["view_mode"],
+        display_filter=display_filter,
+        placements=placements,
+        displayed_placements=displayed,
+    )
+
+
+def project_workspace(
+    document: object,
+    workspace_id: str | None = None,
+    *,
+    external_device_key: str | None = None,
+) -> WorkspaceProjectionResult:
+    """Project one Workspace after validating the complete schema-v2 graph."""
+
+    graph = _validated_graph(document)
+    if graph is None:
+        return RuntimeAdapterRejected("invalid_graph")
+    if external_device_key is not None and not _valid_external_device_key(
+        external_device_key
+    ):
+        return RuntimeAdapterRejected("invalid_device_key")
+
+    selected_id: object = (
+        graph.root["application"]["default_workspace_id"]
+        if workspace_id is None
+        else workspace_id
+    )
+    if type(selected_id) is not str:
+        return RuntimeAdapterRejected("subject_not_found")
+    workspace = graph.workspaces.get(selected_id)
+    if workspace is None:
+        return RuntimeAdapterRejected("subject_not_found")
+
+    tabs = tuple(
+        _project_tab(graph, graph.tabs[tab_id], external_device_key)
+        for tab_id in workspace["tab_order"]
+    )
+    normal_tabs = tuple(
+        tab for tab in tabs if tab.lifecycle == "active" and tab.visibility == "visible"
+    )
+    return WorkspaceProjection(
+        application_title=graph.root["application"]["title"],
+        id=workspace["id"],
+        name=workspace["name"],
+        tabs=tabs,
+        normal_tabs=normal_tabs,
+        window_settings=_selected_window_settings(
+            graph,
+            workspace["id"],
+            external_device_key,
+        ),
+    )
+
+
+def apply_metadata_refresh(
+    document: object,
+    placement_id: str,
+    *,
+    label: str | None = None,
+    icon: str | None = None,
+) -> MetadataRefreshResult:
+    """Return a detached graph with successful refresh fields applied to a Resource."""
+
+    graph = _validated_graph(document)
+    if graph is None:
+        return RuntimeAdapterRejected("invalid_graph")
+    if type(placement_id) is not str or placement_id not in graph.placements:
+        return RuntimeAdapterRejected("subject_not_found")
+    if (label is not None and (type(label) is not str or not _is_utf8_text(label))) or (
+        icon is not None and (type(icon) is not str or not _is_utf8_text(icon))
+    ):
+        return RuntimeAdapterRejected("refresh_failure")
+
+    resource_id = graph.placements[placement_id]["resource_id"]
+    candidate = cast(
+        v2.Root,
+        _clone_strict_json(cast(v2.StrictJsonValue, graph.root)),
+    )
+    resources = {item["id"]: item for item in candidate["resources"]}
+    resource = resources[resource_id]
+    if label is not None:
+        resource["default_label"] = label
+    if icon is not None:
+        resource["default_icon"] = v2.LegacyStringIcon(
+            kind="legacy_string",
+            value=icon,
+        )
+    if not v2.validate_v2(candidate):
+        return RuntimeAdapterRejected("refresh_failure")
+    return candidate
+
+
+__all__ = [
+    "LaunchSettingsProjection",
+    "MetadataRefreshResult",
+    "PlacementProjection",
+    "RuntimeAdapterFailureCategory",
+    "RuntimeAdapterRejected",
+    "TabProjection",
+    "WindowSettingsProjection",
+    "WorkspaceProjection",
+    "WorkspaceProjectionResult",
+    "apply_metadata_refresh",
+    "project_workspace",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,24 @@ Pytest bootstrap for headless/CI runs.
   * Optional marker 'requires_opengl' you can use to skip GL-only tests when libGL isn't available
 """
 
+from __future__ import annotations
+
 import ctypes
 import os
 import pathlib
 import sys
 import tempfile
+from typing import Protocol
 
-import pytest  # noqa: F401  # imported for pytest hooks below
+import pytest
+
+from unit_collection_guard import (
+    ForbiddenUnitImportFinder,
+    forbidden_loaded_modules,
+    is_unit_only_expression,
+    repo_relative_path,
+    should_ignore_test_module,
+)
 
 # ---------- Test-only path sandbox ----------
 # Keep application config, logs, caches, and temp files out of the real user profile.
@@ -78,6 +89,42 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 
+_UNIT_IMPORT_FINDER: ForbiddenUnitImportFinder | None = None
+_UNIT_IGNORED_PATHS: set[str] = set()
+_UNIT_SELECTED_COUNT = 0
+_UNIT_DESELECTED_COUNT = 0
+
+
+class _TerminalReporter(Protocol):
+    stats: dict[str, list[object]]
+
+    def write_line(self, line: str) -> None: ...
+
+
+def _marker_expression(config: pytest.Config) -> str:
+    expression = config.getoption("markexpr")
+    return expression if isinstance(expression, str) else ""
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_ignore_collect(
+    collection_path: pathlib.Path,
+    config: pytest.Config,
+) -> bool | None:
+    """Exclude unsafe or unclassified tests before Python imports them."""
+
+    ignored = should_ignore_test_module(
+        collection_path,
+        ROOT_PATH,
+        _marker_expression(config),
+    )
+    if ignored:
+        relative = repo_relative_path(collection_path, ROOT_PATH)
+        if relative is not None:
+            _UNIT_IGNORED_PATHS.add(relative)
+    return ignored
+
+
 # ---------- Optional: mark and skip GL-only tests in headless CI ----------
 def _has_libgl() -> bool:
     """Detect presence of the OpenGL runtime."""
@@ -88,15 +135,86 @@ def _has_libgl() -> bool:
         return False
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     # Register a marker so pytest doesn't warn about it if/when you use it.
     config.addinivalue_line(
         "markers",
         "requires_opengl: test depends on an OpenGL runtime (libGL); skip in headless CI",
     )
 
+    if not is_unit_only_expression(_marker_expression(config)):
+        return
+    loaded = forbidden_loaded_modules()
+    if loaded:
+        joined = ", ".join(loaded)
+        raise pytest.UsageError(
+            f"forbidden modules loaded before Qt-free unit collection: {joined}"
+        )
 
-def pytest_runtest_setup(item):
+    global _UNIT_IMPORT_FINDER
+    _UNIT_IMPORT_FINDER = ForbiddenUnitImportFinder()
+    sys.meta_path.insert(0, _UNIT_IMPORT_FINDER)
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
     # Only skip tests you explicitly mark; nothing else is affected.
     if "requires_opengl" in item.keywords and not _has_libgl():
         pytest.skip("OpenGL runtime (libGL.so.1) not present in this environment")
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Record the final item count after marker and keyword filtering."""
+
+    if not is_unit_only_expression(_marker_expression(config)):
+        return
+    global _UNIT_SELECTED_COUNT
+    _UNIT_SELECTED_COUNT = len(items)
+
+
+def pytest_deselected(items: list[pytest.Item]) -> None:
+    """Record marker/keyword deselections for explicit unit-gate evidence."""
+
+    global _UNIT_DESELECTED_COUNT
+    _UNIT_DESELECTED_COUNT += len(items)
+
+
+def pytest_terminal_summary(
+    terminalreporter: _TerminalReporter,
+    exitstatus: int,
+    config: pytest.Config,
+) -> None:
+    """Report pre-collection exclusions in the required unit-gate evidence."""
+
+    del exitstatus
+    if not is_unit_only_expression(_marker_expression(config)):
+        return
+    terminalreporter.write_line(
+        "unit collection safety: "
+        f"{len(_UNIT_IGNORED_PATHS)} non-allowlisted test modules excluded before import; "
+        "forbidden imports blocked"
+    )
+    terminalreporter.write_line(
+        "unit marker/keyword selection: "
+        f"{_UNIT_SELECTED_COUNT} selected, {_UNIT_DESELECTED_COUNT} deselected"
+    )
+    terminalreporter.write_line(
+        "unit test outcomes: "
+        f"{len(terminalreporter.stats.get('passed', []))} passed, "
+        f"{len(terminalreporter.stats.get('failed', []))} failed, "
+        f"{len(terminalreporter.stats.get('skipped', []))} skipped, "
+        f"{len(terminalreporter.stats.get('error', []))} errors"
+    )
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Remove the unit-only import guard after the pytest session."""
+
+    del config
+    global _UNIT_IMPORT_FINDER
+    if _UNIT_IMPORT_FINDER in sys.meta_path:
+        sys.meta_path.remove(_UNIT_IMPORT_FINDER)
+    _UNIT_IMPORT_FINDER = None

--- a/tests/unit/test_config_runtime_v2.py
+++ b/tests/unit/test_config_runtime_v2.py
@@ -1,0 +1,845 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import config_runtime_v2 as runtime
+import config_schema as v1
+import config_schema_v2 as v2
+import config_serialization_v2 as serialization
+import config_transform_v1_to_v2 as transform
+
+pytestmark = pytest.mark.unit
+
+FIXTURE_ROOT = Path(__file__).parents[1] / "fixtures" / "schema_v2"
+
+WORKSPACE_1 = "10000000-0000-4000-8000-000000000001"
+WORKSPACE_2 = "10000000-0000-4000-8000-000000000002"
+WORKSPACE_3 = "10000000-0000-4000-8000-000000000003"
+TAB_1 = "20000000-0000-4000-8000-000000000001"
+TAB_2 = "20000000-0000-4000-8000-000000000002"
+TAB_3 = "20000000-0000-4000-8000-000000000003"
+TAB_4 = "20000000-0000-4000-8000-000000000004"
+TAB_5 = "20000000-0000-4000-8000-000000000005"
+RESOURCE_1 = "30000000-0000-4000-8000-000000000001"
+RESOURCE_2 = "30000000-0000-4000-8000-000000000002"
+PLACEMENT_1 = "40000000-0000-4000-8000-000000000001"
+PLACEMENT_2 = "40000000-0000-4000-8000-000000000002"
+PLACEMENT_3 = "40000000-0000-4000-8000-000000000003"
+PLACEMENT_4 = "40000000-0000-4000-8000-000000000004"
+PLACEMENT_5 = "40000000-0000-4000-8000-000000000005"
+
+V1_WORKSPACE = "11111111-1111-4111-8111-111111111111"
+V1_HIGH_TAB = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+V1_LOW_TAB = "00000000-0000-4000-8000-000000000001"
+
+
+def _representative() -> v2.Root:
+    parsed = json.loads(
+        (FIXTURE_ROOT / "representative.json").read_text(encoding="utf-8"),
+        object_pairs_hook=v2.reject_duplicate_json_members,
+    )
+    assert v2.validate_v2(parsed)  # nosec B101
+    return cast(v2.Root, parsed)
+
+
+def _project(
+    document: object,
+    workspace_id: str | None = None,
+    external_device_key: str | None = None,
+) -> runtime.WorkspaceProjection:
+    result = runtime.project_workspace(
+        document,
+        workspace_id,
+        external_device_key=external_device_key,
+    )
+    assert isinstance(result, runtime.WorkspaceProjection)  # nosec B101
+    return result
+
+
+def _tab(
+    projection: runtime.WorkspaceProjection,
+    tab_id: str,
+) -> runtime.TabProjection:
+    matches = [tab for tab in projection.tabs if tab.id == tab_id]
+    assert len(matches) == 1  # nosec B101
+    return matches[0]
+
+
+def _placement(
+    projection: runtime.WorkspaceProjection,
+    placement_id: str,
+) -> runtime.PlacementProjection:
+    matches = [
+        placement
+        for tab in projection.tabs
+        for placement in tab.placements
+        if placement.id == placement_id
+    ]
+    assert len(matches) == 1  # nosec B101
+    return matches[0]
+
+
+def _serialized(document: object) -> bytes:
+    result = serialization.serialize_v2(document)
+    assert isinstance(result, serialization.SerializedV2Document)  # nosec B101
+    return result.data
+
+
+def _deep_extension(depth: int, leaf: str) -> v2.Extensions:
+    root: v2.Extensions = {}
+    current = root
+    for _ in range(depth):
+        child: v2.Extensions = {}
+        current["next"] = child
+        current = child
+    current["leaf"] = leaf
+    return root
+
+
+def _deep_extension_leaf(value: object, depth: int) -> object:
+    current = value
+    for _ in range(depth):
+        assert type(current) is dict  # nosec B101
+        current = cast(dict[str, object], current)["next"]
+    assert type(current) is dict  # nosec B101
+    return cast(dict[str, object], current)["leaf"]
+
+
+def _json_container_ids(value: object) -> set[int]:
+    pending = [value]
+    identifiers: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if type(current) is dict:
+            identifier = id(current)
+            if identifier in identifiers:
+                continue
+            identifiers.add(identifier)
+            pending.extend(cast(dict[object, object], current).values())
+        elif type(current) is list:
+            identifier = id(current)
+            if identifier in identifiers:
+                continue
+            identifiers.add(identifier)
+            pending.extend(cast(list[object], current))
+    return identifiers
+
+
+def _window_values(
+    settings: runtime.WindowSettingsProjection | None,
+) -> tuple[int, bool, int | None, int | None, int | None, int | None] | None:
+    if settings is None:
+        return None
+    return (
+        settings.columns,
+        settings.auto_fit,
+        settings.window_x,
+        settings.window_y,
+        settings.window_w,
+        settings.window_h,
+    )
+
+
+def _launch_values(
+    settings: runtime.LaunchSettingsProjection | None,
+) -> tuple[str | None, str | None, v2.OpenTarget] | None:
+    if settings is None:
+        return None
+    return settings.browser, settings.chrome_profile, settings.open_target
+
+
+def _v1_tile(
+    name: str,
+    url: str,
+    tab_id: str,
+    *,
+    icon: str | None,
+    background: str,
+    browser: str | None,
+    chrome_profile: str | None,
+    open_target: v2.OpenTarget,
+) -> v1.JsonObject:
+    return {
+        "name": name,
+        "url": url,
+        "tab_id": tab_id,
+        "icon": icon,
+        "bg": background,
+        "browser": browser,
+        "chrome_profile": chrome_profile,
+        "open_target": open_target,
+    }
+
+
+def _strict_v1_source() -> v1.JsonObject:
+    return {
+        "schema_version": 1,
+        "application": {
+            "title": "Migrated runtime",
+            "default_workspace_id": V1_WORKSPACE,
+            "extensions": {},
+        },
+        "workspaces": [
+            {
+                "id": V1_WORKSPACE,
+                "name": "Default Workspace",
+                "tab_order": [V1_HIGH_TAB, V1_LOW_TAB],
+                "extensions": {},
+            }
+        ],
+        "tabs": [
+            {
+                "id": V1_LOW_TAB,
+                "workspace_id": V1_WORKSPACE,
+                "name": "Low",
+                "visibility": "hidden",
+                "extensions": {},
+            },
+            {
+                "id": V1_HIGH_TAB,
+                "workspace_id": V1_WORKSPACE,
+                "name": "High",
+                "visibility": "visible",
+                "extensions": {},
+            },
+        ],
+        "tiles": [
+            _v1_tile(
+                "low-0",
+                "custom+low://opaque",
+                V1_LOW_TAB,
+                icon="",
+                background="",
+                browser="",
+                chrome_profile=None,
+                open_target="window",
+            ),
+            _v1_tile(
+                "high-0",
+                "https://high.example.test/0",
+                V1_HIGH_TAB,
+                icon=None,
+                background="#123456",
+                browser=None,
+                chrome_profile="",
+                open_target="tab",
+            ),
+            _v1_tile(
+                "low-1",
+                "https://low.example.test/1",
+                V1_LOW_TAB,
+                icon="low-icon",
+                background="not-a-color",
+                browser="firefox",
+                chrome_profile="Profile L",
+                open_target="tab",
+            ),
+            _v1_tile(
+                "high-1",
+                "",
+                V1_HIGH_TAB,
+                icon="high-icon",
+                background="blue-ish",
+                browser="Unsupported Browser",
+                chrome_profile="   ",
+                open_target="window",
+            ),
+        ],
+        "columns": -2,
+        "auto_fit": True,
+        "window_x": 0,
+        "window_y": -40,
+        "window_w": None,
+        "window_h": 900,
+        "extensions": {},
+    }
+
+
+def test_projection_uses_persisted_identity_and_semantic_orders() -> None:
+    projection = _project(_representative())
+
+    assert projection.application_title == "Café 東京"  # nosec B101
+    assert projection.id == WORKSPACE_1  # nosec B101
+    assert projection.name == "Primary"  # nosec B101
+    assert [tab.id for tab in projection.tabs] == [  # nosec B101
+        TAB_1,
+        TAB_2,
+        TAB_3,
+        TAB_4,
+    ]
+    assert [tab.id for tab in projection.normal_tabs] == [TAB_1]  # nosec B101
+
+    first = _tab(projection, TAB_1)
+    assert (first.visibility, first.lifecycle, first.view_mode) == (  # nosec B101
+        "visible",
+        "active",
+        "display",
+    )
+    assert first.display_filter == ("new", "in_use")  # nosec B101
+    assert [placement.id for placement in first.placements] == [  # nosec B101
+        PLACEMENT_2,
+        PLACEMENT_1,
+        PLACEMENT_3,
+    ]
+    assert [placement.id for placement in first.displayed_placements] == [  # nosec B101
+        PLACEMENT_2,
+        PLACEMENT_1,
+    ]
+
+    archived = _tab(projection, TAB_2)
+    assert (archived.visibility, archived.lifecycle) == (  # nosec B101
+        "visible",
+        "archived",
+    )
+    assert [placement.id for placement in archived.placements] == [PLACEMENT_4]  # nosec B101
+    assert archived.displayed_placements == ()  # nosec B101
+
+    hidden = _tab(projection, TAB_3)
+    assert (hidden.visibility, hidden.lifecycle, hidden.placements) == (  # nosec B101
+        "hidden",
+        "active",
+        (),
+    )
+
+    secondary = _project(_representative(), WORKSPACE_2)
+    assert [tab.id for tab in secondary.tabs] == [TAB_5]  # nosec B101
+    assert [tab.id for tab in secondary.normal_tabs] == [TAB_5]  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["workspaces", "tabs", "resources", "placements", "device_bindings"],
+)
+def test_root_definition_order_does_not_change_projection(field: str) -> None:
+    document = _representative()
+    reordered = deepcopy(document)
+    values = cast(list[v2.StrictJsonValue], reordered[field])
+    values.reverse()
+
+    assert v2.validate_v2(reordered)  # nosec B101
+    for device_key in (None, "device-A"):
+        assert _project(  # nosec B101
+            reordered,
+            external_device_key=device_key,
+        ) == _project(document, external_device_key=device_key)
+
+
+def test_presentation_distinguishes_inheritance_from_explicit_empty_values() -> None:
+    document = _representative()
+    document["resources"][0]["default_icon"] = v2.LegacyStringIcon(
+        kind="legacy_string",
+        value="resource-icon",
+    )
+    assert v2.validate_v2(document)  # nosec B101
+
+    primary = _project(document)
+    inherited = _placement(primary, PLACEMENT_1)
+    explicit_empty = _placement(primary, PLACEMENT_2)
+    secondary = _placement(_project(document, WORKSPACE_2), PLACEMENT_5)
+
+    assert (  # nosec B101
+        inherited.label,
+        inherited.icon,
+        inherited.background_color,
+        inherited.workflow_status,
+    ) == ("Shared", "resource-icon", "", "new")
+    assert (explicit_empty.label, explicit_empty.icon) == ("", "")  # nosec B101
+    assert (secondary.label, secondary.icon) == (  # nosec B101
+        "Secondary placement",
+        "resource-icon",
+    )
+
+
+@pytest.mark.parametrize(
+    ("workspace_id", "device_key", "expected"),
+    [
+        (WORKSPACE_1, "device-A", (0, False, None, None, None, None)),
+        (WORKSPACE_1, None, (-1, True, -20, 0, None, 900)),
+        (WORKSPACE_1, "device-a", (-1, True, -20, 0, None, 900)),
+        (WORKSPACE_1, "device-A ", (-1, True, -20, 0, None, 900)),
+        (WORKSPACE_2, "   ", (5, True, 1, 2, 3, 4)),
+        (WORKSPACE_2, None, None),
+        (WORKSPACE_2, "other-device", None),
+        (WORKSPACE_3, None, None),
+    ],
+)
+def test_window_binding_precedence_is_exact_and_case_sensitive(
+    workspace_id: str,
+    device_key: str | None,
+    expected: tuple[int, bool, int | None, int | None, int | None, int | None] | None,
+) -> None:
+    projection = _project(_representative(), workspace_id, device_key)
+
+    assert _window_values(projection.window_settings) == expected  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("workspace_id", "placement_id", "device_key", "expected"),
+    [
+        (
+            WORKSPACE_1,
+            PLACEMENT_1,
+            "device-A",
+            ("Unsupported Browser", "   ", "window"),
+        ),
+        (WORKSPACE_1, PLACEMENT_1, None, (None, "", "tab")),
+        (WORKSPACE_1, PLACEMENT_1, "device-a", (None, "", "tab")),
+        (WORKSPACE_1, PLACEMENT_2, "device-A", None),
+        (WORKSPACE_2, PLACEMENT_5, "device-A", ("", None, "tab")),
+        (WORKSPACE_2, PLACEMENT_5, None, None),
+    ],
+)
+def test_launch_binding_precedence_preserves_presence_and_absence(
+    workspace_id: str,
+    placement_id: str,
+    device_key: str | None,
+    expected: tuple[str | None, str | None, v2.OpenTarget] | None,
+) -> None:
+    projection = _project(_representative(), workspace_id, device_key)
+
+    assert (  # nosec B101
+        _launch_values(_placement(projection, placement_id).launch_settings) == expected
+    )
+
+
+def test_selected_settings_replace_fallback_settings_without_field_merge() -> None:
+    document = _representative()
+    bindings = document["device_bindings"]
+    portable = cast(v2.PlacementLaunchBinding, bindings[3])
+    exact = cast(v2.PlacementLaunchBinding, bindings[4])
+    portable["settings"] = v2.UrlLaunchSettings(
+        browser="fallback-browser",
+        chrome_profile="fallback-profile",
+        open_target="tab",
+    )
+    exact["settings"] = v2.UrlLaunchSettings(
+        browser=None,
+        chrome_profile=None,
+        open_target="window",
+    )
+    assert v2.validate_v2(document)  # nosec B101
+
+    selected = _placement(
+        _project(document, external_device_key="device-A"),
+        PLACEMENT_1,
+    )
+    fallback = _placement(
+        _project(document, external_device_key="nonmatching"),
+        PLACEMENT_1,
+    )
+
+    assert _launch_values(selected.launch_settings) == (None, None, "window")  # nosec B101
+    assert _launch_values(fallback.launch_settings) == (  # nosec B101
+        "fallback-browser",
+        "fallback-profile",
+        "tab",
+    )
+
+
+def test_invalid_external_device_key_is_distinct_from_no_device_key() -> None:
+    document = _representative()
+
+    invalid = runtime.project_workspace(document, external_device_key="")
+    without_key = runtime.project_workspace(document, external_device_key=None)
+
+    assert isinstance(invalid, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert invalid.category == "invalid_device_key"  # nosec B101
+    assert isinstance(without_key, runtime.WorkspaceProjection)  # nosec B101
+
+
+def test_refresh_is_detached_and_changes_only_referenced_resource_defaults() -> None:
+    source = _representative()
+    source_bytes = _serialized(source)
+    expected = deepcopy(source)
+    expected_resource = next(
+        resource for resource in expected["resources"] if resource["id"] == RESOURCE_1
+    )
+    expected_resource["default_label"] = "Refreshed default"
+    expected_resource["default_icon"] = v2.LegacyStringIcon(
+        kind="legacy_string",
+        value="refreshed-icon",
+    )
+
+    result = runtime.apply_metadata_refresh(
+        source,
+        PLACEMENT_2,
+        label="Refreshed default",
+        icon="refreshed-icon",
+    )
+
+    assert not isinstance(result, runtime.RuntimeAdapterRejected)  # nosec B101
+    refreshed = cast(v2.Root, result)
+    assert refreshed == expected  # nosec B101
+    assert refreshed is not source  # nosec B101
+    assert refreshed["resources"] is not source["resources"]  # nosec B101
+    assert refreshed["placements"] is not source["placements"]  # nosec B101
+    assert _serialized(source) == source_bytes  # nosec B101
+    assert _serialized(refreshed) == _serialized(expected)  # nosec B101
+    assert v2.validate_v2(refreshed)  # nosec B101
+
+    refreshed["application"]["title"] = "detached mutation"
+    assert source["application"]["title"] == "Café 東京"  # nosec B101
+
+
+def test_refresh_detaches_extensions_beyond_deepcopy_recursion_depth() -> None:
+    depth = 1_750
+    leaf = "deep-extension-leaf"
+    source = _representative()
+    source["extensions"]["deep.example.test"] = _deep_extension(depth, leaf)
+    assert v2.validate_v2(source)  # nosec B101
+
+    original_resource = next(
+        resource for resource in source["resources"] if resource["id"] == RESOURCE_1
+    )
+    result = runtime.apply_metadata_refresh(
+        source,
+        PLACEMENT_1,
+        label="Deep refresh",
+        icon="deep-refresh-icon",
+    )
+
+    assert not isinstance(result, runtime.RuntimeAdapterRejected)  # nosec B101
+    refreshed = cast(v2.Root, result)
+    refreshed_resource = next(
+        resource for resource in refreshed["resources"] if resource["id"] == RESOURCE_1
+    )
+    assert _json_container_ids(source).isdisjoint(  # nosec B101
+        _json_container_ids(refreshed)
+    )
+    assert (  # nosec B101
+        _deep_extension_leaf(source["extensions"]["deep.example.test"], depth) == leaf
+    )
+    assert (  # nosec B101
+        _deep_extension_leaf(refreshed["extensions"]["deep.example.test"], depth)
+        == leaf
+    )
+    assert original_resource["default_label"] == "Shared"  # nosec B101
+    assert original_resource["default_icon"] is None  # nosec B101
+    assert refreshed_resource["default_label"] == "Deep refresh"  # nosec B101
+    assert refreshed_resource["default_icon"] == {  # nosec B101
+        "kind": "legacy_string",
+        "value": "deep-refresh-icon",
+    }
+    assert v2.validate_v2(refreshed)  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("label", "icon", "expected_label", "expected_icon"),
+    [
+        ("label-only", None, "label-only", "existing-icon"),
+        (None, "icon-only", "Shared", "icon-only"),
+        (None, None, "Shared", "existing-icon"),
+        ("", "", "", ""),
+    ],
+)
+def test_refresh_updates_label_and_icon_independently(
+    label: str | None,
+    icon: str | None,
+    expected_label: str,
+    expected_icon: str,
+) -> None:
+    source = _representative()
+    source_resource = next(
+        resource for resource in source["resources"] if resource["id"] == RESOURCE_1
+    )
+    source_resource["default_icon"] = v2.LegacyStringIcon(
+        kind="legacy_string",
+        value="existing-icon",
+    )
+    assert v2.validate_v2(source)  # nosec B101
+
+    result = runtime.apply_metadata_refresh(
+        source,
+        PLACEMENT_1,
+        label=label,
+        icon=icon,
+    )
+
+    assert not isinstance(result, runtime.RuntimeAdapterRejected)  # nosec B101
+    refreshed = cast(v2.Root, result)
+    refreshed_resource = next(
+        resource for resource in refreshed["resources"] if resource["id"] == RESOURCE_1
+    )
+    assert _json_container_ids(source).isdisjoint(  # nosec B101
+        _json_container_ids(refreshed)
+    )
+    assert source_resource["default_label"] == "Shared"  # nosec B101
+    assert source_resource["default_icon"] == {  # nosec B101
+        "kind": "legacy_string",
+        "value": "existing-icon",
+    }
+    assert refreshed_resource["default_label"] == expected_label  # nosec B101
+    assert refreshed_resource["default_icon"] == {  # nosec B101
+        "kind": "legacy_string",
+        "value": expected_icon,
+    }
+    assert v2.validate_v2(refreshed)  # nosec B101
+
+
+def test_shared_resource_refresh_keeps_placement_overrides_independent() -> None:
+    result = runtime.apply_metadata_refresh(
+        _representative(),
+        PLACEMENT_2,
+        label="Refreshed default",
+        icon="refreshed-icon",
+    )
+    assert not isinstance(result, runtime.RuntimeAdapterRejected)  # nosec B101
+
+    primary = _project(result)
+    secondary = _project(result, WORKSPACE_2)
+    inherited = _placement(primary, PLACEMENT_1)
+    explicit_empty = _placement(primary, PLACEMENT_2)
+    independent_label = _placement(secondary, PLACEMENT_5)
+
+    assert (inherited.label, inherited.icon) == (  # nosec B101
+        "Refreshed default",
+        "refreshed-icon",
+    )
+    assert (explicit_empty.label, explicit_empty.icon) == ("", "")  # nosec B101
+    assert (independent_label.label, independent_label.icon) == (  # nosec B101
+        "Secondary placement",
+        "refreshed-icon",
+    )
+
+
+def _duplicate_resource_id(document: v2.Root) -> None:
+    document["resources"].append(deepcopy(document["resources"][0]))
+
+
+def _dangling_resource_reference(document: v2.Root) -> None:
+    document["placements"][-1]["resource_id"] = "90000000-0000-4000-8000-000000000001"
+
+
+def _incomplete_display_order(document: v2.Root) -> None:
+    document["tabs"][0]["display_order"].pop()
+
+
+def _duplicate_binding_selector(document: v2.Root) -> None:
+    duplicate = deepcopy(document["device_bindings"][0])
+    duplicate["id"] = "50000000-0000-4000-8000-000000000099"
+    document["device_bindings"].append(duplicate)
+
+
+def _invalid_unrelated_orphan(document: v2.Root) -> None:
+    cast(dict[str, object], document["resources"][2])["unexpected"] = "private"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        _duplicate_resource_id,
+        _dangling_resource_reference,
+        _incomplete_display_order,
+        _duplicate_binding_selector,
+        _invalid_unrelated_orphan,
+    ],
+)
+def test_complete_invalid_graphs_fail_closed_without_partial_results(
+    mutation: Callable[[v2.Root], None],
+) -> None:
+    document = _representative()
+    mutation(document)
+    assert not v2.validate_v2(document)  # nosec B101
+
+    projected = runtime.project_workspace(document, WORKSPACE_1)
+    refreshed = runtime.apply_metadata_refresh(
+        document,
+        PLACEMENT_1,
+        label="unused",
+    )
+
+    assert isinstance(projected, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert projected.category == "invalid_graph"  # nosec B101
+    assert isinstance(refreshed, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert refreshed.category == "invalid_graph"  # nosec B101
+
+
+def test_subject_and_refresh_failures_use_fixed_categories() -> None:
+    document = _representative()
+
+    missing_workspace = runtime.project_workspace(
+        document,
+        "90000000-0000-4000-8000-000000000002",
+    )
+    missing_placement = runtime.apply_metadata_refresh(
+        document,
+        "90000000-0000-4000-8000-000000000003",
+        label="unused",
+    )
+    invalid_refresh = runtime.apply_metadata_refresh(
+        document,
+        PLACEMENT_1,
+        label="\ud800",
+    )
+
+    assert isinstance(missing_workspace, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert missing_workspace.category == "subject_not_found"  # nosec B101
+    assert isinstance(missing_placement, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert missing_placement.category == "subject_not_found"  # nosec B101
+    assert isinstance(invalid_refresh, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert invalid_refresh.category == "refresh_failure"  # nosec B101
+
+
+def test_adapter_rejections_are_silent_and_content_free(
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sentinels = (
+        "https://private-runtime.example.test/path",
+        "private-runtime-label",
+        "private-runtime-icon",
+        "private-device-key",
+        "private-extension-payload",
+    )
+    document = _representative()
+    document["resources"][0]["target"]["url"] = sentinels[0]
+    document["resources"][0]["default_label"] = sentinels[1]
+    document["resources"][0]["default_icon"] = v2.LegacyStringIcon(
+        kind="legacy_string",
+        value=sentinels[2],
+    )
+    exact = cast(v2.DeviceSpecific, document["device_bindings"][1]["applicability"])
+    exact["device_key"] = sentinels[3]
+    document["extensions"][sentinels[4]] = {"unexpected": True}
+    cast(dict[str, object], document["resources"][2])["unexpected"] = sentinels[4]
+    caplog.set_level(logging.DEBUG)
+    capsys.readouterr()
+    caplog.clear()
+
+    projection = runtime.project_workspace(
+        document,
+        external_device_key=sentinels[3],
+    )
+    refresh = runtime.apply_metadata_refresh(
+        document,
+        PLACEMENT_1,
+        label=sentinels[1],
+        icon=sentinels[2],
+    )
+
+    assert isinstance(projection, runtime.RuntimeAdapterRejected)  # nosec B101
+    assert isinstance(refresh, runtime.RuntimeAdapterRejected)  # nosec B101
+    rendered = repr((projection, refresh))
+    captured = capsys.readouterr()
+    assert captured.out == ""  # nosec B101
+    assert captured.err == ""  # nosec B101
+    for sentinel in sentinels:
+        assert sentinel not in rendered  # nosec B101
+        assert sentinel not in caplog.text  # nosec B101
+
+
+def test_strict_v1_transform_projects_equivalent_url_runtime_behavior() -> None:
+    source = _strict_v1_source()
+    transformed = transform.transform_v1_to_v2(source)
+    assert not isinstance(  # nosec B101
+        transformed,
+        serialization.V2SerializationRejected,
+    )
+    assert transformed is not None  # nosec B101
+    candidate = cast(v2.Root, transformed)
+    projection = _project(candidate)
+
+    assert projection.application_title == source["application"]["title"]  # nosec B101[index]
+    assert projection.id == V1_WORKSPACE  # nosec B101
+    assert projection.name == "Default Workspace"  # nosec B101
+    assert [tab.id for tab in projection.tabs] == [V1_HIGH_TAB, V1_LOW_TAB]  # nosec B101
+    assert [tab.id for tab in projection.normal_tabs] == [V1_HIGH_TAB]  # nosec B101
+    assert _window_values(projection.window_settings) == (  # nosec B101
+        -2,
+        True,
+        0,
+        -40,
+        None,
+        900,
+    )
+
+    source_tabs = {
+        tab["id"]: tab for tab in cast(list[dict[str, v1.JsonValue]], source["tabs"])
+    }
+    source_tiles = cast(list[dict[str, v1.JsonValue]], source["tiles"])
+    for projected_tab in projection.tabs:
+        source_tab = source_tabs[projected_tab.id]
+        expected_tiles = [
+            tile for tile in source_tiles if tile["tab_id"] == projected_tab.id
+        ]
+        assert projected_tab.name == source_tab["name"]  # nosec B101
+        assert projected_tab.visibility == source_tab["visibility"]  # nosec B101
+        assert projected_tab.lifecycle == "active"  # nosec B101
+        assert projected_tab.view_mode == "display"  # nosec B101
+        assert projected_tab.display_filter == ("new", "in_use")  # nosec B101
+        assert projected_tab.displayed_placements == projected_tab.placements  # nosec B101
+        actual_tiles = [
+            (
+                placement.url,
+                placement.label,
+                placement.icon,
+                placement.background_color,
+                placement.workflow_status,
+                _launch_values(placement.launch_settings),
+            )
+            for placement in projected_tab.placements
+        ]
+        expected_runtime = [
+            (
+                tile["url"],
+                tile["name"],
+                tile["icon"],
+                tile["bg"],
+                "in_use",
+                (tile["browser"], tile["chrome_profile"], tile["open_target"]),
+            )
+            for tile in expected_tiles
+        ]
+        assert actual_tiles == expected_runtime  # nosec B101
+
+
+def test_transformed_v1_refresh_changes_only_legacy_name_and_icon_behavior() -> None:
+    transformed = transform.transform_v1_to_v2(_strict_v1_source())
+    assert transformed is not None  # nosec B101
+    assert not isinstance(  # nosec B101
+        transformed,
+        serialization.V2SerializationRejected,
+    )
+    candidate = cast(v2.Root, transformed)
+    before = _project(candidate)
+    original = _tab(before, V1_HIGH_TAB).placements[0]
+
+    result = runtime.apply_metadata_refresh(
+        candidate,
+        original.id,
+        label="Refreshed migrated label",
+        icon="refreshed-migrated-icon",
+    )
+    assert not isinstance(result, runtime.RuntimeAdapterRejected)  # nosec B101
+    after = _placement(_project(result), original.id)
+
+    assert (after.label, after.icon) == (  # nosec B101
+        "Refreshed migrated label",
+        "refreshed-migrated-icon",
+    )
+    assert (  # nosec B101
+        after.id,
+        after.resource_id,
+        after.tab_id,
+        after.url,
+        after.background_color,
+        after.workflow_status,
+        _launch_values(after.launch_settings),
+    ) == (
+        original.id,
+        original.resource_id,
+        original.tab_id,
+        original.url,
+        original.background_color,
+        original.workflow_status,
+        _launch_values(original.launch_settings),
+    )
+    assert _project(candidate) == before  # nosec B101

--- a/tests/unit/test_config_schema_v2_boundary.py
+++ b/tests/unit/test_config_schema_v2_boundary.py
@@ -21,12 +21,14 @@ SCHEMA_PATH = REPO_ROOT / "config_schema_v2.py"
 SERIALIZATION_PATH = REPO_ROOT / "config_serialization_v2.py"
 MIGRATION_V2_PATH = REPO_ROOT / "config_migration_v2.py"
 TRANSFORM_V1_TO_V2_PATH = REPO_ROOT / "config_transform_v1_to_v2.py"
+RUNTIME_V2_PATH = REPO_ROOT / "config_runtime_v2.py"
 PERSISTENCE_PATH = REPO_ROOT / "config_persistence.py"
 PACKAGING_SPEC_PATH = REPO_ROOT / "DesktopTileLauncher.spec"
 PRODUCTION_ENTRY_PATH = REPO_ROOT / "tile_launcher.py"
 FORBIDDEN_V2_MODULES = frozenset(
     {
         "config_migration_v2.py",
+        "config_runtime_v2.py",
         "config_schema_v2.py",
         "config_serialization_v2.py",
         "config_transform_v1_to_v2.py",
@@ -104,6 +106,29 @@ TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES = frozenset({"V1ToV2TransformResult"})
 TRANSFORM_V1_TO_V2_PUBLIC_NAMES = (
     TRANSFORM_V1_TO_V2_PUBLIC_FUNCTIONS | TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES
 )
+RUNTIME_V2_PUBLIC_FUNCTIONS = frozenset({"apply_metadata_refresh", "project_workspace"})
+RUNTIME_V2_PUBLIC_DATACLASSES = frozenset(
+    {
+        "LaunchSettingsProjection",
+        "PlacementProjection",
+        "RuntimeAdapterRejected",
+        "TabProjection",
+        "WindowSettingsProjection",
+        "WorkspaceProjection",
+    }
+)
+RUNTIME_V2_PUBLIC_TYPE_ALIASES = frozenset(
+    {
+        "MetadataRefreshResult",
+        "RuntimeAdapterFailureCategory",
+        "WorkspaceProjectionResult",
+    }
+)
+RUNTIME_V2_PUBLIC_NAMES = (
+    RUNTIME_V2_PUBLIC_FUNCTIONS
+    | RUNTIME_V2_PUBLIC_DATACLASSES
+    | RUNTIME_V2_PUBLIC_TYPE_ALIASES
+)
 
 EXPECTED_SCHEMA_IMPORTS = frozenset(
     {
@@ -158,6 +183,17 @@ EXPECTED_TRANSFORM_V1_TO_V2_IMPORTS = frozenset(
         "import config_schema as v1",
         "import config_schema_v2 as v2",
         "import config_serialization_v2 as serialization",
+    }
+)
+EXPECTED_RUNTIME_V2_IMPORTS = frozenset(
+    {
+        "from __future__ import annotations",
+        "from dataclasses import dataclass",
+        "from dataclasses import field",
+        "from typing import Literal",
+        "from typing import TypeAlias",
+        "from typing import cast",
+        "import config_schema_v2 as v2",
     }
 )
 
@@ -629,6 +665,7 @@ def test_public_structural_result_and_behavioral_surfaces_are_exact() -> None:
     serialization_tree = _parse_path(SERIALIZATION_PATH)
     migration_v2_tree = _parse_path(MIGRATION_V2_PATH)
     transform_v1_to_v2_tree = _parse_path(TRANSFORM_V1_TO_V2_PATH)
+    runtime_v2_tree = _parse_path(RUNTIME_V2_PATH)
 
     assert _public_functions(schema_tree) == SCHEMA_PUBLIC_FUNCTIONS  # nosec B101
     assert {  # nosec B101
@@ -731,17 +768,38 @@ def test_public_structural_result_and_behavioral_surfaces_are_exact() -> None:
         _module_all(transform_v1_to_v2_tree) == TRANSFORM_V1_TO_V2_PUBLIC_NAMES
     )
 
+    assert _public_functions(runtime_v2_tree) == RUNTIME_V2_PUBLIC_FUNCTIONS  # nosec B101
+    assert {  # nosec B101
+        node.name
+        for node in runtime_v2_tree.body
+        if isinstance(node, ast.ClassDef) and not node.name.startswith("_")
+    } == RUNTIME_V2_PUBLIC_DATACLASSES
+    assert (  # nosec B101
+        _public_classes(runtime_v2_tree, "dataclass") == RUNTIME_V2_PUBLIC_DATACLASSES
+    )
+    assert _public_classes(runtime_v2_tree, "typed_dict") == set()  # nosec B101
+    assert _public_classes(runtime_v2_tree, "enum") == set()  # nosec B101
+    assert _public_classes(runtime_v2_tree, "exception") == set()  # nosec B101
+    assert (  # nosec B101
+        _public_annotated_names(runtime_v2_tree, "type_alias")
+        == RUNTIME_V2_PUBLIC_TYPE_ALIASES
+    )
+    assert _public_annotated_names(runtime_v2_tree, "constant") == set()  # nosec B101
+    assert _module_all(runtime_v2_tree) == RUNTIME_V2_PUBLIC_NAMES  # nosec B101
+
 
 def test_exact_imports_and_focused_json_ast_contracts() -> None:
     schema_tree = _parse_path(SCHEMA_PATH)
     serialization_tree = _parse_path(SERIALIZATION_PATH)
     migration_v2_tree = _parse_path(MIGRATION_V2_PATH)
     transform_v1_to_v2_tree = _parse_path(TRANSFORM_V1_TO_V2_PATH)
+    runtime_v2_tree = _parse_path(RUNTIME_V2_PATH)
 
     schema_imports = _import_declarations(schema_tree)
     serialization_imports = _import_declarations(serialization_tree)
     migration_v2_imports = _import_declarations(migration_v2_tree)
     transform_v1_to_v2_imports = _import_declarations(transform_v1_to_v2_tree)
+    runtime_v2_imports = _import_declarations(runtime_v2_tree)
     assert len(schema_imports) == len(EXPECTED_SCHEMA_IMPORTS)  # nosec B101
     assert set(schema_imports) == EXPECTED_SCHEMA_IMPORTS  # nosec B101
     assert len(serialization_imports) == len(  # nosec B101
@@ -758,6 +816,8 @@ def test_exact_imports_and_focused_json_ast_contracts() -> None:
     assert (  # nosec B101
         set(transform_v1_to_v2_imports) == EXPECTED_TRANSFORM_V1_TO_V2_IMPORTS
     )
+    assert len(runtime_v2_imports) == len(EXPECTED_RUNTIME_V2_IMPORTS)  # nosec B101
+    assert set(runtime_v2_imports) == EXPECTED_RUNTIME_V2_IMPORTS  # nosec B101
 
     # These assertions describe direct JSON-related syntax, not general capabilities.
     assert not any(  # nosec B101
@@ -812,6 +872,7 @@ def test_transformer_dependency_closure_is_qt_free_and_not_runtime_rooted() -> N
         Path("config_schema_v2.py"),
     }.issubset(relative)
     assert Path("config_migration.py") not in relative  # nosec B101
+    assert Path("config_runtime_v2.py") not in relative  # nosec B101
     assert Path("tile_launcher.py") not in relative  # nosec B101
     for path in dependency_closure:
         import_roots = {
@@ -833,7 +894,26 @@ def test_checked_transform_dependency_closure_is_qt_free_and_excludes_startup() 
         Path("config_serialization_v2.py"),
         Path("config_transform_v1_to_v2.py"),
     }.issubset(relative)
+    assert Path("config_runtime_v2.py") not in relative  # nosec B101
     assert Path("tile_launcher.py") not in relative  # nosec B101
+    for path in dependency_closure:
+        import_roots = {
+            name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)
+        }
+        assert import_roots.isdisjoint(QT_IMPORT_ROOTS), path  # nosec B101
+
+
+def test_runtime_adapter_dependency_closure_is_qt_free_and_detached() -> None:
+    dependency_closure = _repository_local_import_closure(
+        REPO_ROOT,
+        {RUNTIME_V2_PATH},
+    )
+    relative = _relative_paths(REPO_ROOT, dependency_closure)
+
+    assert relative == {  # nosec B101
+        Path("config_runtime_v2.py"),
+        Path("config_schema_v2.py"),
+    }
     for path in dependency_closure:
         import_roots = {
             name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)

--- a/tests/unit/test_unit_collection_boundary.py
+++ b/tests/unit/test_unit_collection_boundary.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for the fail-closed Qt-free unit-test boundary."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+from unit_collection_guard import (
+    FORBIDDEN_UNIT_IMPORT_ROOTS,
+    ForbiddenUnitImportFinder,
+    QT_FREE_UNIT_TEST_PATHS,
+    QUARANTINED_TEST_PATHS,
+    UNIT_ONLY_MARK_EXPRESSION,
+    forbidden_loaded_modules,
+    should_ignore_test_module,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+
+def _test_module_paths() -> frozenset[str]:
+    return frozenset(
+        path.relative_to(REPO_ROOT).as_posix() for path in TESTS_ROOT.rglob("test_*.py")
+    )
+
+
+def _imported_module_names(path: Path) -> frozenset[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            if node.module is not None:
+                names.add(node.module)
+    return frozenset(names)
+
+
+def _repository_module_paths(module_name: str) -> tuple[Path, ...]:
+    parts = module_name.split(".")
+    candidates: list[Path] = []
+    for root in (REPO_ROOT, TESTS_ROOT):
+        module_path = root.joinpath(*parts).with_suffix(".py")
+        package_path = root.joinpath(*parts, "__init__.py")
+        for candidate in (module_path, package_path):
+            if candidate.is_file() and candidate not in candidates:
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _local_import_closure(paths: set[Path]) -> set[Path]:
+    closure: set[Path] = set()
+    pending = list(paths)
+    while pending:
+        path = pending.pop()
+        if path in closure:
+            continue
+        closure.add(path)
+        for module_name in _imported_module_names(path):
+            pending.extend(_repository_module_paths(module_name))
+    return closure
+
+
+def _is_unit_marker(node: ast.AST) -> bool:
+    return any(
+        isinstance(candidate, ast.Attribute)
+        and candidate.attr == "unit"
+        and isinstance(candidate.value, ast.Attribute)
+        and candidate.value.attr == "mark"
+        and isinstance(candidate.value.value, ast.Name)
+        and candidate.value.value.id == "pytest"
+        for candidate in ast.walk(node)
+    )
+
+
+def _module_has_unit_marker(tree: ast.Module) -> bool:
+    return any(
+        isinstance(node, (ast.Assign, ast.AnnAssign))
+        and any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in (
+                node.targets if isinstance(node, ast.Assign) else [node.target]
+            )
+        )
+        and node.value is not None
+        and _is_unit_marker(node.value)
+        for node in tree.body
+    )
+
+
+def _unmarked_test_names(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    module_marked = _module_has_unit_marker(tree)
+    unmarked: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name.startswith("test_") and not (
+                module_marked
+                or any(_is_unit_marker(item) for item in node.decorator_list)
+            ):
+                unmarked.append(node.name)
+            continue
+        if not isinstance(node, ast.ClassDef) or not node.name.startswith("Test"):
+            continue
+        class_marked = module_marked or any(
+            _is_unit_marker(item) for item in node.decorator_list
+        )
+        for child in node.body:
+            if (
+                isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and child.name.startswith("test_")
+                and not (
+                    class_marked
+                    or any(_is_unit_marker(item) for item in child.decorator_list)
+                )
+            ):
+                unmarked.append(f"{node.name}.{child.name}")
+    return tuple(unmarked)
+
+
+def test_every_test_module_is_classified_exactly_once() -> None:
+    assert QT_FREE_UNIT_TEST_PATHS.isdisjoint(QUARANTINED_TEST_PATHS)  # nosec B101
+    assert (  # nosec B101
+        QT_FREE_UNIT_TEST_PATHS | QUARANTINED_TEST_PATHS == _test_module_paths()
+    )
+
+
+def test_unit_collection_is_fail_closed_for_quarantined_and_unknown_tests() -> None:
+    for relative in QUARANTINED_TEST_PATHS:
+        assert (  # nosec B101
+            should_ignore_test_module(
+                REPO_ROOT / relative,
+                REPO_ROOT,
+                UNIT_ONLY_MARK_EXPRESSION,
+            )
+            is True
+        )
+    assert (  # nosec B101
+        should_ignore_test_module(
+            TESTS_ROOT / "unit" / "test_future_unclassified.py",
+            REPO_ROOT,
+            UNIT_ONLY_MARK_EXPRESSION,
+        )
+        is True
+    )
+
+
+def test_unit_collection_allows_only_classified_safe_tests() -> None:
+    for relative in QT_FREE_UNIT_TEST_PATHS:
+        assert (  # nosec B101
+            should_ignore_test_module(
+                REPO_ROOT / relative,
+                REPO_ROOT,
+                UNIT_ONLY_MARK_EXPRESSION,
+            )
+            is None
+        )
+
+
+def test_allowlisted_tests_have_effective_unit_markers() -> None:
+    violations = {
+        relative: _unmarked_test_names(REPO_ROOT / relative)
+        for relative in QT_FREE_UNIT_TEST_PATHS
+        if _unmarked_test_names(REPO_ROOT / relative)
+    }
+
+    assert not violations  # nosec B101
+
+
+def test_unit_collection_ignores_external_test_modules() -> None:
+    external = REPO_ROOT.parent / "test_external_unclassified.py"
+
+    assert (  # nosec B101
+        should_ignore_test_module(
+            external,
+            REPO_ROOT,
+            UNIT_ONLY_MARK_EXPRESSION,
+        )
+        is True
+    )
+
+
+def test_non_unit_collection_is_unchanged() -> None:
+    for relative in _test_module_paths():
+        assert (  # nosec B101
+            should_ignore_test_module(
+                REPO_ROOT / relative,
+                REPO_ROOT,
+                "qt or gui",
+            )
+            is None
+        )
+
+
+def test_import_finder_blocks_forbidden_roots_without_importing_them() -> None:
+    finder = ForbiddenUnitImportFinder()
+
+    assert finder.find_spec("json", None) is None  # nosec B101
+    for root in FORBIDDEN_UNIT_IMPORT_ROOTS:
+        with pytest.raises(RuntimeError, match="forbidden import root"):
+            finder.find_spec(f"{root}.sentinel", None)
+
+
+def test_allowlisted_import_closure_is_qt_free() -> None:
+    allowlisted_paths = {REPO_ROOT / relative for relative in QT_FREE_UNIT_TEST_PATHS}
+    closure = _local_import_closure(allowlisted_paths)
+    violations = {
+        (path.relative_to(REPO_ROOT).as_posix(), module_name)
+        for path in closure
+        for module_name in _imported_module_names(path)
+        if module_name.partition(".")[0] in FORBIDDEN_UNIT_IMPORT_ROOTS
+    }
+
+    assert not violations  # nosec B101
+
+
+def test_unit_session_has_not_loaded_forbidden_modules() -> None:
+    assert not forbidden_loaded_modules()  # nosec B101
+    assert all(  # nosec B101
+        name.partition(".")[0] not in FORBIDDEN_UNIT_IMPORT_ROOTS
+        for name in sys.modules
+    )

--- a/tests/unit/test_unit_collection_boundary.py
+++ b/tests/unit/test_unit_collection_boundary.py
@@ -16,6 +16,7 @@ from unit_collection_guard import (
     QUARANTINED_TEST_PATHS,
     UNIT_ONLY_MARK_EXPRESSION,
     forbidden_loaded_modules,
+    is_pytest_test_module,
     should_ignore_test_module,
 )
 
@@ -23,11 +24,14 @@ pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TESTS_ROOT = REPO_ROOT / "tests"
+MAKEFILE_PATH = REPO_ROOT / "Makefile"
 
 
 def _test_module_paths() -> frozenset[str]:
     return frozenset(
-        path.relative_to(REPO_ROOT).as_posix() for path in TESTS_ROOT.rglob("test_*.py")
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in TESTS_ROOT.rglob("*.py")
+        if is_pytest_test_module(path)
     )
 
 
@@ -69,15 +73,23 @@ def _local_import_closure(paths: set[Path]) -> set[Path]:
 
 
 def _is_unit_marker(node: ast.AST) -> bool:
-    return any(
+    candidate = node.func if isinstance(node, ast.Call) else node
+    return (
         isinstance(candidate, ast.Attribute)
         and candidate.attr == "unit"
         and isinstance(candidate.value, ast.Attribute)
         and candidate.value.attr == "mark"
         and isinstance(candidate.value.value, ast.Name)
         and candidate.value.value.id == "pytest"
-        for candidate in ast.walk(node)
     )
+
+
+def _contains_direct_unit_marker(node: ast.AST) -> bool:
+    if _is_unit_marker(node):
+        return True
+    if isinstance(node, (ast.List, ast.Set, ast.Tuple)):
+        return any(_is_unit_marker(item) for item in node.elts)
+    return False
 
 
 def _module_has_unit_marker(tree: ast.Module) -> bool:
@@ -90,7 +102,7 @@ def _module_has_unit_marker(tree: ast.Module) -> bool:
             )
         )
         and node.value is not None
-        and _is_unit_marker(node.value)
+        and _contains_direct_unit_marker(node.value)
         for node in tree.body
     )
 
@@ -101,7 +113,7 @@ def _unmarked_test_names(path: Path) -> tuple[str, ...]:
     unmarked: list[str] = []
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if node.name.startswith("test_") and not (
+            if node.name.startswith("test") and not (
                 module_marked
                 or any(_is_unit_marker(item) for item in node.decorator_list)
             ):
@@ -115,7 +127,7 @@ def _unmarked_test_names(path: Path) -> tuple[str, ...]:
         for child in node.body:
             if (
                 isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
-                and child.name.startswith("test_")
+                and child.name.startswith("test")
                 and not (
                     class_marked
                     or any(_is_unit_marker(item) for item in child.decorator_list)
@@ -123,6 +135,31 @@ def _unmarked_test_names(path: Path) -> tuple[str, ...]:
             ):
                 unmarked.append(f"{node.name}.{child.name}")
     return tuple(unmarked)
+
+
+def _make_target_recipe(target: str) -> tuple[str, ...]:
+    lines = MAKEFILE_PATH.read_text(encoding="utf-8").splitlines()
+    target_index = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if not line.startswith((" ", "\t")) and line.partition(":")[0] == target
+        ),
+        None,
+    )
+    if target_index is None:
+        return ()
+
+    recipe: list[str] = []
+    for line in lines[target_index + 1 :]:
+        if line.startswith("\t"):
+            recipe.append(line.strip())
+            continue
+        if line.strip():
+            break
+        if recipe:
+            break
+    return tuple(recipe)
 
 
 def test_every_test_module_is_classified_exactly_once() -> None:
@@ -142,14 +179,15 @@ def test_unit_collection_is_fail_closed_for_quarantined_and_unknown_tests() -> N
             )
             is True
         )
-    assert (  # nosec B101
-        should_ignore_test_module(
-            TESTS_ROOT / "unit" / "test_future_unclassified.py",
-            REPO_ROOT,
-            UNIT_ONLY_MARK_EXPRESSION,
+    for filename in ("test_future_unclassified.py", "future_unclassified_test.py"):
+        assert (  # nosec B101
+            should_ignore_test_module(
+                TESTS_ROOT / "unit" / filename,
+                REPO_ROOT,
+                UNIT_ONLY_MARK_EXPRESSION,
+            )
+            is True
         )
-        is True
-    )
 
 
 def test_unit_collection_allows_only_classified_safe_tests() -> None:
@@ -172,6 +210,45 @@ def test_allowlisted_tests_have_effective_unit_markers() -> None:
     }
 
     assert not violations  # nosec B101
+
+
+def test_nested_parameter_mark_does_not_mark_the_whole_test(tmp_path: Path) -> None:
+    path = tmp_path / "test_nested_parameter_mark.py"
+    path.write_text(
+        "import pytest\n\n"
+        "@pytest.mark.parametrize(\n"
+        "    'value',\n"
+        "    [pytest.param(1, marks=pytest.mark.unit), 2],\n"
+        ")\n"
+        "def testMixedMarking(value: int) -> None:\n"
+        "    del value\n",
+        encoding="utf-8",
+    )
+
+    assert _unmarked_test_names(path) == ("testMixedMarking",)  # nosec B101
+
+
+def test_unit_target_collects_only_the_guarded_tests_tree() -> None:
+    makefile_lines = MAKEFILE_PATH.read_text(encoding="utf-8").splitlines()
+    phony_targets = {
+        target
+        for line in makefile_lines
+        if line.startswith(".PHONY:")
+        for target in line.partition(":")[2].split()
+    }
+    recipe = _make_target_recipe("test_unit")
+    pytest_invocations = tuple(
+        line
+        for line in recipe
+        if "pytest" in line
+        and not line.startswith("echo ")
+        and "find_spec('pytest')" not in line
+    )
+
+    assert "test_unit" in phony_targets  # nosec B101
+    assert pytest_invocations == (  # nosec B101
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q tests \\",
+    )
 
 
 def test_unit_collection_ignores_external_test_modules() -> None:

--- a/tests/unit_collection_guard.py
+++ b/tests/unit_collection_guard.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed collection and import guards for the Qt-free unit-test gate."""
+
+from __future__ import annotations
+
+import importlib.abc
+import sys
+from collections.abc import Sequence
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType
+
+UNIT_ONLY_MARK_EXPRESSION = (
+    "unit and not (integration or e2e or slow or network or gui or qt or gl or x11 "
+    "or wayland or docker or gpu or perf or flaky)"
+)
+
+FORBIDDEN_UNIT_IMPORT_ROOTS = frozenset(
+    {
+        "DesktopTileLauncher",
+        "PyQt5",
+        "PyQt6",
+        "PySide6",
+        "debug_scaffold",
+        "shiboken6",
+        "tile_editor_dialog",
+        "tile_launcher",
+        "url_import_dialog",
+    }
+)
+
+QT_FREE_UNIT_TEST_PATHS = frozenset(
+    {
+        "tests/test_browser_chrome_win_unit.py",
+        "tests/unit/test_config_migration.py",
+        "tests/unit/test_config_migration_v2.py",
+        "tests/unit/test_config_persistence.py",
+        "tests/unit/test_config_recovery.py",
+        "tests/unit/test_config_runtime_v2.py",
+        "tests/unit/test_config_schema.py",
+        "tests/unit/test_config_schema_v2.py",
+        "tests/unit/test_config_schema_v2_boundary.py",
+        "tests/unit/test_config_serialization_v2.py",
+        "tests/unit/test_page_title_lookup.py",
+        "tests/unit/test_tab_order.py",
+        "tests/unit/test_test_path_isolation.py",
+        "tests/unit/test_tile_metadata_refresh.py",
+        "tests/unit/test_unit_collection_boundary.py",
+        "tests/unit/test_url_import.py",
+    }
+)
+
+QUARANTINED_TEST_PATHS = frozenset(
+    {
+        "tests/test_auto_columns.py",
+        "tests/test_available_browsers.py",
+        "tests/test_browser.py",
+        "tests/test_debug_scaffold_unit.py",
+        "tests/test_launch_plan.py",
+        "tests/test_smoke.py",
+        "tests/unit/test_breadcrumb_ring.py",
+        "tests/unit/test_compute_grid_fit.py",
+        "tests/unit/test_crash_bundle.py",
+        "tests/unit/test_fit_policy.py",
+        "tests/unit/test_hidden_tabs.py",
+        "tests/unit/test_launching.py",
+        "tests/unit/test_sanitize_log_extra.py",
+        "tests/unit/test_sanitize_url.py",
+        "tests/unit/test_tab_visibility_dialog.py",
+        "tests/unit/test_tile_editor_title_suggestion.py",
+        "tests/unit/test_tile_name_diagnostics.py",
+        "tests/unit/test_url_import_dialog.py",
+        "tests/unit/test_url_import_integration.py",
+        "tests/unit/test_whitespace_context_menu.py",
+    }
+)
+
+
+def is_unit_only_expression(expression: str) -> bool:
+    """Return whether a marker expression is the repository's exact unit contract."""
+
+    return " ".join(expression.split()) == UNIT_ONLY_MARK_EXPRESSION
+
+
+def repo_relative_path(path: Path, repo_root: Path) -> str | None:
+    """Return one normalized repository-relative path, or ``None`` if external."""
+
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
+def should_ignore_test_module(
+    path: Path,
+    repo_root: Path,
+    marker_expression: str,
+) -> bool | None:
+    """Ignore non-allowlisted test modules before import during the unit gate."""
+
+    if not is_unit_only_expression(marker_expression):
+        return None
+    if path.suffix != ".py" or not path.name.startswith("test_"):
+        return None
+    relative = repo_relative_path(path, repo_root)
+    if relative is None or not relative.startswith("tests/"):
+        return True
+    relative_path = Path(relative)
+    if relative_path.suffix != ".py" or not relative_path.name.startswith("test_"):
+        return None
+    if relative in QT_FREE_UNIT_TEST_PATHS:
+        return None
+    return True
+
+
+def forbidden_loaded_modules() -> tuple[str, ...]:
+    """Return forbidden module names already loaded into the current process."""
+
+    return tuple(
+        sorted(
+            name
+            for name in sys.modules
+            if name.partition(".")[0] in FORBIDDEN_UNIT_IMPORT_ROOTS
+        )
+    )
+
+
+class ForbiddenUnitImportFinder(importlib.abc.MetaPathFinder):
+    """Reject imports that would cross the Qt-free unit-test boundary."""
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        del path, target
+        root = fullname.partition(".")[0]
+        if root in FORBIDDEN_UNIT_IMPORT_ROOTS:
+            raise RuntimeError(f"unit collection blocked forbidden import root: {root}")
+        return None
+
+
+__all__ = [
+    "FORBIDDEN_UNIT_IMPORT_ROOTS",
+    "ForbiddenUnitImportFinder",
+    "QT_FREE_UNIT_TEST_PATHS",
+    "QUARANTINED_TEST_PATHS",
+    "UNIT_ONLY_MARK_EXPRESSION",
+    "forbidden_loaded_modules",
+    "is_unit_only_expression",
+    "repo_relative_path",
+    "should_ignore_test_module",
+]

--- a/tests/unit_collection_guard.py
+++ b/tests/unit_collection_guard.py
@@ -91,6 +91,14 @@ def repo_relative_path(path: Path, repo_root: Path) -> str | None:
         return None
 
 
+def is_pytest_test_module(path: Path) -> bool:
+    """Return whether *path* matches either default pytest module pattern."""
+
+    return path.suffix == ".py" and (
+        path.name.startswith("test_") or path.name.endswith("_test.py")
+    )
+
+
 def should_ignore_test_module(
     path: Path,
     repo_root: Path,
@@ -100,14 +108,11 @@ def should_ignore_test_module(
 
     if not is_unit_only_expression(marker_expression):
         return None
-    if path.suffix != ".py" or not path.name.startswith("test_"):
+    if not is_pytest_test_module(path):
         return None
     relative = repo_relative_path(path, repo_root)
     if relative is None or not relative.startswith("tests/"):
         return True
-    relative_path = Path(relative)
-    if relative_path.suffix != ".py" or not relative_path.name.startswith("test_"):
-        return None
     if relative in QT_FREE_UNIT_TEST_PATHS:
         return None
     return True
@@ -148,6 +153,7 @@ __all__ = [
     "QUARANTINED_TEST_PATHS",
     "UNIT_ONLY_MARK_EXPRESSION",
     "forbidden_loaded_modules",
+    "is_pytest_test_module",
     "is_unit_only_expression",
     "repo_relative_path",
     "should_ignore_test_module",


### PR DESCRIPTION
## Summary

- add immutable, Qt-free runtime projections for complete validated schema-v2 Workspace, Tab, Resource, Placement, and DeviceBinding graphs
- preserve URL presentation, semantic tab/display ordering, exact-device and portable-fallback launch/window settings, and whole-object binding precedence
- add detached Resource-owned metadata refresh with fixed, content-free rejection categories
- prove strict-v1 transform equivalence and keep schema v2 unreachable from startup, persistence, and packaging
- make the required unit gate fail closed before collection so Qt-coupled or unclassified tests cannot import in the agent environment

## Why

This completes the third dependency-ordered schema-v2 slice in ADR-0001 without activating schema v2. The unit-gate repair is required for honest validation: pytest marker filtering happens after collection, so the prior target could import or execute Qt-backed modules despite its unit-only selector, and it could exit successfully when pytest was unavailable.

## Impact

Production startup and persistence remain on strict schema version 1 with no UI or launcher behavior change. Schema v2 stays dormant and unregistered.

The unit target now disables external plugin autoload, scopes collection to the guarded `tests/` tree, classifies both default pytest module filename patterns, blocks Qt/PySide6 and Qt-coupled launcher imports, rejects indirect parameter-only unit marks, fails on missing pytest, and reports selected/deselected/outcome counts. It pre-collection excludes 20 non-allowlisted modules. Full and GUI collection behavior is unchanged outside the exact unit selector.

## Validation

- `ruff format --check .` — 62 files already formatted
- `ruff check .` — passed
- `ruff check tests` — passed
- `mypy .` — no issues in 25 source files
- `make test_unit` — 707 selected, 0 deselected; 707 passed, 0 failed/skipped/errors; 20 modules excluded before import

No GUI, Qt, GL, network, integration, or end-to-end tests were run.

Closes #127