### PR TITLE
feat: activate schema-v2 production state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,31 @@
 ### App Behavior
 - Detect unreadable or corrupt configuration at startup and offer a safe default Exit or an
   explicit preserve-and-reset flow before the launcher mutates configuration state.
-- Add a Qt-free, schema-versioned migration harness and activate its pure deterministic
-  v0-to-v1 step for the Workspace/Tab identity schema.
-- Add a dormant, deterministic, Qt-free schema-v1-to-v2 transformer that constructs and
-  checks the complete URL Resource/Placement/DeviceBinding graph while keeping schema v2
-  unregistered and unreachable from production startup and persistence.
-- Add dormant, Qt-free schema-v2 runtime adapters that preserve existing URL presentation,
-  launch, window, tab-order, and metadata-refresh behavior without activating schema v2.
+- Add a Qt-free, schema-versioned migration harness and register its pure deterministic
+  v0-to-v1 and v1-to-v2 steps through the existing guarded migration transaction.
+- Activate schema version 2 as the current production format after constructing and checking
+  the complete URL Resource/Placement/DeviceBinding graph.
+- Activate Qt-free schema-v2 runtime adapters that preserve existing URL presentation,
+  launch, window, tab-order, and metadata-refresh behavior while retaining the complete graph.
+- Define lossless flat-UI mutation defaults: Add, Duplicate, and Import create `in_use`
+  Placements with explicit Display and Kanban insertion positions; cross-Tab moves preserve
+  the current flat Display position and append to the matching destination Kanban queue; Tab
+  deletion discards each owned Placement before removing the empty Tab. Shared, overridden,
+  or otherwise advanced graph state remains read-only where flat controls cannot represent it.
 - Make the unit-test gate fail closed before collection, block Qt-coupled imports, and fail
   instead of silently succeeding when pytest is unavailable.
 - Persist one `Default Workspace`, stable Workspace and Tab identities, ID-based Tile
   membership, and an independent `application.title` while retaining flat Tile behavior and
   existing launcher settings.
-- Construct missing and reset configuration as native version 1, load valid current version 1
-  without a startup write, and reject invalid identity graphs rather than repairing or
-  regenerating IDs.
+- Construct missing and reset configuration as complete version 2, load valid current version 2
+  without a startup write, and reject invalid graphs rather than repairing or regenerating IDs.
+- Publish first-run configuration only while the destination remains absent, preserving a
+  concurrently created configuration instead of overwriting it.
 - Give malformed, explicit-zero, unsupported, and migration-failure outcomes distinct fixed
   Exit-only handling without changing the existing corrupt-configuration Exit / Preserve and
   Reset flow.
-- Guard the normal implicit-v0 normalization save with the successfully classified source
-  snapshot so a concurrent replacement is not overwritten by stale legacy state.
+- Keep the compatibility-only implicit-legacy normalization save guarded by the successfully
+  classified source snapshot so a concurrent replacement is not overwritten by stale state.
 - Add active-tab tile selection with a selected count, Select all, Clear selection, and Done
   controls while preventing tile launches, context-menu changes, and dragging during selection.
 - Refresh selected tile names and icons only after overwrite confirmation; title and favicon
@@ -54,9 +59,8 @@
 - Clarify ADR-0001 so schema version 1 is the Q5 identity-only Workspace/Tab format and the
   unchanged full Resource/Placement/DeviceBinding graph is schema version 2; the Windows
   Content Triage “v1” product milestone name remains unchanged.
-- Document the deterministic schema-v1-to-v2 URL-Tile migration and complete schema-v2
-  contract; this documentation-only change does not alter runtime behavior, activate schema v2,
-  or change persisted state.
+- Document the deterministic schema-v1-to-v2 URL-Tile migration, complete schema-v2 contract,
+  and the bounded flat-UI activation policy that preserves unexposed graph state.
 
 ## v0.3.5 - 2026-06-17
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ endif
 # Always drive pip via the interpreter so self‑upgrade works on Windows too
 PIP := $(PY) -m pip
 
-# Compute once per make invocation
-ONLINE := $(shell $(PY) tools/netprobe.py >/dev/null 2>&1 && echo 1 || echo 0)
+# Compute only for targets that explicitly need dependency installation.
+ONLINE = $(shell $(PY) tools/netprobe.py >/dev/null 2>&1 && echo 1 || echo 0)
 
 help: ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "%-14s %s\n", $$1, $$2}'
@@ -88,17 +88,10 @@ test: install-dev ## Run the full test suite (default)
 
 # Exact fail-closed unit-only filter:
 .PHONY: test_unit
-test_unit: install-dev ensure-test-deps ## Run unit tests only (exclude slow/integration/e2e/etc.)
-	@set -euo pipefail; \
-	if $(PY) -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)" >/dev/null 2>&1; then \
-	  echo "[test_unit] running pytest (unit filter)"; \
-	  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q tests \
-	    -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' \
-	    -k 'not multi_window and not tray and not lazy_refresh'; \
-	else \
-	  echo "[test_unit] pytest unavailable after dependency setup → aborting"; \
-	  exit 1; \
-	fi
+test_unit: ## Run hermetic unit tests only (exclude slow/integration/e2e/etc.)
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q tests \
+	  -m 'unit and not (integration or e2e or slow or network or gui or qt or gl or x11 or wayland or docker or gpu or perf or flaky)' \
+	  -k 'not multi_window and not tray and not lazy_refresh'
 
 .PHONY: smoke
 smoke: install-dev ## Import core modules to ensure environment is sane
@@ -121,4 +114,4 @@ reassemble_wheels:
 
 # One-liner that mirrors the Codex task: reassemble + force offline install + run tests
 test_unit_offline: reassemble_wheels
-	@PIP_NO_INDEX=1 PIP_FIND_LINKS="vendor/wheelhouse-linux" $(MAKE) ONLINE=1 test_unit
+	@PIP_NO_INDEX=1 PIP_FIND_LINKS="vendor/wheelhouse-linux" $(MAKE) ONLINE=1 install-dev ensure-test-deps test_unit

--- a/README.md
+++ b/README.md
@@ -115,20 +115,27 @@ SPDX-License-Identifier: Apache-2.0
 
 ### Configuration versions and recovery
 
-DesktopTileLauncher reads at most 4 MiB of `config.json` for normal UTF-8 and
-JSON parsing. Production persists the explicit identity-only schema version 1:
-one Workspace, stable Workspace and Tab UUIDs, ID-based Tile membership, and the
-existing flat Tile and launcher settings. Legacy configuration without
-`schema_version` is version 0 and migrates transactionally through the registered
-pure v0-to-v1 step. Migration creates exactly one `Default Workspace`; the
-launcher title is preserved independently as `application.title`.
+DesktopTileLauncher reads at most 4 MiB of `config.json` for UTF-8 and JSON
+parsing and rejects duplicate JSON object members at any nesting depth.
+Production persists complete schema version 2: stable Workspace and Tab
+identities, URL Resources, per-Tab Placements and independent orders, and
+portable or device-specific settings represented as DeviceBindings. The
+complete validated graph remains authoritative even when the current flat UI
+does not expose every part of it.
+
+Legacy configuration without `schema_version` is version 0. Explicit version 1
+is the identity-only intermediate format. The registered pure consecutive steps
+migrate version 0 to version 1 and version 1 to version 2 transactionally.
+Migration creates exactly one `Default Workspace`; the launcher title is
+preserved independently as `application.title`. Each legacy Tile becomes one
+distinct URL Resource and Placement, preserving its effective appearance,
+launch behavior, Tab membership, and per-Tab order.
 
 An explicit `schema_version` of 0 is invalid. A malformed version value or any
-unsupported newer version, including the deferred full-graph version 2, receives
-fixed **Exit**-only handling before legacy construction, normalization, or
-saving. Invalid current version 1 and migration failures also use fixed
-Exit-only handling. These version and migration cases never offer Preserve and
-Reset.
+unsupported version newer than 2 receives fixed **Exit**-only handling before
+legacy construction, normalization, or saving. Invalid current version 2,
+invalid version 1 source state, and migration failures also use fixed Exit-only
+handling. These version and migration cases never offer Preserve and Reset.
 
 The existing recovery choices remain unchanged for the established corrupt or
 unreadable configuration categories. Startup offers exactly **Exit** or
@@ -142,17 +149,17 @@ configuration is installed atomically. A reset is not attempted when copying,
 verification, or the final source-change check fails. Verified recovery copies
 are never overwritten or deleted automatically.
 
-The Qt-free migration harness runs the pure deterministic v0-to-v1 step and is
-ready for future consecutive registered steps. It validates the source before
-preservation; a source-validation rejection creates no recovery artifact and
-performs no write. When at least one step will run, the harness preserves and
-independently verifies one exact recovery copy before the first step, validates
-every detached intermediate and target document, and writes deterministic
-UTF-8 JSON through a guarded atomic replacement. Candidate JSON preserves
-non-ASCII text, sorts keys, uses two-space indentation and LF line endings,
-rejects non-finite numbers, and has no trailing newline. The harness reverifies
-both the source and recovery copy immediately before replacement, then reloads
-and validates the installed candidate.
+The Qt-free migration harness runs the registered pure deterministic v0-to-v1
+and v1-to-v2 steps. It validates the source before preservation; a
+source-validation rejection creates no recovery artifact and performs no write.
+When at least one step will run, the harness preserves and independently verifies
+one exact recovery copy before the first step, validates every detached
+intermediate and target document, and writes deterministic UTF-8 JSON through a
+guarded atomic replacement. Candidate JSON preserves non-ASCII text, sorts keys,
+uses two-space indentation and LF line endings, rejects non-finite numbers, and
+has no trailing newline. The harness reverifies both the source and recovery copy
+immediately before replacement, then reloads and validates the installed
+candidate.
 
 After replacement, the harness must successfully reload the exact candidate
 bytes before treating the installed file as transaction-owned. Retention and
@@ -170,11 +177,32 @@ that cannot be completed or verified also fails closed. Published recovery
 copies and failed candidates are private, never overwritten, and never deleted
 automatically.
 
-A valid current version 1 file loads directly without a startup normalization
-write and never passes through repair-oriented legacy normalization. Workspace
-and Tab IDs are not regenerated while loading, saving, or restarting. Actual
-user mutations persist one complete strictly validated version 1 document
-through the shared atomic-write path.
+A valid current version 2 file loads directly without a startup normalization
+write and never passes through repair-oriented legacy normalization. Workspace,
+Tab, Resource, Placement, and DeviceBinding IDs are not regenerated while
+loading, saving, or restarting. Missing and reset configuration is installed as
+a complete validated version 2 document. First-run publication is exclusive: if another
+process creates `config.json` after the missing-file check, that file is retained and this
+startup fails safely instead of replacing it.
+
+Permitted flat-UI changes produce a detached candidate from the complete graph,
+are saved atomically, and replace the authoritative graph only after persistence
+succeeds. Add Tile appends a new `in_use` Placement to both Display and In Use
+Kanban order; Duplicate Tile
+inserts a distinct copied Resource and Placement after its source in both orders and copies
+all of the source Placement's launch bindings under fresh binding IDs;
+and URL import appends its batch in reviewed source order to both. A cross-Tab
+move uses the destination position produced by the current flat Tile order and
+appends to the matching destination Kanban queue. Delete Tab first discards each
+owned Placement and its Placement DeviceBindings, retaining referenced Resources
+as valid orphans, before removing the empty Tab.
+
+Resource sharing, presentation overrides, and other advanced graph state that
+the flat controls cannot represent losslessly remain read-only in those controls.
+Unsupported mutations are disabled or rejected rather than flattening the
+document. Unexposed Workspaces, archived or filtered state, independent orders,
+bindings, extensions, and entity identities remain preserved across permitted
+saves.
 
 Migration recovery is not journaled. A process interruption after an atomic
 candidate replacement but before post-write verification or rollback can leave

--- a/config_migration.py
+++ b/config_migration.py
@@ -18,6 +18,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Final, Generic, Protocol, TypeAlias, TypeVar, cast
 
+import config_migration_v2 as migration_v2
+import config_schema_v2 as schema_v2
 from config_persistence import atomic_write_bytes, atomic_write_text
 from config_recovery import (
     MAX_CONFIG_BYTES,
@@ -1626,7 +1628,7 @@ class ConfigurationMigrationError(Exception):
 
     @classmethod
     def unexpected_success(cls) -> ConfigurationMigrationError:
-        """Fail safely if the dormant registry returns an unsupported app result."""
+        """Fail safely if the production registry returns an unsupported app result."""
 
         return cls(
             StartupNoticeCategory.MIGRATION_FAILED,
@@ -1679,13 +1681,38 @@ def _validate_production_v1(
     return ValidationAccepted() if validate_v1(document) else ValidationRejected()
 
 
+def _migrate_production_v1_to_v2(
+    document: Mapping[str, JsonValue],
+) -> StepDecision:
+    candidate = migration_v2.migrate_v1_to_v2(document)
+    return (
+        StepApplied(cast(Mapping[str, JsonValue], candidate))
+        if candidate is not None
+        else StepRejected()
+    )
+
+
+def _validate_production_v2(
+    document: Mapping[str, JsonValue],
+) -> ValidationDecision:
+    return (
+        ValidationAccepted()
+        if schema_v2.validate_v2(document)
+        else ValidationRejected()
+    )
+
+
 PRODUCTION_REGISTRY_SPEC: Final = RegistrySpec(
     0,
-    1,
-    (MigrationStep(0, 1, "legacy_to_v1", _migrate_production_v0_to_v1),),
+    2,
+    (
+        MigrationStep(0, 1, "legacy_to_v1", _migrate_production_v0_to_v1),
+        MigrationStep(1, 2, "v1_to_v2", _migrate_production_v1_to_v2),
+    ),
     (
         VersionValidator(0, _validate_production_v0),
         VersionValidator(1, _validate_production_v1),
+        VersionValidator(2, _validate_production_v2),
     ),
 )
 _production_registry_result = validate_registry(PRODUCTION_REGISTRY_SPEC)

--- a/config_migration_v2.py
+++ b/config_migration_v2.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Dormant, pure schema-version 1 to schema-version 2 transformation.
+"""Pure schema-version 1 to schema-version 2 transformation.
 
 This module constructs one complete URL-only schema-v2 candidate from an
 already detached strict schema-v1 logical graph.  It deliberately performs no

--- a/config_persistence.py
+++ b/config_persistence.py
@@ -6,7 +6,7 @@ import tempfile
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Protocol, TypeVar, cast
+from typing import Literal, Protocol, TypeAlias, TypeVar, cast
 
 
 class _SyncableTextStream(Protocol):
@@ -30,6 +30,7 @@ class _SyncableBinaryStream(Protocol):
 
 
 _StreamT = TypeVar("_StreamT", _SyncableTextStream, _SyncableBinaryStream)
+_ExclusivePublishResult: TypeAlias = Literal["consumed", "linked"]
 
 
 def _write_and_sync(stream: _SyncableTextStream, text: str) -> None:
@@ -123,3 +124,50 @@ def atomic_write_bytes(
         _write_bytes_and_sync(stream, data)
 
     _atomic_write(path, temporary, write_and_sync, before_replace=before_replace)
+
+
+def _publish_exclusive(
+    temporary_path: Path,
+    path: Path,
+) -> _ExclusivePublishResult:
+    """Publish without replacement and report the temporary name's lifecycle."""
+
+    if os.name == "nt":
+        os.rename(temporary_path, path)
+        return "consumed"
+    os.link(temporary_path, path)
+    return "linked"
+
+
+def atomic_create_bytes(path: Path, data: bytes) -> None:
+    """Atomically publish exact bytes only when *path* is still absent."""
+
+    temporary = cast(
+        AbstractContextManager[_SyncableBinaryStream],
+        tempfile.NamedTemporaryFile(
+            mode="w+b",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ),
+    )
+    temporary_path: Path | None = None
+    try:
+        with temporary as stream:
+            temporary_path = Path(stream.name)
+            _write_bytes_and_sync(stream, data)
+        publish_result = _publish_exclusive(temporary_path, path)
+        if publish_result == "consumed":
+            temporary_path = None
+        else:
+            linked_temporary_path = temporary_path
+            temporary_path = None
+            linked_temporary_path.unlink()
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                # Preserve the original write/publication error and never touch *path*.
+                pass

--- a/config_recovery.py
+++ b/config_recovery.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Bounded, Qt-free loading and explicit recovery for ``config.json``.
 
-Normal parsing admits at most four MiB of encoded JSON.  Explicit recovery may
+Duplicate-aware parsing admits at most four MiB of encoded JSON.  Explicit recovery may
 stream a larger regular file with bounded memory after the user has chosen to
 preserve it.  The final source comparison and ``os.replace`` are adjacent, but
 portable Python does not provide a kernel-level compare-and-swap for file
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Final, Generic, Literal, Protocol, TypeAlias, TypeVar, cast
 
 from config_persistence import atomic_write_text
+from config_schema_v2 import reject_duplicate_json_members
 
 MAX_CONFIG_BYTES: Final = 4 * 1024 * 1024
 _IO_CHUNK_BYTES: Final = 64 * 1024
@@ -526,7 +527,7 @@ def load_raw_config(
         return ConfigRecoveryRequired(ConfigLoadFailureCategory.INVALID_UTF8, snapshot)
 
     try:
-        parsed = json.loads(decoded)
+        parsed = json.loads(decoded, object_pairs_hook=reject_duplicate_json_members)
     except (ValueError, RecursionError):
         return ConfigRecoveryRequired(
             ConfigLoadFailureCategory.MALFORMED_JSON, snapshot

--- a/config_runtime_state_v2.py
+++ b/config_runtime_state_v2.py
@@ -389,6 +389,7 @@ def _valid_tile_values(tile: object, tab_ids: set[str]) -> bool:
         )
     ):
         return False
+    open_target: object = tile.open_target
     return (
         _is_utf8_text(tile.tab_id)
         and tile.tab_id in tab_ids
@@ -398,8 +399,8 @@ def _valid_tile_values(tile: object, tab_ids: set[str]) -> bool:
         and _is_utf8_text(tile.background_color)
         and (tile.browser is None or _is_utf8_text(tile.browser))
         and (tile.chrome_profile is None or _is_utf8_text(tile.chrome_profile))
-        and type(tile.open_target) is str
-        and tile.open_target in ("tab", "window")
+        and type(open_target) is str
+        and open_target in ("tab", "window")
     )
 
 

--- a/config_runtime_state_v2.py
+++ b/config_runtime_state_v2.py
@@ -1,0 +1,862 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qt-free schema-v2 state bridge for the launcher's current flat-grid UI.
+
+The complete validated graph remains authoritative.  This module projects the
+legacy-compatible part used by today's UI and synchronizes a detached flat edit
+back into that graph without rebuilding or discarding unrelated v2 state.
+Graphs containing semantics the flat UI cannot faithfully edit are projected
+read-only.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias, cast
+from uuid import UUID, uuid4
+
+import config_migration_v2 as migration_v2
+import config_runtime_v2 as runtime
+import config_schema as v1
+import config_schema_v2 as v2
+
+_ID_ALLOCATION_ATTEMPTS = 32
+_DEFAULT_COLUMNS = 5
+_DEFAULT_AUTO_FIT = True
+
+FlatStateFailureCategory: TypeAlias = Literal[
+    "invalid_graph",
+    "unsupported_graph",
+    "invalid_state",
+    "identity_allocation_failure",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class FlatStateRejected:
+    """A graph or projected edit failed without exposing persisted content."""
+
+    category: FlatStateFailureCategory
+
+
+@dataclass(frozen=True, slots=True)
+class FlatTileState:
+    """One flat-grid Tile projected from, or destined for, a v2 Placement."""
+
+    placement_id: str | None = field(repr=False)
+    resource_id: str | None = field(repr=False)
+    launch_binding_id: str | None = field(repr=False)
+    name: str = field(repr=False)
+    url: str = field(repr=False)
+    tab_id: str = field(repr=False)
+    icon: str | None = field(repr=False)
+    background_color: str = field(repr=False)
+    browser: str | None = field(repr=False)
+    chrome_profile: str | None = field(repr=False)
+    open_target: v2.OpenTarget = field(repr=False)
+    duplicate_source_placement_id: str | None = field(
+        default=None,
+        repr=False,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FlatTabState:
+    """One active Tab exposed by the current flat-grid UI."""
+
+    id: str = field(repr=False)
+    name: str = field(repr=False)
+    hidden: bool
+
+
+@dataclass(frozen=True, slots=True)
+class FlatWorkspaceState:
+    """The default Workspace projection used by today's launcher UI."""
+
+    title: str = field(repr=False)
+    workspace_id: str = field(repr=False)
+    workspace_name: str = field(repr=False)
+    tabs: tuple[FlatTabState, ...] = field(repr=False)
+    tab_order: tuple[str, ...] = field(repr=False)
+    tiles: tuple[FlatTileState, ...] = field(repr=False)
+    columns: int
+    auto_fit: bool
+    window_x: int | None
+    window_y: int | None
+    window_w: int | None
+    window_h: int | None
+    editable: bool
+
+
+@dataclass(frozen=True, slots=True)
+class FlatTileIdentity:
+    """Persisted identities assigned to one projected Tile after a save."""
+
+    placement_id: str = field(repr=False)
+    resource_id: str = field(repr=False)
+    launch_binding_id: str = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class FlatWorkspaceUpdate:
+    """A complete validated candidate plus identities aligned to input Tiles."""
+
+    document: v2.Root = field(repr=False)
+    tile_identities: tuple[FlatTileIdentity, ...] = field(repr=False)
+
+
+FlatWorkspaceProjectionResult: TypeAlias = FlatWorkspaceState | FlatStateRejected
+FlatWorkspaceUpdateResult: TypeAlias = FlatWorkspaceUpdate | FlatStateRejected
+_JsonContainer: TypeAlias = list[v2.StrictJsonValue] | dict[str, v2.StrictJsonValue]
+
+
+class NativeV2ConstructionError(ValueError):
+    """Native schema-v2 construction failed with one fixed safe category."""
+
+    def __init__(
+        self, category: Literal["identity_allocation_failure", "validation_failure"]
+    ):
+        self.category = category
+        super().__init__(category)
+
+
+def _is_utf8_text(value: object) -> bool:
+    if type(value) is not str:
+        return False
+    try:
+        value.encode("utf-8")
+    except UnicodeError:
+        return False
+    return True
+
+
+def _canonical_uuid(value: object) -> str | None:
+    if type(value) is not str:
+        return None
+    try:
+        parsed = UUID(value)
+    except ValueError:
+        return None
+    canonical = str(parsed)
+    return canonical if value == canonical else None
+
+
+def _allocator_uuid4(value: object) -> str | None:
+    if isinstance(value, UUID):
+        parsed = value
+    elif type(value) is str:
+        canonical = _canonical_uuid(value)
+        if canonical is None:
+            return None
+        parsed = UUID(canonical)
+    else:
+        return None
+    return str(parsed) if parsed.version == 4 else None
+
+
+def _allocate_id(id_factory: v1.Uuid4Allocator, blocked: set[str]) -> str | None:
+    for _ in range(_ID_ALLOCATION_ATTEMPTS):
+        try:
+            candidate = _allocator_uuid4(id_factory())
+        except Exception:
+            return None
+        if candidate is not None and candidate not in blocked:
+            blocked.add(candidate)
+            return candidate
+    return None
+
+
+def _clone_strict_json(value: v2.StrictJsonValue) -> v2.StrictJsonValue:
+    """Clone an exact strict-JSON subtree without using the Python call stack."""
+
+    if type(value) is list:
+        cloned: _JsonContainer = []
+    elif type(value) is dict:
+        cloned = {}
+    else:
+        return value
+
+    pending: list[tuple[_JsonContainer, _JsonContainer]] = [(value, cloned)]
+    while pending:
+        source, target = pending.pop()
+        if type(source) is list:
+            target_items = cast(list[v2.StrictJsonValue], target)
+            for item in source:
+                if type(item) is list:
+                    child_items: list[v2.StrictJsonValue] = []
+                    target_items.append(child_items)
+                    pending.append((item, child_items))
+                elif type(item) is dict:
+                    child_object: dict[str, v2.StrictJsonValue] = {}
+                    target_items.append(child_object)
+                    pending.append((item, child_object))
+                else:
+                    target_items.append(item)
+            continue
+
+        source_object = cast(dict[str, v2.StrictJsonValue], source)
+        target_object = cast(dict[str, v2.StrictJsonValue], target)
+        for key, item in source_object.items():
+            if type(item) is list:
+                child_items = []
+                target_object[key] = child_items
+                pending.append((item, child_items))
+            elif type(item) is dict:
+                child_object = {}
+                target_object[key] = child_object
+                pending.append((item, child_object))
+            else:
+                target_object[key] = item
+    return cloned
+
+
+def build_native_v2(id_factory: v1.Uuid4Allocator = uuid4) -> v2.Root:
+    """Build one complete native v2 document without ever persisting v1."""
+
+    try:
+        source = v1.build_native_v1(id_factory)
+    except v1.NativeV1ConstructionError:
+        raise NativeV2ConstructionError("identity_allocation_failure") from None
+    candidate = migration_v2.migrate_v1_to_v2(source)
+    if candidate is None or not v2.validate_v2(candidate):
+        raise NativeV2ConstructionError("validation_failure")
+    return candidate
+
+
+def reserved_entity_ids(document: object) -> frozenset[str]:
+    """Return all entity IDs from a valid graph, or an empty set if invalid."""
+
+    if not v2.validate_v2(document):
+        return frozenset()
+    root = cast(v2.Root, document)
+    return frozenset(
+        item["id"]
+        for definitions in (
+            root["workspaces"],
+            root["tabs"],
+            root["resources"],
+            root["placements"],
+            root["device_bindings"],
+        )
+        for item in definitions
+    )
+
+
+def _portable_bindings(
+    root: v2.Root,
+) -> tuple[
+    dict[str, v2.WorkspaceWindowBinding],
+    dict[str, v2.PlacementLaunchBinding],
+]:
+    windows: dict[str, v2.WorkspaceWindowBinding] = {}
+    launches: dict[str, v2.PlacementLaunchBinding] = {}
+    for binding in root["device_bindings"]:
+        if binding["applicability"]["kind"] != "portable_fallback":
+            continue
+        if binding["subject_kind"] == "workspace":
+            windows[binding["subject_id"]] = binding
+        else:
+            launches[binding["subject_id"]] = binding
+    return windows, launches
+
+
+def _editable_flat_graph(root: v2.Root, workspace_id: str) -> bool:
+    tabs = [tab for tab in root["tabs"] if tab["workspace_id"] == workspace_id]
+    active_tabs = [tab for tab in tabs if tab["lifecycle"] == "active"]
+    active_tab_ids = {tab["id"] for tab in active_tabs}
+    active_placements = [
+        placement
+        for placement in root["placements"]
+        if placement["tab_id"] in active_tab_ids
+    ]
+    resource_uses = Counter(
+        placement["resource_id"] for placement in root["placements"]
+    )
+    windows, launches = _portable_bindings(root)
+    if workspace_id not in windows:
+        return False
+    if any(
+        tab["view_mode"] != "display" or tab["display_filter"] != ["new", "in_use"]
+        for tab in active_tabs
+    ):
+        return False
+    if any(
+        placement["workflow_status"] != "in_use"
+        or placement["label_override"] is not None
+        or placement["icon_override"] is not None
+        or resource_uses[placement["resource_id"]] != 1
+        or placement["id"] not in launches
+        for placement in active_placements
+    ):
+        return False
+    return all(
+        tab["kanban_order"]["new"] == []
+        and tab["kanban_order"]["archived"] == []
+        and set(tab["kanban_order"]["in_use"]) == set(tab["display_order"])
+        for tab in active_tabs
+    )
+
+
+def project_flat_workspace(document: object) -> FlatWorkspaceProjectionResult:
+    """Project the default Workspace and mark unsupported rich graphs read-only."""
+
+    projection = runtime.project_workspace(document)
+    if isinstance(projection, runtime.RuntimeAdapterRejected):
+        return FlatStateRejected("invalid_graph")
+    root = cast(v2.Root, document)
+    workspace_id = projection.id
+    windows, launches = _portable_bindings(root)
+    active_tabs = tuple(tab for tab in projection.tabs if tab.lifecycle == "active")
+    projected_tiles = tuple(
+        placement for tab in active_tabs for placement in tab.displayed_placements
+    )
+    tiles: list[FlatTileState] = []
+    for placement in projected_tiles:
+        settings = placement.launch_settings
+        binding = launches.get(placement.id)
+        tiles.append(
+            FlatTileState(
+                placement_id=placement.id,
+                resource_id=placement.resource_id,
+                launch_binding_id=None if binding is None else binding["id"],
+                name=placement.label,
+                url=placement.url,
+                tab_id=placement.tab_id,
+                icon=placement.icon,
+                background_color=placement.background_color,
+                browser=None if settings is None else settings.browser,
+                chrome_profile=None if settings is None else settings.chrome_profile,
+                open_target="tab" if settings is None else settings.open_target,
+            )
+        )
+    window = projection.window_settings
+    return FlatWorkspaceState(
+        title=projection.application_title,
+        workspace_id=workspace_id,
+        workspace_name=projection.name,
+        tabs=tuple(
+            FlatTabState(tab.id, tab.name, tab.visibility == "hidden")
+            for tab in active_tabs
+        ),
+        tab_order=tuple(tab.id for tab in active_tabs),
+        tiles=tuple(tiles),
+        columns=_DEFAULT_COLUMNS if window is None else window.columns,
+        auto_fit=_DEFAULT_AUTO_FIT if window is None else window.auto_fit,
+        window_x=None if window is None else window.window_x,
+        window_y=None if window is None else window.window_y,
+        window_w=None if window is None else window.window_w,
+        window_h=None if window is None else window.window_h,
+        editable=_editable_flat_graph(root, workspace_id),
+    )
+
+
+def _valid_tab_state(state: FlatWorkspaceState, used_ids: set[str]) -> bool:
+    if type(state.tabs) is not tuple or type(state.tab_order) is not tuple:
+        return False
+    if not state.tabs or any(not isinstance(tab, FlatTabState) for tab in state.tabs):
+        return False
+    for tab in state.tabs:
+        if (
+            _canonical_uuid(tab.id) is None
+            or not _is_utf8_text(tab.name)
+            or not tab.name
+            or type(tab.hidden) is not bool
+        ):
+            return False
+
+    tab_ids = [tab.id for tab in state.tabs]
+    tab_names = [tab.name for tab in state.tabs]
+    if (
+        len(tab_ids) != len(set(tab_ids))
+        or tuple(tab_ids) != state.tab_order
+        or len(tab_names) != len(set(tab_names))
+        or not any(not tab.hidden for tab in state.tabs)
+    ):
+        return False
+    return all(tab_id in used_ids or UUID(tab_id).version == 4 for tab_id in tab_ids)
+
+
+def _valid_tile_values(tile: object, tab_ids: set[str]) -> bool:
+    if not isinstance(tile, FlatTileState):
+        return False
+    if any(
+        value is not None and _canonical_uuid(value) is None
+        for value in (
+            tile.placement_id,
+            tile.resource_id,
+            tile.launch_binding_id,
+            tile.duplicate_source_placement_id,
+        )
+    ):
+        return False
+    return (
+        _is_utf8_text(tile.tab_id)
+        and tile.tab_id in tab_ids
+        and _is_utf8_text(tile.name)
+        and _is_utf8_text(tile.url)
+        and (tile.icon is None or _is_utf8_text(tile.icon))
+        and _is_utf8_text(tile.background_color)
+        and (tile.browser is None or _is_utf8_text(tile.browser))
+        and (tile.chrome_profile is None or _is_utf8_text(tile.chrome_profile))
+        and type(tile.open_target) is str
+        and tile.open_target in ("tab", "window")
+    )
+
+
+def _valid_new_tile_positions(tiles: tuple[FlatTileState, ...]) -> bool:
+    """Require flat Add/Import suffixes and source-adjacent Duplicates."""
+
+    tiles_by_tab: dict[str, list[FlatTileState]] = {}
+    for tile in tiles:
+        tiles_by_tab.setdefault(tile.tab_id, []).append(tile)
+
+    for ordered_tiles in tiles_by_tab.values():
+        append_started = False
+        previous: FlatTileState | None = None
+        for tile in ordered_tiles:
+            if tile.placement_id is not None:
+                if append_started:
+                    return False
+            elif tile.duplicate_source_placement_id is None:
+                append_started = True
+            else:
+                source_id = tile.duplicate_source_placement_id
+                follows_source = previous is not None and (
+                    previous.placement_id == source_id
+                    or (
+                        previous.placement_id is None
+                        and previous.duplicate_source_placement_id == source_id
+                    )
+                )
+                if append_started or not follows_source:
+                    return False
+            previous = tile
+    return True
+
+
+def _duplicate_values_match(tile: FlatTileState, source: FlatTileState) -> bool:
+    return (
+        tile.name,
+        tile.url,
+        tile.tab_id,
+        tile.icon,
+        tile.background_color,
+        tile.browser,
+        tile.chrome_profile,
+        tile.open_target,
+    ) == (
+        source.name,
+        source.url,
+        source.tab_id,
+        source.icon,
+        source.background_color,
+        source.browser,
+        source.chrome_profile,
+        source.open_target,
+    )
+
+
+def _full_tab_order(
+    existing: list[str],
+    old_active_ids: set[str],
+    desired_active_ids: list[str],
+) -> list[str]:
+    desired_existing = {item for item in desired_active_ids if item in old_active_ids}
+    desired_iter = iter(desired_active_ids)
+    retained = [
+        item
+        for item in existing
+        if item not in old_active_ids or item in desired_existing
+    ]
+    reordered = [
+        next(desired_iter) if item in old_active_ids else item for item in retained
+    ]
+    reordered.extend(desired_iter)
+    return reordered
+
+
+def synchronize_flat_workspace(
+    document: object,
+    state: object,
+    *,
+    id_factory: v1.Uuid4Allocator = uuid4,
+) -> FlatWorkspaceUpdateResult:
+    """Apply one current-UI edit to a detached, complete v2 graph candidate."""
+
+    base_state = project_flat_workspace(document)
+    if isinstance(base_state, FlatStateRejected):
+        return base_state
+    if not base_state.editable:
+        return FlatStateRejected("unsupported_graph")
+    if not isinstance(state, FlatWorkspaceState):
+        return FlatStateRejected("invalid_state")
+    if state.workspace_id != base_state.workspace_id:
+        return FlatStateRejected("invalid_state")
+    cloned = runtime.clone_document(document)
+    if isinstance(cloned, runtime.RuntimeAdapterRejected):
+        return FlatStateRejected("invalid_graph")
+    root = cloned
+    used_ids = set(reserved_entity_ids(root))
+    if (
+        not _is_utf8_text(state.title)
+        or not _is_utf8_text(state.workspace_name)
+        or not state.workspace_name
+        or type(state.columns) is not int
+        or type(state.auto_fit) is not bool
+        or any(
+            value is not None and type(value) is not int
+            for value in (
+                state.window_x,
+                state.window_y,
+                state.window_w,
+                state.window_h,
+            )
+        )
+        or not _valid_tab_state(state, used_ids)
+    ):
+        return FlatStateRejected("invalid_state")
+
+    workspace = next(
+        item for item in root["workspaces"] if item["id"] == state.workspace_id
+    )
+    old_tabs = {
+        tab["id"]: tab
+        for tab in root["tabs"]
+        if tab["workspace_id"] == state.workspace_id and tab["lifecycle"] == "active"
+    }
+    old_active_ids = set(old_tabs)
+    desired_tabs = {tab.id: tab for tab in state.tabs}
+    new_tab_ids = set(desired_tabs) - old_active_ids
+    if any(tab_id in used_ids for tab_id in new_tab_ids):
+        return FlatStateRejected("invalid_state")
+    used_ids.update(new_tab_ids)
+    if (
+        type(state.tiles) is not tuple
+        or not all(_valid_tile_values(tile, set(desired_tabs)) for tile in state.tiles)
+        or not _valid_new_tile_positions(state.tiles)
+    ):
+        return FlatStateRejected("invalid_state")
+
+    placements = {item["id"]: item for item in root["placements"]}
+    resources = {item["id"]: item for item in root["resources"]}
+    _, launches = _portable_bindings(root)
+    source_tiles = {
+        tile.placement_id: tile
+        for tile in base_state.tiles
+        if tile.placement_id is not None
+    }
+    bindings_by_placement: dict[str, list[v2.PlacementLaunchBinding]] = {}
+    for binding in root["device_bindings"]:
+        if binding["subject_kind"] != "placement":
+            continue
+        bindings_by_placement.setdefault(binding["subject_id"], []).append(binding)
+    managed_placement_ids = {
+        item["id"] for item in root["placements"] if item["tab_id"] in old_active_ids
+    }
+    seen_placements: set[str] = set()
+    prepared_tiles: list[tuple[FlatTileState, FlatTileIdentity]] = []
+    new_definitions: list[
+        tuple[v2.Resource, v2.Placement, list[v2.PlacementLaunchBinding]]
+    ] = []
+    for tile in state.tiles:
+        if tile.placement_id is None:
+            if tile.resource_id is not None or tile.launch_binding_id is not None:
+                return FlatStateRejected("invalid_state")
+            duplicate_source_id = tile.duplicate_source_placement_id
+            source_tile = (
+                None
+                if duplicate_source_id is None
+                else source_tiles.get(duplicate_source_id)
+            )
+            if duplicate_source_id is not None and (
+                _canonical_uuid(duplicate_source_id) is None
+                or source_tile is None
+                or not _duplicate_values_match(tile, source_tile)
+            ):
+                return FlatStateRejected("invalid_state")
+            resource_id = _allocate_id(id_factory, used_ids)
+            if resource_id is None:
+                return FlatStateRejected("identity_allocation_failure")
+            placement_id = _allocate_id(id_factory, used_ids)
+            if placement_id is None:
+                return FlatStateRejected("identity_allocation_failure")
+            icon = (
+                None
+                if tile.icon is None
+                else v2.LegacyStringIcon(kind="legacy_string", value=tile.icon)
+            )
+            resource = v2.Resource(
+                id=resource_id,
+                kind="url",
+                target=v2.UrlTarget(url=tile.url),
+                default_label=tile.name,
+                default_icon=icon,
+                extensions={},
+            )
+            placement = v2.Placement(
+                id=placement_id,
+                resource_id=resource_id,
+                tab_id=tile.tab_id,
+                label_override=None,
+                icon_override=None,
+                background_color=tile.background_color,
+                workflow_status="in_use",
+                extensions={},
+            )
+            new_bindings: list[v2.PlacementLaunchBinding] = []
+            portable_binding_id: str | None = None
+            if duplicate_source_id is None:
+                binding_id = _allocate_id(id_factory, used_ids)
+                if binding_id is None:
+                    return FlatStateRejected("identity_allocation_failure")
+                new_bindings.append(
+                    v2.PlacementLaunchBinding(
+                        id=binding_id,
+                        subject_kind="placement",
+                        subject_id=placement_id,
+                        binding_kind="launch",
+                        applicability=v2.PortableFallback(kind="portable_fallback"),
+                        settings=v2.UrlLaunchSettings(
+                            browser=tile.browser,
+                            chrome_profile=tile.chrome_profile,
+                            open_target=tile.open_target,
+                        ),
+                        extensions={},
+                    )
+                )
+                portable_binding_id = binding_id
+            else:
+                for source_binding in bindings_by_placement.get(
+                    duplicate_source_id,
+                    [],
+                ):
+                    binding_id = _allocate_id(id_factory, used_ids)
+                    if binding_id is None:
+                        return FlatStateRejected("identity_allocation_failure")
+                    copied_binding = cast(
+                        v2.PlacementLaunchBinding,
+                        _clone_strict_json(
+                            cast(v2.StrictJsonValue, source_binding),
+                        ),
+                    )
+                    copied_binding["id"] = binding_id
+                    copied_binding["subject_id"] = placement_id
+                    new_bindings.append(copied_binding)
+                    if copied_binding["applicability"]["kind"] == "portable_fallback":
+                        portable_binding_id = binding_id
+                if portable_binding_id is None:
+                    return FlatStateRejected("invalid_state")
+            new_definitions.append((resource, placement, new_bindings))
+            prepared_tiles.append(
+                (
+                    tile,
+                    FlatTileIdentity(
+                        placement_id,
+                        resource_id,
+                        portable_binding_id,
+                    ),
+                )
+            )
+            continue
+
+        placement_id = tile.placement_id
+        if (
+            tile.duplicate_source_placement_id is not None
+            or placement_id in seen_placements
+            or placement_id not in managed_placement_ids
+        ):
+            return FlatStateRejected("invalid_state")
+        seen_placements.add(placement_id)
+        placement = placements[placement_id]
+        existing_binding = launches.get(placement_id)
+        if (
+            tile.resource_id != placement["resource_id"]
+            or existing_binding is None
+            or tile.launch_binding_id != existing_binding["id"]
+        ):
+            return FlatStateRejected("invalid_state")
+        prepared_tiles.append(
+            (
+                tile,
+                FlatTileIdentity(
+                    placement_id,
+                    placement["resource_id"],
+                    existing_binding["id"],
+                ),
+            )
+        )
+
+    current_tiles = {
+        tile.placement_id: tile
+        for tile, _identity in prepared_tiles
+        if tile.placement_id is not None
+    }
+    for tile, _identity in prepared_tiles:
+        source_id = tile.duplicate_source_placement_id
+        if source_id is None:
+            continue
+        current_source = current_tiles.get(source_id)
+        base_source = source_tiles.get(source_id)
+        if (
+            source_id not in seen_placements
+            or current_source is None
+            or base_source is None
+            or not _duplicate_values_match(current_source, base_source)
+        ):
+            return FlatStateRejected("invalid_state")
+
+    removed_placements = managed_placement_ids - seen_placements
+    removed_tabs = old_active_ids - set(desired_tabs)
+    root["placements"] = [
+        item for item in root["placements"] if item["id"] not in removed_placements
+    ]
+    root["device_bindings"] = [
+        item
+        for item in root["device_bindings"]
+        if not (
+            item["subject_kind"] == "placement"
+            and item["subject_id"] in removed_placements
+        )
+    ]
+    root["tabs"] = [item for item in root["tabs"] if item["id"] not in removed_tabs]
+
+    root["application"]["title"] = state.title
+    workspace["name"] = state.workspace_name
+    workspace["tab_order"] = _full_tab_order(
+        workspace["tab_order"],
+        old_active_ids,
+        list(state.tab_order),
+    )
+    candidate_tabs = {item["id"]: item for item in root["tabs"]}
+    for tab_id, desired in desired_tabs.items():
+        if tab_id in old_tabs:
+            tab = candidate_tabs[tab_id]
+            tab["name"] = desired.name
+            tab["visibility"] = "hidden" if desired.hidden else "visible"
+            continue
+        tab = v2.Tab(
+            id=tab_id,
+            workspace_id=state.workspace_id,
+            name=desired.name,
+            visibility="hidden" if desired.hidden else "visible",
+            lifecycle="active",
+            view_mode="display",
+            display_filter=["new", "in_use"],
+            display_order=[],
+            kanban_order=v2.KanbanOrder(new=[], in_use=[], archived=[]),
+            extensions={},
+        )
+        root["tabs"].append(tab)
+        candidate_tabs[tab_id] = tab
+
+    windows, _ = _portable_bindings(root)
+    window_binding = windows[state.workspace_id]
+    window_binding["settings"] = v2.WindowSettings(
+        columns=state.columns,
+        auto_fit=state.auto_fit,
+        window_x=state.window_x,
+        window_y=state.window_y,
+        window_w=state.window_w,
+        window_h=state.window_h,
+    )
+
+    for resource, placement, bindings in new_definitions:
+        root["resources"].append(resource)
+        root["placements"].append(placement)
+        resources[resource["id"]] = resource
+        placements[placement["id"]] = placement
+        for binding in bindings:
+            root["device_bindings"].append(binding)
+            if binding["applicability"]["kind"] == "portable_fallback":
+                launches[placement["id"]] = binding
+
+    desired_by_tab: dict[str, list[str]] = {tab_id: [] for tab_id in desired_tabs}
+    old_tab_by_placement = {
+        placement_id: placements[placement_id]["tab_id"]
+        for placement_id in seen_placements
+    }
+    identities: list[FlatTileIdentity] = []
+    duplicate_sources: dict[str, str] = {}
+    appended_by_tab: dict[str, list[str]] = {tab_id: [] for tab_id in desired_tabs}
+    moved_by_tab: dict[str, list[str]] = {tab_id: [] for tab_id in desired_tabs}
+    for tile, identity in prepared_tiles:
+        placement = placements[identity.placement_id]
+        resource = resources[identity.resource_id]
+        binding = launches[identity.placement_id]
+        old_tab_id = old_tab_by_placement.get(identity.placement_id)
+        if old_tab_id is None:
+            if tile.duplicate_source_placement_id is None:
+                appended_by_tab[tile.tab_id].append(identity.placement_id)
+            else:
+                duplicate_sources[identity.placement_id] = (
+                    tile.duplicate_source_placement_id
+                )
+        elif old_tab_id != tile.tab_id:
+            moved_by_tab[tile.tab_id].append(identity.placement_id)
+        placement["tab_id"] = tile.tab_id
+        placement["background_color"] = tile.background_color
+        resource["target"]["url"] = tile.url
+        resource["default_label"] = tile.name
+        resource["default_icon"] = (
+            None
+            if tile.icon is None
+            else v2.LegacyStringIcon(kind="legacy_string", value=tile.icon)
+        )
+        binding["settings"] = v2.UrlLaunchSettings(
+            browser=tile.browser,
+            chrome_profile=tile.chrome_profile,
+            open_target=tile.open_target,
+        )
+        desired_by_tab[tile.tab_id].append(identity.placement_id)
+        identities.append(identity)
+
+    for tab_id, tab in candidate_tabs.items():
+        if tab_id not in desired_tabs:
+            continue
+        old_queue = [
+            placement_id
+            for placement_id in tab["kanban_order"]["in_use"]
+            if placement_id in seen_placements
+            and placements[placement_id]["tab_id"] == tab_id
+        ]
+        for index, placement_id in enumerate(desired_by_tab[tab_id]):
+            source_id = duplicate_sources.get(placement_id)
+            if source_id is None:
+                continue
+            insertion = old_queue.index(source_id) + 1
+            prior_display_ids = set(desired_by_tab[tab_id][:index])
+            while (
+                insertion < len(old_queue)
+                and old_queue[insertion] in prior_display_ids
+                and duplicate_sources.get(old_queue[insertion]) == source_id
+            ):
+                insertion += 1
+            old_queue.insert(insertion, placement_id)
+        tab["display_order"] = desired_by_tab[tab_id]
+        tab["kanban_order"]["new"] = []
+        tab["kanban_order"]["in_use"] = (
+            old_queue + appended_by_tab[tab_id] + moved_by_tab[tab_id]
+        )
+        tab["kanban_order"]["archived"] = []
+
+    if not v2.validate_v2(root):
+        return FlatStateRejected("invalid_state")
+    return FlatWorkspaceUpdate(root, tuple(identities))
+
+
+__all__ = [
+    "FlatStateFailureCategory",
+    "FlatStateRejected",
+    "FlatTabState",
+    "FlatTileIdentity",
+    "FlatTileState",
+    "FlatWorkspaceProjectionResult",
+    "FlatWorkspaceState",
+    "FlatWorkspaceUpdate",
+    "FlatWorkspaceUpdateResult",
+    "NativeV2ConstructionError",
+    "build_native_v2",
+    "project_flat_workspace",
+    "reserved_entity_ids",
+    "synchronize_flat_workspace",
+]

--- a/config_runtime_v2.py
+++ b/config_runtime_v2.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Dormant, Qt-free runtime projections for validated schema-version 2 state.
+"""Qt-free runtime projections for validated schema-version 2 state.
 
 This module resolves the complete persisted graph into immutable values needed
 by the existing URL launcher and metadata-refresh behavior.  It performs no
@@ -94,6 +94,7 @@ class WorkspaceProjection:
 
 WorkspaceProjectionResult: TypeAlias = WorkspaceProjection | RuntimeAdapterRejected
 MetadataRefreshResult: TypeAlias = v2.Root | RuntimeAdapterRejected
+CloneResult: TypeAlias = v2.Root | RuntimeAdapterRejected
 _JsonContainer: TypeAlias = list[v2.StrictJsonValue] | dict[str, v2.StrictJsonValue]
 
 
@@ -385,6 +386,18 @@ def project_workspace(
     )
 
 
+def clone_document(document: object) -> CloneResult:
+    """Return a detached copy of one complete validated schema-v2 graph."""
+
+    graph = _validated_graph(document)
+    if graph is None:
+        return RuntimeAdapterRejected("invalid_graph")
+    return cast(
+        v2.Root,
+        _clone_strict_json(cast(v2.StrictJsonValue, graph.root)),
+    )
+
+
 def apply_metadata_refresh(
     document: object,
     placement_id: str,
@@ -424,6 +437,7 @@ def apply_metadata_refresh(
 
 
 __all__ = [
+    "CloneResult",
     "LaunchSettingsProjection",
     "MetadataRefreshResult",
     "PlacementProjection",
@@ -434,5 +448,6 @@ __all__ = [
     "WorkspaceProjection",
     "WorkspaceProjectionResult",
     "apply_metadata_refresh",
+    "clone_document",
     "project_workspace",
 ]

--- a/config_schema_v2.py
+++ b/config_schema_v2.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Dormant, Qt-free schema-version 2 wire types and strict validation.
+"""Qt-free schema-version 2 wire types and strict validation.
 
 This module deliberately does not parse files, register schema support, allocate
 identities, migrate state, or import production startup and persistence code.
-The object-pairs callback is a dormant capability for a later parser boundary;
-``validate_v2`` accepts only an already-decoded mapping.
+The production parser uses the object-pairs callback before ``validate_v2``
+receives an already-decoded mapping.
 """
 
 from __future__ import annotations
@@ -197,8 +197,8 @@ def reject_duplicate_json_members(
 ) -> dict[str, object]:
     """Build one object or reject a duplicate without exposing its key or value.
 
-    This function is suitable as ``json.loads(..., object_pairs_hook=...)`` but
-    intentionally performs no decoding itself and is not wired into production.
+    This function is used as ``json.loads(..., object_pairs_hook=...)`` and
+    intentionally performs no decoding itself.
     """
 
     result: dict[str, object] = {}

--- a/config_serialization_v2.py
+++ b/config_serialization_v2.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Dormant canonical serialization for complete schema-version 2 candidates."""
+"""Canonical serialization for complete schema-version 2 candidates."""
 
 from __future__ import annotations
 

--- a/docs/adr/0001-vnext-state-and-migration-contract.md
+++ b/docs/adr/0001-vnext-state-and-migration-contract.md
@@ -9,16 +9,17 @@
 
 ## Context
 
-DesktopTileLauncher currently persists one unversioned JSON object represented by
-`LauncherConfig` in `tile_launcher.py`. The current file stores application and window
+At the start of this ADR, DesktopTileLauncher persisted one unversioned JSON object represented
+by `LauncherConfig` in `tile_launcher.py`. That historical file stored application and window
 settings, tiles, tab titles, hidden tab titles, stable tab UUIDs keyed by title, and a
-canonical list of tab UUIDs. A tile identifies its tab by mutable title. The current
-model has no first-class Workspace, Resource, Placement, DeviceBinding, or ImportBatch.
+canonical list of tab UUIDs. A tile identified its tab by mutable title. That model had no
+first-class Workspace, Resource, Placement, DeviceBinding, or ImportBatch. The activation
+amendment below supersedes this historical context for the current production format.
 
-`config_persistence.py` already writes a complete replacement through a sibling
-temporary file, flushes it, and uses `os.replace`. That protects a valid configuration
-from a failed write, but startup still parses JSON directly. Malformed JSON, unsupported
-versions, migration failures, backups, and rollback do not yet have a contract.
+At that time, `config_persistence.py` already wrote a complete replacement through a sibling
+temporary file, flushed it, and used `os.replace`. That protected a valid configuration from
+a failed write, but startup still parsed JSON directly. Malformed JSON, unsupported versions,
+migration failures, backups, and rollback did not yet have a contract.
 
 The Windows Content Triage milestone needs named workspaces, typed URL and image
 resources, per-tab placements, New/In Use/Archived workflow state, Display and Kanban
@@ -62,17 +63,19 @@ persisted schema-version numbers are distinct.
 10. Version 0 to version 1 migration always names the single created Workspace
     `Default Workspace`. The existing launcher title remains `application.title` only and
     is not reused as the Workspace name.
-11. Q5 implements only version 0 to version 1. A later focused slice will implement version
-    1 to version 2. Until then, explicit version 2 is unsupported newer and is never opened
-    or rewritten.
+11. Q5 implements only version 0 to version 1. The final integration slice registers the
+    version 1 to version 2 step and makes complete schema version 2 the current production
+    format. Explicit version 1 is migrated transactionally; valid version 2 is opened
+    directly without a normalization write.
 
 ## Schema version 2 URL-Tile contract
 
 ### Status and scope
 
-Issue #118 is documentation-only. Schema version 2 remains unsupported and unregistered.
-This is not Q6. The issue patch is limited to this ADR and `CHANGELOG.md`; checkpoints 0
-through 6 changed only this ADR.
+Issue #118 was documentation-only and left schema version 2 unsupported and unregistered.
+It was not Q6, and its checkpoints changed only this ADR and `CHANGELOG.md`. The later final
+integration slice described below activates the already accepted complete schema-v2 graph;
+that activation does not retroactively broaden issue #118.
 
 This section inherits these boundaries:
 
@@ -1624,8 +1627,9 @@ Implementation defects retain exactly these `PureEngineDefectCategory` values:
 `callback_exception`, `invalid_callback_result`, `invalid_step_output`, and
 `unexpected_target_version`. Callback exception text MUST be discarded. A registry step
 name MAY appear only as a fixed, validated internal registry event name; it MUST NOT contain
-or derive from source data, an entity ID, or a UUID input name. This ADR does not register or
-name the dormant v1-to-v2 step.
+or derive from source data, an entity ID, or a UUID input name. At the issue-#118 checkpoint,
+the ADR did not register or name the then-dormant v1-to-v2 step. The final integration slice
+registers the fixed internal name `v1_to_v2` without changing that privacy boundary.
 
 The transaction reuses exactly these `TransactionFailureCategory` values:
 
@@ -1747,9 +1751,9 @@ automatically deleted. Cleanup MUST remove only temporary or staging files prove
 owned by the writer. There is no kernel compare-and-swap guarantee; any ownership
 uncertainty fails closed.
 
-Once schema v2 is eventually supported and current, an already-valid schema-v2 document is
-validated as current state, MUST NOT be replayed through v1-to-v2, and MUST NOT receive a
-migration normalization write. This rule does not register or activate schema v2 now.
+Now that schema v2 is supported and current, an already-valid schema-v2 document is validated
+as current state, MUST NOT be replayed through v1-to-v2, and MUST NOT receive a migration
+normalization write.
 
 #### Interruption boundaries
 
@@ -1813,6 +1817,64 @@ or incomplete schema-v2 graph. The dependency order is:
 
 These slices assign no issue number, branch, milestone, release, or `Q6` name.
 
+#### Current flat-UI activation policy
+
+Schema-v2 activation does not make the current flat UI the serialization authority. The
+complete validated schema-v2 document remains the authoritative production state. Every
+permitted flat-UI persistence attempt constructs a candidate from a detached copy of that
+complete document, changes only the fields and memberships required by the operation below,
+validates and canonically serializes the complete candidate, persists it atomically, and
+replaces the authoritative live document only after persistence succeeds. It MUST NOT
+rebuild version 2 from a flat Tile list or round-trip version 2 through version 1.
+
+The current flat UI uses these operation-specific defaults for its legacy-compatible
+Resource/Placement subset:
+
+- **Add Tile** creates one distinct URL Resource and one Placement with
+  `workflow_status: in_use`. It appends the Placement ID to the destination Tab's
+  `display_order` and to `kanban_order.in_use`.
+- **Duplicate Tile** creates a distinct URL Resource and Placement carrying the duplicated
+  flat Tile values, with new globally unique entity IDs and `workflow_status: in_use`. It
+  inserts the new Placement immediately after the source in both `display_order` and
+  `kanban_order.in_use`. Every portable and device-specific launch binding is copied with a
+  new globally unique binding ID, the duplicate Placement as subject, and exact
+  applicability, settings, and Extensions values. The flat operation does not introduce
+  Resource sharing.
+- **Import URLs** creates one distinct URL Resource and Placement per accepted row. Every
+  Placement uses `workflow_status: in_use`; the batch appends in reviewed source order to
+  both the destination `display_order` and `kanban_order.in_use`.
+- **Move Tile to another Tab** preserves the Placement identity, Resource reference,
+  workflow status, presentation fields, Extensions, and every DeviceBinding. It removes the
+  Placement ID from the source Display order and matching Kanban queue, changes `tab_id`,
+  inserts it at the destination Display position produced by the current flat UI's ordered
+  Tile list, and appends it to the destination queue matching its unchanged workflow status.
+- **Delete Tab** first applies the defined Discard operation to every Placement owned by the
+  Tab: remove the Placement from its Display and matching Kanban memberships, remove every
+  DeviceBinding whose subject is that Placement, and retain the referenced Resource as a
+  permitted orphan. Only after the Tab is empty does the operation remove its ID from the
+  owning Workspace's `tab_order` and remove the Tab definition. The existing protection for
+  the last usable Tab remains in force.
+
+Add, duplicate, import, and cross-Tab move therefore supply both independent insertion
+positions required by the schema-v2 contract; none derives Kanban order from Display order.
+Within-Tab drag reorder continues to use filtered-slot replacement and changes only
+`display_order`.
+
+The flat UI is read-only for a mutation whose target or required ordering context uses
+Resource sharing, a non-null label or icon override, or other advanced graph state that the
+current controls cannot represent losslessly. Examples include Kanban view, non-default
+workflow/filter state, multiple-Workspace or multi-placement interaction, and device-specific
+editing. Archived Tabs and other unexposed definitions may remain editable only when the
+operation preserves them exactly. The application may project and launch supported values,
+but it MUST disable or reject the ambiguous mutation before constructing a candidate. It
+MUST NOT flatten, repair, delete, regenerate, or silently normalize the advanced state.
+
+Every permitted flat operation preserves all unmodified Workspaces, Tabs, Resources,
+Placements, DeviceBindings, Extensions values, lifecycle and filter state, independent
+orders, and entity IDs from the complete schema-v2 source. Definitions not exposed by the
+flat UI remain value-equivalent with every array order unchanged after canonical
+reserialization; object key order follows the required canonical sorting.
+
 ## Version envelope
 
 ### Version identification
@@ -1822,8 +1884,8 @@ These slices assign no issue number, branch, milestone, release, or `Q6` name.
 - Boolean, floating-point, string, negative, and otherwise malformed version values are
   invalid; they are not coerced.
 - The application migrates only through consecutive registered steps.
-- Q5 supports versions 0 through 1 and registers only the version 0 to version 1 step.
-  Explicit version 2 remains unsupported newer until the later version 1 to version 2 slice.
+- Production supports versions 0 through 2, treats version 2 as current, and registers the
+  consecutive version 0 to version 1 and version 1 to version 2 steps.
 - A document whose version is greater than the newest supported version is not opened or
   rewritten. The user receives an unsupported-newer-version recovery message.
 - A document whose version is lower than the oldest supported input version is preserved
@@ -1925,10 +1987,10 @@ Root `extensions` is empty or exactly:
 
 Retained legacy values must be recursively finite strict JSON. For migration and native
 missing/reset construction, the Workspace name is exactly `Default Workspace`. A valid
-current version 1 document may use another non-empty Workspace name and round-trips it
-unchanged. The launcher title remains independent: a legacy launcher titled `My Launcher`
-retains `application.title: "My Launcher"`, while its migrated Workspace is still named
-`Default Workspace`.
+explicit version 1 migration source may use another non-empty Workspace name and carries it
+unchanged into version 2. The launcher title remains independent: a legacy launcher titled
+`My Launcher` retains `application.title: "My Launcher"`, while its migrated Workspace is
+still named `Default Workspace`.
 
 ### Version 2 full-graph root state
 
@@ -2435,8 +2497,9 @@ independent orders.
   recoverable. It may delete only an unreferenced managed asset beneath the validated DTL
   managed root.
 - External originals are never cleanup targets.
-- Deleting or archiving a Tab is not equivalent to discarding all of its Placements. Tab
-  archive/delete/trash semantics require their own later decision.
+- Archiving a Tab is not equivalent to discarding all of its Placements and remains a later
+  decision. The current flat-UI activation policy above separately defines active Tab deletion
+  as an explicit discard of every owned Placement before the empty Tab is removed.
 
 ## Legacy version 0 to identity version 1 migration
 
@@ -2514,21 +2577,22 @@ exactly `Default Workspace`, its ID is the `default_workspace_id` target, and
 `application.title` equals the preserved legacy launcher title. Custom, blank/default,
 missing, and non-ASCII title cases demonstrate that the two names are independent.
 
-Missing configuration bypasses migration and constructs native version 1 directly with
+Q5 missing-configuration handling constructs native version 1 with
 `application.title: "My Launcher"`, one `Default Workspace`, one visible `Main` Tab, and the
 existing ChatGPT, Gmail, and Notion Tiles assigned to Main by `tab_id`. It uses distinct,
-collision-checked Workspace and Tab UUIDv4 values from an injectable runtime allocator,
-validates the complete candidate, and atomically persists it before returning usable state.
-Q3 Preserve and Reset installs the same native version 1 only after preserving and verifying
-the corrupt source. Native IDs are never regenerated while loading, normalizing, saving, or
-restarting.
+collision-checked Workspace and Tab UUIDv4 values from an injectable runtime allocator. On
+schema-v2 activation, missing and reset configuration passes that validated native state
+through the same pure version 1 to version 2 construction before the complete version 2
+candidate is validated and atomically persisted. Q3 Preserve and Reset does so only after
+preserving and verifying the corrupt source. Native IDs are never regenerated while loading,
+migrating, saving, or restarting. Missing-file publication MUST be exclusive and MUST NOT
+replace a configuration created by another process after the initial absence check.
 
 ## Version 1 to version 2 migration
 
-A later focused slice will implement version 1 to version 2. It must preserve the version 1
-Workspace, Tab, Tile, application, setting, and extension state while producing the accepted
-full graph. The accepted mapping, previously described as direct version 0 to version 1,
-remains:
+The activation slice implements version 1 to version 2. It preserves the version 1 Workspace,
+Tab, Tile, application, setting, and extension state while producing the accepted full graph.
+The accepted mapping, previously described as direct version 0 to version 1, remains:
 
 | Version 1 value | Version 2 value |
 |---|---|
@@ -2547,12 +2611,12 @@ remains:
 | existing Tiles | Placement `workflow_status: in_use` |
 | existing Tabs | `view_mode: display`, Display filter `new` + `in_use` |
 
-The later step does not deduplicate Resources, merge Tabs, normalize user-facing labels, drop
-Tiles, or change launch behavior. Each Tile becomes a distinct Resource, so Resource defaults
-and null Placement overrides preserve appearance without introducing sharing between formerly
-independent Tiles. Existing Tiles initialize Display order and the In Use Kanban column from
-the same preserved per-Tab order; New and Archived Kanban arrays start empty. Every current
-Tab, hidden state, stable order, Tile field, launch setting, window value, and permitted
+The registered step does not deduplicate Resources, merge Tabs, normalize user-facing labels,
+drop Tiles, or change launch behavior. Each Tile becomes a distinct Resource, so Resource
+defaults and null Placement overrides preserve appearance without introducing sharing between
+formerly independent Tiles. Existing Tiles initialize Display order and the In Use Kanban
+column from the same preserved per-Tab order; New and Archived Kanban arrays start empty. Every
+current Tab, hidden state, stable order, Tile field, launch setting, window value, and permitted
 extension remains accounted for. The complete version 2 candidate must pass all version 2
 invariants before any write.
 
@@ -2566,7 +2630,7 @@ safety and failure behavior are authoritative for v1-to-v2 and reuse the existin
 path.
 
 One bounded raw load precedes parsing and classification. Raw parse failures, including
-duplicate members once the documented parser boundary is implemented, retain the Q3
+duplicate members rejected at the parser boundary, retain the Q3
 recovery route. Malformed and unsupported version values use the fixed Q4 Exit-only
 categories and are not rewritten.
 
@@ -2590,9 +2654,10 @@ write.
 
 Q3 implements corrupt-input preservation and user recovery. Q4 implements the version
 registry, pure step runner, validation hooks, deterministic tests, and rollback plumbing.
-Q5 implements the version 0 to version 1 Workspace/Tab identity slice. A later focused slice
-implements version 1 to version 2 before subsequent slices add the accepted full-graph
-Resource/Placement, workflow, DeviceBinding, and ImportBatch runtime behavior.
+Q5 implements the version 0 to version 1 Workspace/Tab identity slice. The final integration
+slice registers version 1 to version 2, activates the complete Resource/Placement and
+DeviceBinding graph, and applies the bounded flat-UI policy above. Kanban, ImportBatch, and
+other advanced product behavior remain later slices.
 
 ## Validation invariants
 
@@ -2641,9 +2706,10 @@ Anything else enters explicit recovery without configuration mutation or automat
 - Q5: create the default Workspace named exactly `Default Workspace`, preserve the existing
   launcher title in `application.title`, and introduce stable Workspace/Tab identity
   migration while preserving existing valid Tab IDs and behavior as schema version 1.
-- Later schema-v2 implementation follows the dormant-types, dormant-transformer, runtime
-  adapter, and final integration/activation dependency order documented above. No slice may
-  emit an incomplete schema-v2 graph.
+- Schema-v2 implementation follows the types, transformer, runtime-adapter, and final
+  integration/activation dependency order documented above. The final slice activates only
+  the complete graph and the bounded flat-UI mutation policy; no slice may emit an incomplete
+  schema-v2 graph.
 - Later image/import, Kanban UI, Workspace-selection, multi-placement, and device-platform
   slices remain separate product or future-schema work.
 

--- a/tab_order.py
+++ b/tab_order.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from uuid import UUID, uuid4
 
 TabIdFactory = Callable[[], str]
+_TAB_ID_ALLOCATION_ATTEMPTS = 32
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,6 +16,13 @@ class TabOrderState:
     tabs: list[str]
     tab_ids: dict[str, str]
     tab_order: list[str]
+
+
+class TabIdentityAllocationError(ValueError):
+    """A new runtime Tab ID could not be allocated safely."""
+
+    def __init__(self) -> None:
+        super().__init__("identity_allocation_failure")
 
 
 def new_tab_id() -> str:
@@ -32,11 +40,26 @@ def _canonical_tab_id(value: object) -> str | None:
         return None
 
 
+def _generated_tab_id(value: object) -> str | None:
+    candidate = _canonical_tab_id(value)
+    if candidate is None or UUID(candidate).version != 4:
+        return None
+    return candidate
+
+
 def _new_unique_tab_id(blocked_ids: set[str], id_factory: TabIdFactory) -> str:
-    while True:
-        candidate = _canonical_tab_id(id_factory())
+    for _ in range(_TAB_ID_ALLOCATION_ATTEMPTS):
+        allocator_failed = False
+        try:
+            candidate = _generated_tab_id(id_factory())
+        except Exception:
+            candidate = None
+            allocator_failed = True
+        if allocator_failed:
+            raise TabIdentityAllocationError
         if candidate is not None and candidate not in blocked_ids:
             return candidate
+    raise TabIdentityAllocationError
 
 
 def _reserved_saved_ids(raw_tab_ids: object, raw_tab_order: object) -> set[str]:

--- a/tests/unit/test_config_migration.py
+++ b/tests/unit/test_config_migration.py
@@ -10,8 +10,10 @@ from typing import cast
 import pytest
 
 import config_migration as migration
+import config_migration_v2
 import config_recovery
 import config_schema
+import config_schema_v2
 from config_recovery import MAX_CONFIG_BYTES
 
 pytestmark = pytest.mark.unit
@@ -40,6 +42,12 @@ def _native_v1_document() -> config_schema.JsonObject:
         )
     )
     return config_schema.build_native_v1(lambda: next(identifiers))
+
+
+def _native_v2_document() -> config_schema_v2.Root:
+    candidate = config_migration_v2.migrate_v1_to_v2(_native_v1_document())
+    assert candidate is not None  # nosec B101
+    return candidate
 
 
 def _single_step_registry(
@@ -93,7 +101,7 @@ def _forbid_legacy_constructor(_mapping: dict[str, object]) -> object:
     raise AssertionError("migration result must not enter legacy construction")
 
 
-def test_production_registry_prepares_exactly_v0_to_v1() -> None:
+def test_production_registry_prepares_consecutive_v0_to_v2_and_v1_to_v2() -> None:
     source: migration.JsonObject = {
         "title": "Legacy",
         "unknown": {"private": "not rendered"},
@@ -103,8 +111,8 @@ def test_production_registry_prepares_exactly_v0_to_v1() -> None:
 
     assert isinstance(result, migration.PreparedMigration)  # nosec B101
     assert result.source_version == 0  # nosec B101
-    assert result.target_version == 1  # nosec B101
-    assert result.step_count == 1  # nosec B101
+    assert result.target_version == 2  # nosec B101
+    assert result.step_count == 2  # nosec B101
     assert (
         migration.migration_startup_route(result)
         is migration.MigrationStartupRoute.MIGRATION_REQUIRED
@@ -114,6 +122,14 @@ def test_production_registry_prepares_exactly_v0_to_v1() -> None:
         "title": "Legacy",
         "unknown": {"private": "not rendered"},
     }
+    v1_result = migration.prepare_migration(
+        _native_v1_document(),
+        migration.PRODUCTION_REGISTRY,
+    )
+    assert isinstance(v1_result, migration.PreparedMigration)  # nosec B101
+    assert v1_result.source_version == 1  # nosec B101
+    assert v1_result.target_version == 2  # nosec B101
+    assert v1_result.step_count == 1  # nosec B101
 
 
 def test_production_nonfinite_unknown_fails_before_preservation_or_step(
@@ -201,19 +217,25 @@ def test_positive_explicit_versions_are_identified_exactly(version: int) -> None
     assert result == migration.ExplicitVersion(version)  # nosec B101
 
 
-def test_production_accepts_strict_v1_and_rejects_explicit_v2() -> None:
-    current = _native_v1_document()
-
+def test_production_migrates_strict_v1_accepts_v2_and_rejects_v3() -> None:
+    prepared = migration.prepare_migration(
+        _native_v1_document(),
+        migration.PRODUCTION_REGISTRY,
+    )
+    current = _native_v2_document()
     accepted = migration.prepare_migration(current, migration.PRODUCTION_REGISTRY)
-    future = deepcopy(current)
-    future["schema_version"] = 2
+    future = cast(migration.JsonObject, deepcopy(current))
+    future["schema_version"] = 3
     rejected = migration.prepare_migration(future, migration.PRODUCTION_REGISTRY)
 
+    assert isinstance(prepared, migration.PreparedMigration)  # nosec B101
+    assert prepared.source_version == 1  # nosec B101
+    assert prepared.target_version == 2  # nosec B101
     assert isinstance(accepted, migration.VersionedCurrent)  # nosec B101
-    assert accepted.version == 1  # nosec B101
+    assert accepted.version == 2  # nosec B101
     assert isinstance(rejected, migration.VersionRejected)  # nosec B101
     assert rejected.category is migration.VersionRejectionCategory.UNSUPPORTED_NEWER
-    assert rejected.version == 2  # nosec B101
+    assert rejected.version == 3  # nosec B101
 
 
 def test_production_v0_migrates_transactionally_without_legacy_construction(
@@ -221,7 +243,10 @@ def test_production_v0_migrates_transactionally_without_legacy_construction(
 ) -> None:
     config_path = tmp_path / "config.json"
     original = (
-        b'{"title":"Legacy","tabs":["Main"],"tiles":[],"unknown":{"retained":true}}'
+        b'{"title":"Legacy","tabs":["Main"],"tiles":[{"name":"Docs",'
+        b'"url":"https://docs.example.test/path","tab":"Main","icon":null,'
+        b'"bg":"#123456","browser":null,"chrome_profile":null,'
+        b'"open_target":"tab"}],"unknown":{"retained":true}}'
     )
     config_path.write_bytes(original)
 
@@ -233,8 +258,14 @@ def test_production_v0_migrates_transactionally_without_legacy_construction(
     )
 
     assert isinstance(result, migration.MigrationCommitted)  # nosec B101
-    assert result.target_version == 1  # nosec B101
-    assert config_schema.validate_v1(result.document)  # nosec B101
+    assert result.target_version == 2  # nosec B101
+    assert config_schema_v2.validate_v2(result.document)  # nosec B101
+    assert len(result.document["resources"]) == 1  # nosec B101
+    assert result.document["resources"][0]["target"] == {  # nosec B101
+        "url": "https://docs.example.test/path"
+    }
+    assert len(result.document["placements"]) == 1  # nosec B101
+    assert result.document["placements"][0]["workflow_status"] == "in_use"  # nosec B101
     extensions = cast(dict[str, object], result.document["extensions"])
     assert extensions == {  # nosec B101
         config_schema.LEGACY_EXTENSION_NAMESPACE: {"unknown": {"retained": True}}
@@ -272,12 +303,40 @@ def test_production_known_incompatible_v0_uses_q3_recovery_without_artifacts(
     assert _temporary_residue(tmp_path) == []  # nosec B101
 
 
-def test_production_current_v1_startup_is_exact_no_write(
+def test_production_v1_startup_migrates_transactionally(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    document = _native_v1_document()
+    original = json.dumps(document, ensure_ascii=False, separators=(", ", ": ")).encode(
+        "utf-8"
+    )
+    config_path.write_bytes(original)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(result, migration.MigrationCommitted)  # nosec B101
+    assert result.target_version == 2  # nosec B101
+    assert config_schema_v2.validate_v2(result.document)  # nosec B101
+    serialized = migration.serialize_deterministically(result.document)
+    assert isinstance(serialized, migration.SerializedDocument)  # nosec B101
+    assert config_path.read_bytes() == serialized.data  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_current_v2_startup_is_exact_no_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_path = tmp_path / "config.json"
-    document = _native_v1_document()
+    document = _native_v2_document()
     original = json.dumps(document, ensure_ascii=False, separators=(", ", ": ")).encode(
         "utf-8"
     )
@@ -292,6 +351,7 @@ def test_production_current_v1_startup_is_exact_no_write(
     )
 
     assert isinstance(result, migration.VersionedCurrent)  # nosec B101
+    assert result.version == 2  # nosec B101
     assert result.document == document  # nosec B101
     assert config_path.read_bytes() == original  # nosec B101
     assert _recovery_files(config_path) == []  # nosec B101
@@ -299,7 +359,45 @@ def test_production_current_v1_startup_is_exact_no_write(
     assert _temporary_residue(tmp_path) == []  # nosec B101
 
 
-def test_production_current_v1_with_lone_surrogate_is_exit_only_and_no_write(
+def test_production_invalid_current_v2_is_exit_only_and_exact_no_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    document = _native_v2_document()
+    document["application"]["default_workspace_id"] = (
+        "99000000-0000-4000-8000-000000000001"
+    )
+    original = json.dumps(document, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    config_path.write_bytes(original)
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(result, migration.PureExecutionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.category
+        is migration.PureExecutionRejectionCategory.SOURCE_VALIDATION_FAILURE
+    )
+    assert result.stage is migration.PureExecutionStage.SOURCE_VALIDATION  # nosec B101
+    assert (
+        migration.startup_failure_route(result)
+        is migration.StartupFailureRoute.EXIT_ONLY
+    )  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_v1_migration_source_with_lone_surrogate_is_exit_only_and_no_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -373,7 +471,7 @@ def test_production_empty_legacy_tab_rejects_after_exact_preservation(
     assert _temporary_residue(tmp_path) == []  # nosec B101
 
 
-def test_production_invalid_applied_output_uses_target_validation_after_preservation(
+def test_production_invalid_v0_output_uses_intermediate_validation_after_preservation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -402,16 +500,60 @@ def test_production_invalid_applied_output_uses_target_validation_after_preserva
     assert isinstance(result.problem, migration.PureExecutionRejected)  # nosec B101
     assert (  # nosec B101
         result.problem.category
-        is migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+        is migration.PureExecutionRejectionCategory.INTERMEDIATE_VALIDATION_FAILURE
     )
     assert (  # nosec B101
-        result.problem.stage is migration.PureExecutionStage.TARGET_VALIDATION
+        result.problem.stage is migration.PureExecutionStage.INTERMEDIATE_VALIDATION
     )
     assert result.problem.step_name == "legacy_to_v1"  # nosec B101
     assert result.authority is migration.ConfigurationAuthority.ORIGINAL  # nosec B101
     assert result.recovery_copy_count == 1  # nosec B101
     assert result.failed_candidate_copy_count == 0  # nosec B101
     assert result.rollback_count == 0  # nosec B101
+    assert config_path.read_bytes() == original  # nosec B101
+    assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert _temporary_residue(tmp_path) == []  # nosec B101
+
+
+def test_production_invalid_v2_output_uses_target_validation_after_preservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    source = _native_v1_document()
+    original = json.dumps(source, separators=(",", ":")).encode("utf-8")
+    config_path.write_bytes(original)
+
+    def invalid_target(
+        _document: Mapping[str, config_schema.JsonValue],
+    ) -> config_schema_v2.Root:
+        return cast(config_schema_v2.Root, {"schema_version": 2})
+
+    monkeypatch.setattr(config_migration_v2, "migrate_v1_to_v2", invalid_target)
+    monkeypatch.setattr(migration, "atomic_write_bytes", _forbidden_candidate_writer)
+
+    result = migration.load_startup_configuration(
+        config_path,
+        _forbid_legacy_constructor,
+        migration.PRODUCTION_REGISTRY,
+        legacy_validator=config_recovery.validate_legacy_mapping,
+    )
+
+    assert isinstance(  # nosec B101
+        result, migration.MigrationAbortedAfterPreservation
+    )
+    assert isinstance(result.problem, migration.PureExecutionRejected)  # nosec B101
+    assert (  # nosec B101
+        result.problem.category
+        is migration.PureExecutionRejectionCategory.TARGET_VALIDATION_FAILURE
+    )
+    assert (  # nosec B101
+        result.problem.stage is migration.PureExecutionStage.TARGET_VALIDATION
+    )
+    assert result.problem.step_name == "v1_to_v2"  # nosec B101
+    assert result.authority is migration.ConfigurationAuthority.ORIGINAL  # nosec B101
+    assert result.recovery_copy_count == 1  # nosec B101
     assert config_path.read_bytes() == original  # nosec B101
     assert [path.read_bytes() for path in _recovery_files(config_path)] == [original]
     assert _failed_candidate_files(config_path) == []  # nosec B101

--- a/tests/unit/test_config_persistence.py
+++ b/tests/unit/test_config_persistence.py
@@ -8,7 +8,11 @@ from typing import Any
 import pytest
 
 import config_persistence
-from config_persistence import atomic_write_bytes, atomic_write_text
+from config_persistence import (
+    atomic_create_bytes,
+    atomic_write_bytes,
+    atomic_write_text,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -147,6 +151,114 @@ def test_atomic_write_bytes_preserves_exact_mixed_newline_and_unicode_bytes(
 
     assert config_path.read_bytes() == payload  # nosec B101
     assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_create_bytes_publishes_complete_missing_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = b"complete native configuration"
+
+    atomic_create_bytes(config_path, payload)
+
+    assert config_path.read_bytes() == payload  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_create_bytes_never_replaces_existing_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    original = b"concurrent winner"
+    config_path.write_bytes(original)
+
+    with pytest.raises(FileExistsError):
+        atomic_create_bytes(config_path, b"native candidate")
+
+    assert config_path.read_bytes() == original  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_create_late_race_preserves_winner_and_cleans_owned_temp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    winner = b"late concurrent winner"
+    real_publish = config_persistence._publish_exclusive
+
+    def publish_after_race(
+        temporary_path: Path,
+        destination: Path,
+    ) -> config_persistence._ExclusivePublishResult:
+        destination.write_bytes(winner)
+        return real_publish(temporary_path, destination)
+
+    monkeypatch.setattr(
+        config_persistence,
+        "_publish_exclusive",
+        publish_after_race,
+    )
+
+    with pytest.raises(FileExistsError):
+        atomic_create_bytes(config_path, b"native candidate")
+
+    assert config_path.read_bytes() == winner  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
+def test_atomic_create_does_not_unlink_reused_name_after_consuming_temp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    payload = b"native candidate"
+    replacement = b"unowned replacement"
+    reused_paths: list[Path] = []
+
+    def consume_then_reuse(temporary_path: Path, destination: Path) -> str:
+        config_persistence.os.rename(temporary_path, destination)
+        temporary_path.write_bytes(replacement)
+        reused_paths.append(temporary_path)
+        return "consumed"
+
+    monkeypatch.setattr(config_persistence, "_publish_exclusive", consume_then_reuse)
+
+    atomic_create_bytes(config_path, payload)
+
+    assert config_path.read_bytes() == payload  # nosec B101
+    assert len(reused_paths) == 1  # nosec B101
+    assert reused_paths[0].read_bytes() == replacement  # nosec B101
+
+
+def test_atomic_create_reports_linked_temp_cleanup_failure_without_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    payload = b"native candidate"
+    linked_paths: list[Path] = []
+    unlink_attempts = 0
+    real_unlink = Path.unlink
+
+    def publish_as_linked(temporary_path: Path, destination: Path) -> str:
+        destination.write_bytes(temporary_path.read_bytes())
+        linked_paths.append(temporary_path)
+        return "linked"
+
+    def reject_linked_cleanup(path: Path, *, missing_ok: bool = False) -> None:
+        nonlocal unlink_attempts
+        if linked_paths and path == linked_paths[0]:
+            unlink_attempts += 1
+            raise OSError("synthetic linked-temp cleanup failure")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(config_persistence, "_publish_exclusive", publish_as_linked)
+    monkeypatch.setattr(Path, "unlink", reject_linked_cleanup)
+
+    with pytest.raises(OSError, match="synthetic linked-temp cleanup failure"):
+        atomic_create_bytes(config_path, payload)
+
+    assert config_path.read_bytes() == payload  # nosec B101
+    assert unlink_attempts == 1  # nosec B101
+    assert len(linked_paths) == 1  # nosec B101
+    assert linked_paths[0].read_bytes() == payload  # nosec B101
 
 
 def test_atomic_byte_write_failure_preserves_original_and_cleans_temporary_file(

--- a/tests/unit/test_config_recovery.py
+++ b/tests/unit/test_config_recovery.py
@@ -256,6 +256,58 @@ def test_malformed_json_and_bom_are_classified(tmp_path: Path, payload: bytes) -
     assert result.category is ConfigLoadFailureCategory.MALFORMED_JSON  # nosec B101
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            b'{"schema_version":1,"schema_version":2}',
+            id="root-member",
+        ),
+        pytest.param(
+            b'{"application":{"title":"one","title":"two"}}',
+            id="nested-member",
+        ),
+        pytest.param(
+            b'{"items":[{"id":"one","id":"two"}]}',
+            id="array-object-member",
+        ),
+        pytest.param(
+            b'{"extensions":{"outer":{"inner":{"secret":1,"secret":2}}}}',
+            id="deep-extensions-member",
+        ),
+        pytest.param(
+            b'{"decoded-name":1,"\\u0064ecoded-name":2}',
+            id="decoded-equivalent-member",
+        ),
+    ],
+)
+def test_duplicate_json_members_are_malformed_before_construction(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(payload)
+    constructor_called = False
+
+    def constructor(_mapping: dict[str, object]) -> object:
+        nonlocal constructor_called
+        constructor_called = True
+        return object()
+
+    result = load_config(config_path, constructor)
+
+    assert isinstance(result, ConfigRecoveryRequired)  # nosec B101
+    assert result.category is ConfigLoadFailureCategory.MALFORMED_JSON  # nosec B101
+    assert result.snapshot is not None  # nosec B101
+    assert result.snapshot.evidence_is_complete  # nosec B101
+    assert result.snapshot.evidence_byte_count == len(payload)  # nosec B101
+    assert not constructor_called  # nosec B101
+    assert config_path.read_bytes() == payload  # nosec B101
+    assert _recovery_files(config_path) == []  # nosec B101
+    assert _failed_candidate_files(config_path) == []  # nosec B101
+    assert set(tmp_path.iterdir()) == {config_path}  # nosec B101
+
+
 @pytest.mark.parametrize("payload", [b"[]", b'"text"', b"1", b"true", b"null"])
 def test_every_non_object_root_is_rejected(tmp_path: Path, payload: bytes) -> None:
     config_path = tmp_path / "config.json"

--- a/tests/unit/test_config_runtime_state_v2.py
+++ b/tests/unit/test_config_runtime_state_v2.py
@@ -735,6 +735,30 @@ def test_unhashable_flat_state_fields_are_rejected_without_mutation() -> None:
         assert document == original  # nosec B101
 
 
+@pytest.mark.parametrize("invalid_open_target", ["popup", 1])
+def test_invalid_open_target_is_rejected_without_mutation(
+    invalid_open_target: object,
+) -> None:
+    document = _native_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    malformed = replace(
+        projection,
+        tiles=(
+            replace(
+                projection.tiles[0],
+                open_target=cast(schema.OpenTarget, invalid_open_target),
+            ),
+            *projection.tiles[1:],
+        ),
+    )
+
+    result = runtime_state.synchronize_flat_workspace(document, malformed)
+
+    assert result == runtime_state.FlatStateRejected("invalid_state")  # nosec B101
+    assert document == original  # nosec B101
+
+
 def test_move_remove_and_tab_delete_are_coordinated_and_keep_orphan_resource() -> None:
     document = _two_tab_document()
     projection = _projected(document)

--- a/tests/unit/test_config_runtime_state_v2.py
+++ b/tests/unit/test_config_runtime_state_v2.py
@@ -1,0 +1,974 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+import pytest
+
+import config_runtime_state_v2 as runtime_state
+import config_schema_v2 as schema
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPRESENTATIVE_FIXTURE = (
+    REPO_ROOT / "tests" / "fixtures" / "schema_v2" / "representative.json"
+)
+
+WORKSPACE_ID = "11000000-0000-4000-8000-000000000001"
+MAIN_TAB_ID = "22000000-0000-4000-8000-000000000001"
+SECOND_WORKSPACE_ID = "11000000-0000-4000-8000-000000000002"
+SECOND_TAB_ID = "22000000-0000-4000-8000-000000000002"
+DEVICE_BINDING_ID = "55000000-0000-4000-8000-000000000001"
+SOURCE_DEVICE_BINDING_ID = "55000000-0000-4000-8000-000000000002"
+NEW_TAB_ID = "77000000-0000-4000-8000-000000000001"
+ARCHIVED_DEVICE_BINDING_ID = "88000000-0000-4000-8000-000000000001"
+NEW_ENTITY_IDS = (
+    "66000000-0000-4000-8000-000000000001",
+    "66000000-0000-4000-8000-000000000002",
+    "66000000-0000-4000-8000-000000000003",
+    "66000000-0000-4000-8000-000000000004",
+    "66000000-0000-4000-8000-000000000005",
+    "66000000-0000-4000-8000-000000000006",
+    "66000000-0000-4000-8000-000000000007",
+)
+
+
+def _native_document() -> schema.Root:
+    identifiers = iter((WORKSPACE_ID, MAIN_TAB_ID))
+    return runtime_state.build_native_v2(lambda: next(identifiers))
+
+
+def _representative_document() -> schema.Root:
+    parsed = json.loads(
+        REPRESENTATIVE_FIXTURE.read_text(encoding="utf-8"),
+        object_pairs_hook=schema.reject_duplicate_json_members,
+    )
+    assert schema.validate_v2(parsed)  # nosec B101
+    return cast(schema.Root, parsed)
+
+
+def _projected(document: object) -> runtime_state.FlatWorkspaceState:
+    result = runtime_state.project_flat_workspace(document)
+    assert isinstance(result, runtime_state.FlatWorkspaceState)  # nosec B101
+    return result
+
+
+def _updated(
+    result: runtime_state.FlatWorkspaceUpdateResult,
+) -> runtime_state.FlatWorkspaceUpdate:
+    assert isinstance(result, runtime_state.FlatWorkspaceUpdate)  # nosec B101
+    return result
+
+
+def _workspace(
+    document: schema.Root, workspace_id: str = WORKSPACE_ID
+) -> schema.Workspace:
+    return next(item for item in document["workspaces"] if item["id"] == workspace_id)
+
+
+def _tab(document: schema.Root, tab_id: str) -> schema.Tab:
+    return next(item for item in document["tabs"] if item["id"] == tab_id)
+
+
+def _portable_window_binding(
+    document: schema.Root,
+    workspace_id: str = WORKSPACE_ID,
+) -> schema.WorkspaceWindowBinding:
+    binding = next(
+        item
+        for item in document["device_bindings"]
+        if item["subject_kind"] == "workspace"
+        and item["subject_id"] == workspace_id
+        and item["applicability"]["kind"] == "portable_fallback"
+    )
+    return cast(schema.WorkspaceWindowBinding, binding)
+
+
+def _two_tab_document() -> schema.Root:
+    document = _native_document()
+    _workspace(document)["tab_order"].append(SECOND_TAB_ID)
+    document["tabs"].append(
+        schema.Tab(
+            id=SECOND_TAB_ID,
+            workspace_id=WORKSPACE_ID,
+            name="Work",
+            visibility="visible",
+            lifecycle="active",
+            view_mode="display",
+            display_filter=["new", "in_use"],
+            display_order=[],
+            kanban_order=schema.KanbanOrder(new=[], in_use=[], archived=[]),
+            extensions={"second-tab.example.test": {"retained": True}},
+        )
+    )
+    assert schema.validate_v2(document)  # nosec B101
+    return document
+
+
+def _identity_tuple(tile: runtime_state.FlatTileState) -> tuple[str, str, str]:
+    assert tile.placement_id is not None  # nosec B101
+    assert tile.resource_id is not None  # nosec B101
+    assert tile.launch_binding_id is not None  # nosec B101
+    return tile.placement_id, tile.resource_id, tile.launch_binding_id
+
+
+def test_native_v2_construction_projects_one_editable_current_workspace() -> None:
+    document = _native_document()
+
+    projection = _projected(document)
+
+    assert schema.validate_v2(document)  # nosec B101
+    assert document["schema_version"] == 2  # nosec B101
+    assert projection.editable  # nosec B101
+    assert projection.workspace_id == WORKSPACE_ID  # nosec B101
+    assert projection.tab_order == (MAIN_TAB_ID,)  # nosec B101
+    assert projection.tabs == (  # nosec B101
+        runtime_state.FlatTabState(MAIN_TAB_ID, "Main", False),
+    )
+    assert len(projection.tiles) == 3  # nosec B101
+    assert all(all(_identity_tuple(tile)) for tile in projection.tiles)  # nosec B101
+    assert runtime_state.reserved_entity_ids(document) == frozenset(  # nosec B101
+        item["id"]
+        for collection in (
+            document["workspaces"],
+            document["tabs"],
+            document["resources"],
+            document["placements"],
+            document["device_bindings"],
+        )
+        for item in collection
+    )
+
+
+def test_noop_sync_is_lossless_for_extensions_unselected_state_bindings_and_ids() -> (
+    None
+):
+    document = _native_document()
+    document["extensions"]["root.example.test"] = {"ordered": [2, 1]}
+    document["application"]["extensions"]["application.example.test"] = None
+    workspace = _workspace(document)
+    workspace["extensions"]["workspace.example.test"] = {"kept": True}
+    _tab(document, MAIN_TAB_ID)["extensions"]["tab.example.test"] = ["kept"]
+    document["resources"][0]["extensions"]["resource.example.test"] = 7
+    document["placements"][0]["extensions"]["placement.example.test"] = "kept"
+    document["device_bindings"][0]["extensions"]["portable.example.test"] = False
+    unselected_workspace = schema.Workspace(
+        id=SECOND_WORKSPACE_ID,
+        name="Unselected",
+        tab_order=[],
+        extensions={"unselected.example.test": {"private": "preserved"}},
+    )
+    document["workspaces"].append(unselected_workspace)
+    device_binding = schema.WorkspaceWindowBinding(
+        id=DEVICE_BINDING_ID,
+        subject_kind="workspace",
+        subject_id=WORKSPACE_ID,
+        binding_kind="window",
+        applicability=schema.DeviceSpecific(
+            kind="device_specific",
+            device_key="device-A",
+        ),
+        settings=schema.WindowSettings(
+            columns=99,
+            auto_fit=False,
+            window_x=1,
+            window_y=2,
+            window_w=3,
+            window_h=4,
+        ),
+        extensions={"device-binding.example.test": ["preserved"]},
+    )
+    document["device_bindings"].append(device_binding)
+    assert schema.validate_v2(document)  # nosec B101
+    original = deepcopy(document)
+    reserved = runtime_state.reserved_entity_ids(document)
+    projection = _projected(document)
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, projection))
+
+    assert update.document == original  # nosec B101
+    assert document == original  # nosec B101
+    assert runtime_state.reserved_entity_ids(update.document) == reserved  # nosec B101
+    assert [_identity_tuple(tile) for tile in projection.tiles] == [  # nosec B101
+        (
+            identity.placement_id,
+            identity.resource_id,
+            identity.launch_binding_id,
+        )
+        for identity in update.tile_identities
+    ]
+    assert _workspace(update.document, SECOND_WORKSPACE_ID) == unselected_workspace  # nosec B101
+    assert (
+        next(  # nosec B101
+            item
+            for item in update.document["device_bindings"]
+            if item["id"] == DEVICE_BINDING_ID
+        )
+        == device_binding
+    )
+
+
+def test_permitted_edit_preserves_populated_unselected_and_archived_graphs() -> None:
+    document = _native_document()
+    rich = _representative_document()
+    secondary_workspace = deepcopy(rich["workspaces"][1])
+    secondary_tab_ids = set(secondary_workspace["tab_order"])
+    archived_tab = deepcopy(
+        next(
+            tab
+            for tab in rich["tabs"]
+            if tab["workspace_id"] == rich["application"]["default_workspace_id"]
+            and tab["lifecycle"] == "archived"
+            and tab["display_order"]
+        )
+    )
+    archived_tab["workspace_id"] = WORKSPACE_ID
+    selected_tab_ids = {*secondary_tab_ids, archived_tab["id"]}
+    selected_tabs = [
+        archived_tab,
+        *[deepcopy(tab) for tab in rich["tabs"] if tab["id"] in secondary_tab_ids],
+    ]
+    selected_placements = [
+        deepcopy(placement)
+        for placement in rich["placements"]
+        if placement["tab_id"] in selected_tab_ids
+    ]
+    selected_placement_ids = {placement["id"] for placement in selected_placements}
+    selected_resource_ids = {
+        placement["resource_id"] for placement in selected_placements
+    }
+    selected_resources = [
+        deepcopy(resource)
+        for resource in rich["resources"]
+        if resource["id"] in selected_resource_ids
+    ]
+    selected_bindings = [
+        deepcopy(binding)
+        for binding in rich["device_bindings"]
+        if (
+            binding["subject_kind"] == "workspace"
+            and binding["subject_id"] == secondary_workspace["id"]
+        )
+        or (
+            binding["subject_kind"] == "placement"
+            and binding["subject_id"] in selected_placement_ids
+        )
+    ]
+    selected_bindings.append(
+        schema.PlacementLaunchBinding(
+            id=ARCHIVED_DEVICE_BINDING_ID,
+            subject_kind="placement",
+            subject_id=archived_tab["display_order"][0],
+            binding_kind="launch",
+            applicability=schema.DeviceSpecific(
+                kind="device_specific",
+                device_key="archived-device",
+            ),
+            settings=schema.UrlLaunchSettings(
+                browser="Archived Browser",
+                chrome_profile=None,
+                open_target="window",
+            ),
+            extensions={"archived-binding.example.test": {"kept": True}},
+        )
+    )
+
+    document["workspaces"].append(secondary_workspace)
+    _workspace(document)["tab_order"].insert(0, archived_tab["id"])
+    document["tabs"].extend(selected_tabs)
+    document["resources"].extend(selected_resources)
+    document["placements"].extend(selected_placements)
+    document["device_bindings"].extend(selected_bindings)
+    assert schema.validate_v2(document)  # nosec B101
+    preserved_ids = {
+        "workspaces": {secondary_workspace["id"]},
+        "tabs": selected_tab_ids,
+        "resources": selected_resource_ids,
+        "placements": selected_placement_ids,
+        "device_bindings": {binding["id"] for binding in selected_bindings},
+    }
+    preserved = {
+        collection: {
+            item["id"]: deepcopy(item)
+            for item in document[collection]
+            if item["id"] in identifiers
+        }
+        for collection, identifiers in preserved_ids.items()
+    }
+    projection = _projected(document)
+    assert projection.editable  # nosec B101
+    edited = replace(
+        projection,
+        title="Edited while rich state remains unexposed",
+        tiles=(
+            replace(projection.tiles[0], background_color="#abcdef"),
+            *projection.tiles[1:],
+        ),
+    )
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, edited))
+
+    for collection, expected in preserved.items():
+        actual = {
+            item["id"]: item
+            for item in update.document[collection]
+            if item["id"] in expected
+        }
+        assert actual == expected  # nosec B101
+    assert _workspace(update.document)["tab_order"][0] == archived_tab["id"]  # nosec B101
+    assert schema.validate_v2(update.document)  # nosec B101
+
+
+def test_sync_updates_title_window_and_tab_visibility_name_and_order() -> None:
+    document = _two_tab_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    reordered_tabs = (
+        replace(projection.tabs[1], name="Projects", hidden=False),
+        replace(projection.tabs[0], name="Home", hidden=True),
+    )
+    edited = replace(
+        projection,
+        title="Renamed Launcher",
+        workspace_name="Renamed Workspace",
+        tabs=reordered_tabs,
+        tab_order=tuple(tab.id for tab in reordered_tabs),
+        columns=8,
+        auto_fit=False,
+        window_x=-20,
+        window_y=10,
+        window_w=1200,
+        window_h=700,
+    )
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, edited))
+    candidate = update.document
+
+    assert document == original  # nosec B101
+    assert candidate["application"]["title"] == "Renamed Launcher"  # nosec B101
+    assert _workspace(candidate)["name"] == "Renamed Workspace"  # nosec B101
+    assert _workspace(candidate)["tab_order"] == [SECOND_TAB_ID, MAIN_TAB_ID]  # nosec B101
+    assert _tab(candidate, SECOND_TAB_ID)["name"] == "Projects"  # nosec B101
+    assert _tab(candidate, SECOND_TAB_ID)["visibility"] == "visible"  # nosec B101
+    assert _tab(candidate, MAIN_TAB_ID)["name"] == "Home"  # nosec B101
+    assert _tab(candidate, MAIN_TAB_ID)["visibility"] == "hidden"  # nosec B101
+    assert _portable_window_binding(candidate)["settings"] == {  # nosec B101
+        "columns": 8,
+        "auto_fit": False,
+        "window_x": -20,
+        "window_y": 10,
+        "window_w": 1200,
+        "window_h": 700,
+    }
+    assert schema.validate_v2(candidate)  # nosec B101
+
+
+def test_new_uuid4_tab_round_trips_into_the_complete_graph() -> None:
+    document = _native_document()
+    projection = _projected(document)
+    added = runtime_state.FlatTabState(NEW_TAB_ID, "Added", False)
+    edited = replace(
+        projection,
+        tabs=(*projection.tabs, added),
+        tab_order=(*projection.tab_order, NEW_TAB_ID),
+    )
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, edited))
+
+    assert _workspace(update.document)["tab_order"] == [  # nosec B101
+        MAIN_TAB_ID,
+        NEW_TAB_ID,
+    ]
+    assert _tab(update.document, NEW_TAB_ID) == {  # nosec B101
+        "id": NEW_TAB_ID,
+        "workspace_id": WORKSPACE_ID,
+        "name": "Added",
+        "visibility": "visible",
+        "lifecycle": "active",
+        "view_mode": "display",
+        "display_filter": ["new", "in_use"],
+        "display_order": [],
+        "kanban_order": {"new": [], "in_use": [], "archived": []},
+        "extensions": {},
+    }
+    assert schema.validate_v2(update.document)  # nosec B101
+
+
+def test_tile_reorder_changes_only_display_order_and_preserves_kanban_order() -> None:
+    document = _native_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    edited = replace(projection, tiles=tuple(reversed(projection.tiles)))
+    expected_display_order = [cast(str, tile.placement_id) for tile in edited.tiles]
+    expected = deepcopy(document)
+    _tab(expected, MAIN_TAB_ID)["display_order"] = expected_display_order
+    original_kanban = deepcopy(_tab(document, MAIN_TAB_ID)["kanban_order"])
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, edited))
+
+    assert document == original  # nosec B101
+    assert update.document == expected  # nosec B101
+    assert _tab(update.document, MAIN_TAB_ID)["kanban_order"] == original_kanban  # nosec B101
+    assert [  # nosec B101
+        identity.placement_id for identity in update.tile_identities
+    ] == expected_display_order
+
+
+def test_existing_tile_edit_updates_only_owned_fields_and_keeps_identity() -> None:
+    document = _native_document()
+    projection = _projected(document)
+    source = projection.tiles[0]
+    placement_id, resource_id, portable_binding_id = _identity_tuple(source)
+    placement = next(
+        item for item in document["placements"] if item["id"] == placement_id
+    )
+    resource = next(item for item in document["resources"] if item["id"] == resource_id)
+    portable_binding = next(
+        item
+        for item in document["device_bindings"]
+        if item["id"] == portable_binding_id
+    )
+    placement["extensions"] = {"placement.example.test": {"kept": True}}
+    resource["extensions"] = {"resource.example.test": ["kept"]}
+    portable_binding["extensions"] = {"portable.example.test": "kept"}
+    device_binding = schema.PlacementLaunchBinding(
+        id=SOURCE_DEVICE_BINDING_ID,
+        subject_kind="placement",
+        subject_id=placement_id,
+        binding_kind="launch",
+        applicability=schema.DeviceSpecific(
+            kind="device_specific",
+            device_key="device-A",
+        ),
+        settings=schema.UrlLaunchSettings(
+            browser="Device Browser",
+            chrome_profile="Device Profile",
+            open_target="tab",
+        ),
+        extensions={"device.example.test": {"kept": True}},
+    )
+    document["device_bindings"].append(device_binding)
+    assert schema.validate_v2(document)  # nosec B101
+    original = deepcopy(document)
+    projection = _projected(document)
+    edited_tile = replace(
+        projection.tiles[0],
+        name="Edited label",
+        url="https://edited.example.test/path",
+        icon="edited-icon",
+        background_color="#010203",
+        browser="Edited Browser",
+        chrome_profile="Edited Profile",
+        open_target="window",
+    )
+    edited = replace(projection, tiles=(edited_tile, *projection.tiles[1:]))
+    expected = deepcopy(document)
+    expected_placement = next(
+        item for item in expected["placements"] if item["id"] == placement_id
+    )
+    expected_resource = next(
+        item for item in expected["resources"] if item["id"] == resource_id
+    )
+    expected_binding = next(
+        item
+        for item in expected["device_bindings"]
+        if item["id"] == portable_binding_id
+    )
+    expected_placement["background_color"] = "#010203"
+    expected_resource["target"]["url"] = "https://edited.example.test/path"
+    expected_resource["default_label"] = "Edited label"
+    expected_resource["default_icon"] = schema.LegacyStringIcon(
+        kind="legacy_string",
+        value="edited-icon",
+    )
+    expected_binding["settings"] = schema.UrlLaunchSettings(
+        browser="Edited Browser",
+        chrome_profile="Edited Profile",
+        open_target="window",
+    )
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, edited))
+
+    assert document == original  # nosec B101
+    assert update.document == expected  # nosec B101
+    assert update.tile_identities[0] == runtime_state.FlatTileIdentity(  # nosec B101
+        placement_id,
+        resource_id,
+        portable_binding_id,
+    )
+    assert schema.validate_v2(update.document)  # nosec B101
+
+
+def test_add_and_duplicate_style_tiles_allocate_uuid4_and_join_in_use_order() -> None:
+    document = _native_document()
+    source_order = list(_tab(document, MAIN_TAB_ID)["display_order"])
+    _tab(document, MAIN_TAB_ID)["kanban_order"]["in_use"] = [
+        source_order[2],
+        source_order[0],
+        source_order[1],
+    ]
+    source_placement_id = source_order[0]
+    source_portable = next(
+        binding
+        for binding in document["device_bindings"]
+        if binding["subject_kind"] == "placement"
+        and binding["subject_id"] == source_placement_id
+        and binding["applicability"]["kind"] == "portable_fallback"
+    )
+    source_portable["extensions"] = {"portable.example.test": {"kept": True}}
+    document["device_bindings"].append(
+        schema.PlacementLaunchBinding(
+            id=SOURCE_DEVICE_BINDING_ID,
+            subject_kind="placement",
+            subject_id=source_placement_id,
+            binding_kind="launch",
+            applicability=schema.DeviceSpecific(
+                kind="device_specific",
+                device_key="device-A",
+            ),
+            settings=schema.UrlLaunchSettings(
+                browser="Device Browser",
+                chrome_profile="Device Profile",
+                open_target="window",
+            ),
+            extensions={"device.example.test": ["kept"]},
+        )
+    )
+    assert schema.validate_v2(document)  # nosec B101
+    original = deepcopy(document)
+    projection = _projected(document)
+    source = projection.tiles[0]
+    added = runtime_state.FlatTileState(
+        placement_id=None,
+        resource_id=None,
+        launch_binding_id=None,
+        name="Added",
+        url="https://added.example.test/path",
+        tab_id=MAIN_TAB_ID,
+        icon="added-icon",
+        background_color="#123456",
+        browser="Browser",
+        chrome_profile="Profile",
+        open_target="window",
+    )
+    duplicated = replace(
+        source,
+        placement_id=None,
+        resource_id=None,
+        launch_binding_id=None,
+        duplicate_source_placement_id=source.placement_id,
+    )
+    edited = replace(
+        projection,
+        tiles=(projection.tiles[0], duplicated, *projection.tiles[1:], added),
+    )
+    identifiers = iter(NEW_ENTITY_IDS)
+    old_display = list(_tab(document, MAIN_TAB_ID)["display_order"])
+    old_in_use = list(_tab(document, MAIN_TAB_ID)["kanban_order"]["in_use"])
+
+    update = _updated(
+        runtime_state.synchronize_flat_workspace(
+            document,
+            edited,
+            id_factory=lambda: next(identifiers),
+        )
+    )
+    candidate = update.document
+    duplicated_identity = update.tile_identities[1]
+    added_identity = update.tile_identities[-1]
+    duplicated_bindings = [
+        binding
+        for binding in candidate["device_bindings"]
+        if binding["subject_kind"] == "placement"
+        and binding["subject_id"] == duplicated_identity.placement_id
+    ]
+
+    assert document == original  # nosec B101
+    assert (
+        duplicated_identity.resource_id,
+        duplicated_identity.placement_id,
+        duplicated_identity.launch_binding_id,
+        duplicated_bindings[1]["id"],
+        added_identity.resource_id,
+        added_identity.placement_id,
+        added_identity.launch_binding_id,
+    ) == NEW_ENTITY_IDS  # nosec B101
+    assert all(UUID(identifier).version == 4 for identifier in NEW_ENTITY_IDS)  # nosec B101
+    placements = {item["id"]: item for item in candidate["placements"]}
+    resources = {item["id"]: item for item in candidate["resources"]}
+    bindings = {item["id"]: item for item in candidate["device_bindings"]}
+    assert placements[added_identity.placement_id]["workflow_status"] == "in_use"  # nosec B101
+    assert placements[added_identity.placement_id]["tab_id"] == MAIN_TAB_ID  # nosec B101
+    assert resources[added_identity.resource_id]["default_label"] == "Added"  # nosec B101
+    assert bindings[added_identity.launch_binding_id]["subject_id"] == (  # nosec B101
+        added_identity.placement_id
+    )
+    source_bindings = [
+        binding
+        for binding in document["device_bindings"]
+        if binding["subject_kind"] == "placement"
+        and binding["subject_id"] == source_placement_id
+    ]
+    assert len(source_bindings) == len(duplicated_bindings) == 2  # nosec B101
+    for source_binding, copied_binding in zip(
+        source_bindings,
+        duplicated_bindings,
+        strict=True,
+    ):
+        assert copied_binding["id"] != source_binding["id"]  # nosec B101
+        assert copied_binding["subject_id"] == duplicated_identity.placement_id  # nosec B101
+        assert {  # nosec B101
+            key: value
+            for key, value in copied_binding.items()
+            if key not in {"id", "subject_id"}
+        } == {
+            key: value
+            for key, value in source_binding.items()
+            if key not in {"id", "subject_id"}
+        }
+    assert resources[duplicated_identity.resource_id]["default_label"] == source.name  # nosec B101
+    tab = _tab(candidate, MAIN_TAB_ID)
+    assert (
+        tab["display_order"]
+        == [  # nosec B101
+            old_display[0],
+            duplicated_identity.placement_id,
+            *old_display[1:],
+            added_identity.placement_id,
+        ]
+    )
+    assert (
+        tab["kanban_order"]
+        == {  # nosec B101
+            "new": [],
+            "in_use": [
+                old_in_use[0],
+                old_in_use[1],
+                duplicated_identity.placement_id,
+                *old_in_use[2:],
+                added_identity.placement_id,
+            ],
+            "archived": [],
+        }
+    )
+    assert schema.validate_v2(candidate)  # nosec B101
+
+
+def test_new_tiles_reject_noncontractual_display_positions_without_mutation() -> None:
+    document = _native_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    source = projection.tiles[0]
+    added = runtime_state.FlatTileState(
+        placement_id=None,
+        resource_id=None,
+        launch_binding_id=None,
+        name="Added",
+        url="https://added.example.test/path",
+        tab_id=MAIN_TAB_ID,
+        icon=None,
+        background_color="#123456",
+        browser=None,
+        chrome_profile=None,
+        open_target="tab",
+    )
+    duplicated = replace(
+        source,
+        placement_id=None,
+        resource_id=None,
+        launch_binding_id=None,
+        duplicate_source_placement_id=source.placement_id,
+    )
+    malformed_states = (
+        replace(projection, tiles=(added, *projection.tiles)),
+        replace(projection, tiles=(*projection.tiles, duplicated)),
+    )
+
+    for state in malformed_states:
+        result = runtime_state.synchronize_flat_workspace(document, state)
+
+        assert result == runtime_state.FlatStateRejected("invalid_state")  # nosec B101
+        assert document == original  # nosec B101
+
+
+def test_unhashable_flat_state_fields_are_rejected_without_mutation() -> None:
+    document = _native_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    malformed_states = (
+        replace(
+            projection,
+            tabs=(
+                replace(projection.tabs[0], id=cast(str, [])),
+                *projection.tabs[1:],
+            ),
+        ),
+        replace(
+            projection,
+            tiles=(
+                replace(projection.tiles[0], tab_id=cast(str, [])),
+                *projection.tiles[1:],
+            ),
+        ),
+        replace(
+            projection,
+            tiles=(
+                replace(
+                    projection.tiles[0],
+                    placement_id=cast(str | None, {}),
+                ),
+                *projection.tiles[1:],
+            ),
+        ),
+    )
+
+    for state in malformed_states:
+        result = runtime_state.synchronize_flat_workspace(document, state)
+
+        assert result == runtime_state.FlatStateRejected("invalid_state")  # nosec B101
+        assert document == original  # nosec B101
+
+
+def test_move_remove_and_tab_delete_are_coordinated_and_keep_orphan_resource() -> None:
+    document = _two_tab_document()
+    projection = _projected(document)
+    moved_first, removed, moved_last = projection.tiles
+    removed_placement_id, removed_resource_id, removed_binding_id = _identity_tuple(
+        removed
+    )
+    removed_resource = deepcopy(
+        next(
+            item for item in document["resources"] if item["id"] == removed_resource_id
+        )
+    )
+    removed_resource["extensions"]["orphan.example.test"] = "retained"
+    source_resource = next(
+        item for item in document["resources"] if item["id"] == removed_resource_id
+    )
+    source_resource["extensions"] = deepcopy(removed_resource["extensions"])
+    original = deepcopy(document)
+    remaining_tab = replace(projection.tabs[1], hidden=False)
+    moved_tiles = (
+        replace(moved_first, tab_id=SECOND_TAB_ID),
+        replace(moved_last, tab_id=SECOND_TAB_ID),
+    )
+    edited = replace(
+        projection,
+        tabs=(remaining_tab,),
+        tab_order=(SECOND_TAB_ID,),
+        tiles=moved_tiles,
+    )
+
+    update = _updated(runtime_state.synchronize_flat_workspace(document, edited))
+    candidate = update.document
+
+    assert document == original  # nosec B101
+    assert all(item["id"] != MAIN_TAB_ID for item in candidate["tabs"])  # nosec B101
+    assert _workspace(candidate)["tab_order"] == [SECOND_TAB_ID]  # nosec B101
+    assert all(  # nosec B101
+        item["id"] != removed_placement_id for item in candidate["placements"]
+    )
+    assert all(  # nosec B101
+        item["id"] != removed_binding_id for item in candidate["device_bindings"]
+    )
+    assert (
+        next(  # nosec B101
+            item for item in candidate["resources"] if item["id"] == removed_resource_id
+        )
+        == removed_resource
+    )
+    retained_placement_ids = [cast(str, tile.placement_id) for tile in moved_tiles]
+    for placement_id in retained_placement_ids:
+        placement = next(
+            item for item in candidate["placements"] if item["id"] == placement_id
+        )
+        assert placement["tab_id"] == SECOND_TAB_ID  # nosec B101
+    remaining = _tab(candidate, SECOND_TAB_ID)
+    assert remaining["display_order"] == retained_placement_ids  # nosec B101
+    assert remaining["kanban_order"] == {  # nosec B101
+        "new": [],
+        "in_use": retained_placement_ids,
+        "archived": [],
+    }
+    assert schema.validate_v2(candidate)  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "duplicate_placement",
+        "stale_placement",
+        "swapped_resource",
+        "swapped_binding",
+        "partial_new_identity",
+    ],
+)
+def test_existing_tile_identity_mismatch_is_rejected_without_mutation(
+    mode: str,
+) -> None:
+    document = _native_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    tiles = list(projection.tiles)
+    first, second = tiles[:2]
+
+    if mode == "duplicate_placement":
+        tiles.append(first)
+    elif mode == "stale_placement":
+        tiles[0] = replace(first, placement_id=NEW_TAB_ID)
+    elif mode == "swapped_resource":
+        tiles[0] = replace(first, resource_id=second.resource_id)
+    elif mode == "swapped_binding":
+        tiles[0] = replace(first, launch_binding_id=second.launch_binding_id)
+    else:
+        tiles[0] = replace(first, placement_id=None)
+
+    result = runtime_state.synchronize_flat_workspace(
+        document,
+        replace(projection, tiles=tuple(tiles)),
+    )
+
+    assert result == runtime_state.FlatStateRejected("invalid_state")  # nosec B101
+    assert document == original  # nosec B101
+
+
+@pytest.mark.parametrize("mode", ["invalid", "collision"])
+def test_new_tile_allocator_rejects_invalid_or_colliding_values_without_mutation(
+    mode: str,
+) -> None:
+    document = _native_document()
+    original = deepcopy(document)
+    projection = _projected(document)
+    new_tile = replace(
+        projection.tiles[0],
+        placement_id=None,
+        resource_id=None,
+        launch_binding_id=None,
+    )
+    edited = replace(projection, tiles=(*projection.tiles, new_tile))
+    collision = WORKSPACE_ID
+    calls = 0
+
+    def allocate() -> str:
+        nonlocal calls
+        calls += 1
+        return "not-a-uuid" if mode == "invalid" else collision
+
+    result = runtime_state.synchronize_flat_workspace(
+        document,
+        edited,
+        id_factory=allocate,
+    )
+
+    assert result == runtime_state.FlatStateRejected(  # nosec B101
+        "identity_allocation_failure"
+    )
+    assert calls == 32  # nosec B101
+    assert document == original  # nosec B101
+
+
+@pytest.mark.parametrize("mode", ["invalid", "collision"])
+def test_native_builder_rejects_invalid_or_colliding_allocator_values(
+    mode: str,
+) -> None:
+    values = ["not-a-uuid"] * 32 if mode == "invalid" else [WORKSPACE_ID] * 33
+    identifiers = iter(values)
+
+    with pytest.raises(runtime_state.NativeV2ConstructionError) as exc_info:
+        runtime_state.build_native_v2(lambda: next(identifiers))
+
+    assert exc_info.value.category == "identity_allocation_failure"  # nosec B101
+    assert str(exc_info.value) == "identity_allocation_failure"  # nosec B101
+
+
+def test_rich_shared_override_filter_and_status_graph_is_read_only() -> None:
+    document = _representative_document()
+    original = deepcopy(document)
+
+    projection = _projected(document)
+
+    assert not projection.editable  # nosec B101
+    assert [tile.name for tile in projection.tiles] == ["", "Shared"]  # nosec B101
+    assert projection.tiles[0].icon == ""  # nosec B101
+    assert projection.tiles[0].resource_id == projection.tiles[1].resource_id  # nosec B101
+    result = runtime_state.synchronize_flat_workspace(document, projection)
+    assert result == runtime_state.FlatStateRejected("unsupported_graph")  # nosec B101
+    assert document == original  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "shared_resource",
+        "label_override",
+        "icon_override",
+        "workflow_status",
+        "kanban_view",
+        "display_filter",
+        "missing_portable_binding",
+        "missing_portable_window_binding",
+    ],
+)
+def test_each_unrepresentable_flat_graph_feature_is_independently_read_only(
+    reason: str,
+) -> None:
+    document = _native_document()
+    tab = _tab(document, MAIN_TAB_ID)
+    placement_id = tab["display_order"][0]
+    placement = next(
+        item for item in document["placements"] if item["id"] == placement_id
+    )
+
+    if reason == "shared_resource":
+        document["placements"][1]["resource_id"] = placement["resource_id"]
+    elif reason == "label_override":
+        placement["label_override"] = "Override"
+    elif reason == "icon_override":
+        placement["icon_override"] = schema.LegacyStringIcon(
+            kind="legacy_string",
+            value="override-icon",
+        )
+    elif reason == "workflow_status":
+        placement["workflow_status"] = "new"
+        tab["kanban_order"]["in_use"].remove(placement_id)
+        tab["kanban_order"]["new"].append(placement_id)
+    elif reason == "kanban_view":
+        tab["view_mode"] = "kanban"
+    elif reason == "display_filter":
+        tab["display_filter"] = ["in_use"]
+    elif reason == "missing_portable_binding":
+        document["device_bindings"] = [
+            binding
+            for binding in document["device_bindings"]
+            if not (
+                binding["subject_kind"] == "placement"
+                and binding["subject_id"] == placement_id
+                and binding["applicability"]["kind"] == "portable_fallback"
+            )
+        ]
+    else:
+        document["device_bindings"] = [
+            binding
+            for binding in document["device_bindings"]
+            if not (
+                binding["subject_kind"] == "workspace"
+                and binding["subject_id"] == WORKSPACE_ID
+                and binding["applicability"]["kind"] == "portable_fallback"
+            )
+        ]
+
+    assert schema.validate_v2(document)  # nosec B101
+    original = deepcopy(document)
+    projection = _projected(document)
+
+    assert not projection.editable  # nosec B101
+    assert runtime_state.synchronize_flat_workspace(document, projection) == (  # nosec B101
+        runtime_state.FlatStateRejected("unsupported_graph")
+    )
+    assert document == original  # nosec B101

--- a/tests/unit/test_config_schema_v2_boundary.py
+++ b/tests/unit/test_config_schema_v2_boundary.py
@@ -25,15 +25,17 @@ RUNTIME_V2_PATH = REPO_ROOT / "config_runtime_v2.py"
 PERSISTENCE_PATH = REPO_ROOT / "config_persistence.py"
 PACKAGING_SPEC_PATH = REPO_ROOT / "DesktopTileLauncher.spec"
 PRODUCTION_ENTRY_PATH = REPO_ROOT / "tile_launcher.py"
-FORBIDDEN_V2_MODULES = frozenset(
+ACTIVATED_V2_MODULES = frozenset(
     {
         "config_migration_v2.py",
+        "config_runtime_state_v2.py",
         "config_runtime_v2.py",
         "config_schema_v2.py",
         "config_serialization_v2.py",
-        "config_transform_v1_to_v2.py",
     }
 )
+DORMANT_V2_MODULES = frozenset({"config_transform_v1_to_v2.py"})
+ALL_V2_MODULES = ACTIVATED_V2_MODULES | DORMANT_V2_MODULES
 QT_IMPORT_ROOTS = frozenset({"PyQt5", "PyQt6", "PySide2", "PySide6"})
 
 SCHEMA_PUBLIC_FUNCTIONS = frozenset({"reject_duplicate_json_members", "validate_v2"})
@@ -106,7 +108,9 @@ TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES = frozenset({"V1ToV2TransformResult"})
 TRANSFORM_V1_TO_V2_PUBLIC_NAMES = (
     TRANSFORM_V1_TO_V2_PUBLIC_FUNCTIONS | TRANSFORM_V1_TO_V2_PUBLIC_TYPE_ALIASES
 )
-RUNTIME_V2_PUBLIC_FUNCTIONS = frozenset({"apply_metadata_refresh", "project_workspace"})
+RUNTIME_V2_PUBLIC_FUNCTIONS = frozenset(
+    {"apply_metadata_refresh", "clone_document", "project_workspace"}
+)
 RUNTIME_V2_PUBLIC_DATACLASSES = frozenset(
     {
         "LaunchSettingsProjection",
@@ -119,6 +123,7 @@ RUNTIME_V2_PUBLIC_DATACLASSES = frozenset(
 )
 RUNTIME_V2_PUBLIC_TYPE_ALIASES = frozenset(
     {
+        "CloneResult",
         "MetadataRefreshResult",
         "RuntimeAdapterFailureCategory",
         "WorkspaceProjectionResult",
@@ -615,7 +620,9 @@ def test_standard_decoder_callback_rejects_duplicates_at_every_nesting_depth(
         assert forbidden not in rendered  # nosec B101
 
 
-def test_valid_fixture_decodes_through_dormant_callback_then_validates() -> None:
+def test_valid_fixture_decodes_through_duplicate_aware_callback_then_validates() -> (
+    None
+):
     parsed = json.loads(
         (FIXTURE_ROOT / "representative.json").read_text(encoding="utf-8"),
         object_pairs_hook=schema.reject_duplicate_json_members,
@@ -835,7 +842,9 @@ def test_exact_imports_and_focused_json_ast_contracts() -> None:
     ] == ["Exception"]
 
 
-def test_vocabulary_dependency_is_symbol_only_one_way_and_qt_free() -> None:
+def test_production_migration_dependency_activates_v2_transform_and_stays_qt_free() -> (
+    None
+):
     migration_path = REPO_ROOT / "config_migration.py"
     dependency_closure = _repository_local_import_closure(
         REPO_ROOT,
@@ -848,10 +857,13 @@ def test_vocabulary_dependency_is_symbol_only_one_way_and_qt_free() -> None:
         Path("config_persistence.py"),
         Path("config_recovery.py"),
         Path("config_schema.py"),
+        Path("config_migration_v2.py"),
+        Path("config_schema_v2.py"),
     }.issubset(relative)
-    assert not {path.name for path in relative}.intersection(  # nosec B101
-        FORBIDDEN_V2_MODULES
-    )
+    assert {path.name for path in relative}.intersection(ALL_V2_MODULES) == {  # nosec B101
+        "config_migration_v2.py",
+        "config_schema_v2.py",
+    }
     for path in dependency_closure:
         import_roots = {
             name.split(".", maxsplit=1)[0] for name in _raw_import_names(path)
@@ -921,7 +933,7 @@ def test_runtime_adapter_dependency_closure_is_qt_free_and_detached() -> None:
         assert import_roots.isdisjoint(QT_IMPORT_ROOTS), path  # nosec B101
 
 
-def test_persistence_dependency_closure_excludes_dormant_v2() -> None:
+def test_low_level_persistence_dependency_closure_remains_schema_agnostic() -> None:
     dependency_closure = _repository_local_import_closure(
         REPO_ROOT,
         {PERSISTENCE_PATH},
@@ -930,11 +942,11 @@ def test_persistence_dependency_closure_excludes_dormant_v2() -> None:
 
     assert Path("config_persistence.py") in relative  # nosec B101
     assert not {path.name for path in relative}.intersection(  # nosec B101
-        FORBIDDEN_V2_MODULES
+        ALL_V2_MODULES
     )
 
 
-def test_real_production_and_packaging_closure_excludes_v2() -> None:
+def test_real_production_and_packaging_closure_contains_exact_activated_v2() -> None:
     closure = _production_and_packaging_closure(
         REPO_ROOT,
         PRODUCTION_ENTRY_PATH,
@@ -944,9 +956,11 @@ def test_real_production_and_packaging_closure_excludes_v2() -> None:
 
     assert Path("url_import.py") in relative  # nosec B101
     assert Path("config_migration.py") in relative  # nosec B101
-    assert not {path.name for path in relative}.intersection(  # nosec B101
-        FORBIDDEN_V2_MODULES
+    relative_names = {path.name for path in relative}
+    assert relative_names.intersection(ALL_V2_MODULES) == (  # nosec B101
+        ACTIVATED_V2_MODULES
     )
+    assert relative_names.isdisjoint(DORMANT_V2_MODULES)  # nosec B101
 
 
 def test_transitive_entry_import_of_v2_is_detected(tmp_path: Path) -> None:
@@ -1100,26 +1114,40 @@ def test_packaging_declarations_fail_closed_when_nonliteral(
         )
 
 
-def test_production_registry_remains_exactly_v0_to_v1_and_rejects_v2() -> None:
+def test_production_registry_is_exactly_v0_to_v2_and_rejects_v3() -> None:
     spec = config_migration.PRODUCTION_REGISTRY_SPEC
     assert spec.oldest_supported_version == 0  # nosec B101
-    assert spec.current_version == 1  # nosec B101
+    assert spec.current_version == 2  # nosec B101
     assert [(step.source_version, step.target_version) for step in spec.steps] == [  # nosec B101
-        (0, 1)
+        (0, 1),
+        (1, 2),
     ]
-    assert [validator.version for validator in spec.validators] == [0, 1]  # nosec B101
+    assert [validator.version for validator in spec.validators] == [  # nosec B101
+        0,
+        1,
+        2,
+    ]
 
     parsed = json.loads(
         (FIXTURE_ROOT / "minimal.json").read_text(encoding="utf-8"),
         object_pairs_hook=schema.reject_duplicate_json_members,
     )
-    result = config_migration.prepare_migration(
+    current = config_migration.prepare_migration(
         cast(config_migration.JsonObject, parsed),
         config_migration.PRODUCTION_REGISTRY,
     )
-
-    assert isinstance(result, config_migration.VersionRejected)  # nosec B101
-    assert (  # nosec B101
-        result.category is config_migration.VersionRejectionCategory.UNSUPPORTED_NEWER
+    future_document = cast(config_migration.JsonObject, dict(parsed))
+    future_document["schema_version"] = 3
+    future = config_migration.prepare_migration(
+        future_document,
+        config_migration.PRODUCTION_REGISTRY,
     )
-    assert result.version == 2  # nosec B101
+
+    assert isinstance(current, config_migration.VersionedCurrent)  # nosec B101
+    assert current.version == 2  # nosec B101
+    assert current.document == parsed  # nosec B101
+    assert isinstance(future, config_migration.VersionRejected)  # nosec B101
+    assert (  # nosec B101
+        future.category is config_migration.VersionRejectionCategory.UNSUPPORTED_NEWER
+    )
+    assert future.version == 3  # nosec B101

--- a/tests/unit/test_hidden_tabs.py
+++ b/tests/unit/test_hidden_tabs.py
@@ -8,8 +8,11 @@ import pytest
 pytest.importorskip("PySide6.QtWidgets")
 
 import config_migration
+import config_migration_v2
 import config_persistence
+import config_runtime_state_v2
 import config_schema
+import config_schema_v2
 import tile_launcher
 from tile_launcher import LauncherConfig, Main
 
@@ -99,7 +102,37 @@ def _runtime_config() -> LauncherConfig:
     ]
     document["extensions"] = copy.deepcopy(_ROOT_EXTENSION)
     assert config_schema.validate_v1(document)  # nosec B101
-    return LauncherConfig.from_v1_mapping(document)
+    v2_document = config_migration_v2.migrate_v1_to_v2(document)
+    assert v2_document is not None  # nosec B101
+    assert config_schema_v2.validate_v2(v2_document)  # nosec B101
+    config = LauncherConfig.from_v2_mapping(v2_document)
+    runtime_order = {
+        name: index
+        for index, name in enumerate(("Main A", "Work X", "Main B", "Archive Z"))
+    }
+    config.tiles.sort(key=lambda tile: runtime_order[tile.name])
+    return config
+
+
+def _project_v2(document: object) -> config_runtime_state_v2.FlatWorkspaceState:
+    assert config_schema_v2.validate_v2(document)  # nosec B101
+    projected = config_runtime_state_v2.project_flat_workspace(document)
+    assert isinstance(  # nosec B101
+        projected,
+        config_runtime_state_v2.FlatWorkspaceState,
+    )
+    return projected
+
+
+def _config_v2_document(config: LauncherConfig) -> dict[str, object]:
+    document = json.loads(config.serialize())
+    assert isinstance(document, dict)  # nosec B101
+    assert config_schema_v2.validate_v2(document)  # nosec B101
+    return document
+
+
+def _fail_v2_size(_update: object) -> bytes:
+    raise ValueError("schema_v2_size_limit_exceeded")
 
 
 class _TabBar:
@@ -224,16 +257,21 @@ def test_hidden_tabs_load_and_save(tmp_path, monkeypatch):
     assert cfg.hidden_tabs == ["Extra"]
     cfg.save()
     data = json.loads(cfg_path.read_text())
-    assert data["schema_version"] == 1
+    assert data["schema_version"] == 2
+    assert config_schema_v2.validate_v2(data)  # nosec B101
     assert "hidden_tabs" not in data
     tabs = {tab["name"]: tab for tab in data["tabs"]}
     assert tabs["Main"]["visibility"] == "visible"
     assert tabs["Extra"]["visibility"] == "hidden"
-    assert data["tiles"][0]["tab_id"] == tabs["Extra"]["id"]
+    projection = _project_v2(data)
+    assert projection.tiles[0].tab_id == tabs["Extra"]["id"]  # nosec B101
 
 
 @pytest.mark.unit
-def test_current_v1_load_is_no_write_and_save_preserves_identity(tmp_path, monkeypatch):
+def test_v1_migration_source_loads_as_v2_and_save_preserves_identity(
+    tmp_path,
+    monkeypatch,
+):
     cfg_path = tmp_path / "config.json"
     identifiers = iter(
         (
@@ -251,16 +289,19 @@ def test_current_v1_load_is_no_write_and_save_preserves_identity(tmp_path, monke
     original = json.dumps(
         document, ensure_ascii=False, separators=(", ", ": ")
     ).encode()
+    expected_v2 = config_migration_v2.migrate_v1_to_v2(document)
+    assert expected_v2 is not None  # nosec B101
     cfg_path.write_bytes(original)
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
 
-    def forbid_write(*_args, **_kwargs):
-        raise AssertionError("valid current v1 startup must not write")
-
-    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_write)
     cfg = LauncherConfig.load()
 
-    assert cfg_path.read_bytes() == original
+    migrated = json.loads(cfg_path.read_bytes())
+    assert migrated == expected_v2  # nosec B101
+    assert config_schema_v2.validate_v2(migrated)  # nosec B101
+    recovery_files = list((tmp_path / "recovery").glob("config-*.recovery"))
+    assert len(recovery_files) == 1  # nosec B101
+    assert recovery_files[0].read_bytes() == original  # nosec B101
     assert cfg.workspace_id == "11111111-1111-4111-8111-111111111111"
     assert cfg.workspace_name == "Custom Workspace"
     assert cfg.tab_ids == {"Main": "22222222-2222-4222-8222-222222222222"}
@@ -277,6 +318,8 @@ def test_current_v1_load_is_no_write_and_save_preserves_identity(tmp_path, monke
     cfg.save()
     assert len(writes) == 1
     saved = json.loads(writes[0][1])
+    assert config_schema_v2.validate_v2(saved)  # nosec B101
+    assert saved == _config_v2_document(cfg)  # nosec B101
     assert saved["application"]["default_workspace_id"] == cfg.workspace_id
     assert saved["workspaces"][0]["name"] == "Custom Workspace"
     assert saved["tabs"][0]["id"] == cfg.tab_ids["Main"]
@@ -284,7 +327,42 @@ def test_current_v1_load_is_no_write_and_save_preserves_identity(tmp_path, monke
 
 
 @pytest.mark.unit
-def test_missing_config_constructs_native_v1_and_restart_preserves_ids(
+def test_current_v2_load_is_no_write_and_preserves_identity(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    identifiers = iter((_WORKSPACE_ID, _MAIN_ID))
+    source = config_schema.build_native_v1(lambda: next(identifiers))
+    workspace = source["workspaces"][0]
+    assert isinstance(workspace, dict)  # nosec B101
+    workspace["name"] = "Current V2 Workspace"
+    document = config_migration_v2.migrate_v1_to_v2(source)
+    assert document is not None  # nosec B101
+    original = json.dumps(
+        document,
+        ensure_ascii=False,
+        separators=(", ", ": "),
+    ).encode()
+    cfg_path.write_bytes(original)
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+
+    def forbid_write(*_args, **_kwargs):
+        raise AssertionError("valid current v2 startup must not write")
+
+    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_write)
+    monkeypatch.setattr(tile_launcher, "atomic_create_bytes", forbid_write)
+    monkeypatch.setattr(config_migration, "atomic_write_bytes", forbid_write)
+
+    cfg = LauncherConfig.load()
+
+    assert cfg_path.read_bytes() == original  # nosec B101
+    assert cfg.workspace_id == _WORKSPACE_ID  # nosec B101
+    assert cfg.workspace_name == "Current V2 Workspace"  # nosec B101
+    assert cfg.tab_ids == {"Main": _MAIN_ID}  # nosec B101
+    assert _config_v2_document(cfg) == document  # nosec B101
+    assert list((tmp_path / "recovery").glob("config-*.recovery")) == []
+
+
+@pytest.mark.unit
+def test_missing_config_constructs_native_v2_and_restart_preserves_ids(
     tmp_path, monkeypatch
 ):
     cfg_path = tmp_path / "config.json"
@@ -294,7 +372,7 @@ def test_missing_config_constructs_native_v1_and_restart_preserves_ids(
     original = cfg_path.read_bytes()
     document = json.loads(original)
 
-    assert config_schema.validate_v1(document)
+    assert config_schema_v2.validate_v2(document)
     assert created.title == "My Launcher"
     assert created.workspace_name == "Default Workspace"
     assert created.tabs == ["Main"]
@@ -302,9 +380,10 @@ def test_missing_config_constructs_native_v1_and_restart_preserves_ids(
     created_ids = (created.workspace_id, dict(created.tab_ids))
 
     def forbid_write(*_args, **_kwargs):
-        raise AssertionError("valid current v1 restart must not write")
+        raise AssertionError("valid current v2 restart must not write")
 
     monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_write)
+    monkeypatch.setattr(tile_launcher, "atomic_create_bytes", forbid_write)
     monkeypatch.setattr(config_migration, "atomic_write_bytes", forbid_write)
     restarted = LauncherConfig.load()
 
@@ -313,7 +392,7 @@ def test_missing_config_constructs_native_v1_and_restart_preserves_ids(
 
 
 @pytest.mark.unit
-def test_q3_preserve_and_reset_installs_the_same_native_v1(tmp_path, monkeypatch):
+def test_q3_preserve_and_reset_installs_the_same_native_v2(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.json"
     original = b'{"malformed":'
     cfg_path.write_bytes(original)
@@ -328,8 +407,8 @@ def test_q3_preserve_and_reset_installs_the_same_native_v1(tmp_path, monkeypatch
 
     assert isinstance(startup, tile_launcher._StartupReady)
     document = json.loads(cfg_path.read_bytes())
-    assert config_schema.validate_v1(document)
-    assert startup.config.to_v1_mapping() == document
+    assert config_schema_v2.validate_v2(document)
+    assert _config_v2_document(startup.config) == document
     assert startup.config.title == "My Launcher"
     assert startup.config.workspace_name == "Default Workspace"
     recovery_files = list((tmp_path / "recovery").glob("config-*.recovery"))
@@ -346,7 +425,7 @@ def test_q3_preserve_and_reset_installs_the_same_native_v1(tmp_path, monkeypatch
         ("persistence", "persistence_failure"),
     ),
 )
-def test_missing_native_v1_failure_exits_safely_without_residue(
+def test_missing_native_v2_failure_exits_safely_without_residue(
     tmp_path,
     monkeypatch,
     failure_mode,
@@ -359,21 +438,21 @@ def test_missing_native_v1_failure_exits_safely_without_residue(
     if failure_mode == "construction":
 
         def fail_build(_allocator):
-            raise config_schema.NativeV1ConstructionError
+            raise tile_launcher.NativeV2ConstructionError("identity_allocation_failure")
 
-        monkeypatch.setattr(tile_launcher, "build_native_v1", fail_build)
+        monkeypatch.setattr(tile_launcher, "build_native_v2", fail_build)
     elif failure_mode == "validation":
         monkeypatch.setattr(
             tile_launcher,
-            "build_native_v1",
-            lambda _allocator: {"schema_version": 1},
+            "build_native_v2",
+            lambda _allocator: {"schema_version": 2},
         )
     else:
 
         def fail_write(_path, _payload):
             raise OSError(sensitive)
 
-        monkeypatch.setattr(tile_launcher, "atomic_write_bytes", fail_write)
+        monkeypatch.setattr(tile_launcher, "atomic_create_bytes", fail_write)
 
     breadcrumbs = []
     shown_errors = []
@@ -440,9 +519,9 @@ def test_q3_native_reset_candidate_failure_is_controlled_and_non_mutating(
     if failure_mode == "construction":
 
         def fail_build(_allocator):
-            raise config_schema.NativeV1ConstructionError
+            raise tile_launcher.NativeV2ConstructionError("identity_allocation_failure")
 
-        monkeypatch.setattr(tile_launcher, "build_native_v1", fail_build)
+        monkeypatch.setattr(tile_launcher, "build_native_v2", fail_build)
     else:
 
         def fail_serialization(_config):
@@ -492,7 +571,7 @@ def test_q3_native_reset_candidate_failure_is_controlled_and_non_mutating(
 
 
 @pytest.mark.unit
-def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v1(
+def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v2(
     tmp_path,
     monkeypatch,
 ):
@@ -507,7 +586,7 @@ def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v1(
 
     def capture_write(path, payload):
         document = json.loads(payload)
-        assert config_schema.validate_v1(document)  # nosec B101
+        assert config_schema_v2.validate_v2(document)  # nosec B101
         writes.append(document)
         real_atomic_write(path, payload)
 
@@ -515,10 +594,11 @@ def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v1(
 
     def assert_committed(expected_write_count):
         assert len(writes) == expected_write_count  # nosec B101
-        runtime_document = harness.cfg.to_v1_mapping()
+        runtime_document = _config_v2_document(harness.cfg)
         persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
-        assert config_schema.validate_v1(runtime_document)  # nosec B101
+        assert config_schema_v2.validate_v2(runtime_document)  # nosec B101
         assert persisted == runtime_document == writes[-1]  # nosec B101
+        projected = _project_v2(persisted)
         application = persisted["application"]
         workspace = persisted["workspaces"][0]
         assert application["title"] == "Independent Application Title"  # nosec B101
@@ -527,6 +607,12 @@ def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v1(
         assert workspace["id"] == _WORKSPACE_ID  # nosec B101
         assert workspace["name"] == "Custom Workspace"  # nosec B101
         assert workspace["tab_order"] == harness.cfg.tab_order  # nosec B101
+        assert list(projected.tab_order) == harness.cfg.tab_order  # nosec B101
+        assert [tab.name for tab in projected.tabs] == harness.cfg.tabs  # nosec B101
+        for tab_id in projected.tab_order:
+            assert [  # nosec B101
+                tile.name for tile in projected.tiles if tile.tab_id == tab_id
+            ] == [tile.name for tile in harness.cfg.tiles if tile.tab_id == tab_id]
         assert harness.cfg.tab_order == [  # nosec B101
             harness.cfg.tab_ids[name] for name in harness.cfg.tabs
         ]
@@ -674,7 +760,7 @@ def test_runtime_tab_and_tile_actions_preserve_identity_and_strict_v1(
 
 
 @pytest.mark.unit
-def test_auto_fit_toggle_persists_one_complete_strict_v1_document(
+def test_auto_fit_toggle_persists_one_complete_strict_v2_document(
     tmp_path,
     monkeypatch,
 ):
@@ -682,7 +768,7 @@ def test_auto_fit_toggle_persists_one_complete_strict_v1_document(
     cfg = _runtime_config()
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
     cfg.save()
-    baseline = copy.deepcopy(cfg.to_v1_mapping())
+    baseline = copy.deepcopy(_config_v2_document(cfg))
     harness = _RuntimeHarness(cfg, current_tab="Work")
     harness._computed_columns = 23
     harness.auto_fit_action.checked = False
@@ -692,7 +778,7 @@ def test_auto_fit_toggle_persists_one_complete_strict_v1_document(
 
     def capture_write(path, payload):
         document = json.loads(payload)
-        assert config_schema.validate_v1(document)  # nosec B101
+        assert config_schema_v2.validate_v2(document)  # nosec B101
         writes.append(document)
         real_atomic_write(path, payload)
 
@@ -707,11 +793,19 @@ def test_auto_fit_toggle_persists_one_complete_strict_v1_document(
     )
     assert len(writes) == 1  # nosec B101
     persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
-    assert persisted == writes[0] == harness.cfg.to_v1_mapping()  # nosec B101
-    assert config_schema.validate_v1(persisted)  # nosec B101
+    assert persisted == writes[0] == _config_v2_document(harness.cfg)  # nosec B101
+    assert config_schema_v2.validate_v2(persisted)  # nosec B101
     expected = copy.deepcopy(baseline)
-    expected["auto_fit"] = False
+    expected_window_binding = next(
+        binding
+        for binding in expected["device_bindings"]
+        if binding["subject_kind"] == "workspace"
+        and binding["subject_id"] == _WORKSPACE_ID
+        and binding["applicability"]["kind"] == "portable_fallback"
+    )
+    expected_window_binding["settings"]["auto_fit"] = False
     assert persisted == expected  # nosec B101
+    assert _project_v2(persisted).auto_fit is False  # nosec B101
     assert harness.cfg.auto_fit is False  # nosec B101
     assert harness._computed_columns == harness.cfg.columns  # nosec B101
     assert harness.auto_fit_action.checked is False  # nosec B101
@@ -733,7 +827,7 @@ def test_auto_fit_size_failure_rolls_back_live_and_action_state(
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
     cfg.save()
     baseline_bytes = cfg_path.read_bytes()
-    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    baseline_mapping = copy.deepcopy(_config_v2_document(cfg))
     harness = _RuntimeHarness(cfg, current_tab="Work")
     harness._computed_columns = 23
     harness.auto_fit_action.checked = False
@@ -750,21 +844,29 @@ def test_auto_fit_size_failure_rolls_back_live_and_action_state(
         "critical",
         lambda parent, title, text: messages.append((parent, title, text)),
     )
-    monkeypatch.setattr(tile_launcher, "MAX_CONFIG_BYTES", len(baseline_bytes))
 
     def forbid_atomic_write(*_args, **_kwargs):
         raise AssertionError("the oversized document must be rejected before writing")
 
-    monkeypatch.setattr(tile_launcher, "atomic_write_bytes", forbid_atomic_write)
-
-    Main._toggle_auto_fit(harness, False)
+    with monkeypatch.context() as size_limit_patch:
+        size_limit_patch.setattr(
+            LauncherConfig,
+            "_payload_for_update",
+            staticmethod(_fail_v2_size),
+        )
+        size_limit_patch.setattr(
+            tile_launcher,
+            "atomic_write_bytes",
+            forbid_atomic_write,
+        )
+        Main._toggle_auto_fit(harness, False)
 
     assert harness.cfg is cfg  # nosec B101
     assert all(  # nosec B101
         current is original
         for current, original in zip(harness.cfg.tiles, live_tiles, strict=True)
     )
-    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert _config_v2_document(harness.cfg) == baseline_mapping  # nosec B101
     assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
     assert harness.cfg.auto_fit is True  # nosec B101
     assert harness._computed_columns == 23  # nosec B101
@@ -804,7 +906,7 @@ def test_auto_fit_size_failure_rolls_back_live_and_action_state(
 
 
 @pytest.mark.unit
-def test_add_tile_with_strict_v1_preserves_identity_and_extension_state(
+def test_add_tile_with_strict_v2_preserves_identity_and_extension_state(
     tmp_path,
     monkeypatch,
 ):
@@ -812,7 +914,7 @@ def test_add_tile_with_strict_v1_preserves_identity_and_extension_state(
     cfg = _runtime_config()
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
     cfg.save()
-    baseline = copy.deepcopy(cfg.to_v1_mapping())
+    baseline = copy.deepcopy(_config_v2_document(cfg))
     baseline_tab_ids = dict(cfg.tab_ids)
     baseline_tab_order = list(cfg.tab_order)
     live_tiles = tuple(cfg.tiles)
@@ -835,7 +937,7 @@ def test_add_tile_with_strict_v1_preserves_identity_and_extension_state(
 
     def capture_write(path, payload):
         document = json.loads(payload)
-        assert config_schema.validate_v1(document)  # nosec B101
+        assert config_schema_v2.validate_v2(document)  # nosec B101
         writes.append(document)
         real_atomic_write(path, payload)
 
@@ -872,13 +974,22 @@ def test_add_tile_with_strict_v1_preserves_identity_and_extension_state(
     ]
     assert len(writes) == 1  # nosec B101
     persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
-    assert persisted == writes[0] == cfg.to_v1_mapping()  # nosec B101
-    assert config_schema.validate_v1(persisted)  # nosec B101
-    assert {key: value for key, value in persisted.items() if key != "tiles"} == {
-        key: value for key, value in baseline.items() if key != "tiles"
-    }  # nosec B101
-    assert persisted["tiles"][:-1] == baseline["tiles"]  # nosec B101
-    assert persisted["tiles"][-1]["tab_id"] == _WORK_ID  # nosec B101
+    assert persisted == writes[0] == _config_v2_document(cfg)  # nosec B101
+    assert config_schema_v2.validate_v2(persisted)  # nosec B101
+    assert persisted["application"] == baseline["application"]  # nosec B101
+    assert persisted["workspaces"] == baseline["workspaces"]  # nosec B101
+    assert persisted["extensions"] == baseline["extensions"]  # nosec B101
+    assert persisted["resources"][:-1] == baseline["resources"]  # nosec B101
+    assert persisted["placements"][:-1] == baseline["placements"]  # nosec B101
+    assert persisted["device_bindings"][:-1] == baseline["device_bindings"]
+    projected = _project_v2(persisted)
+    assert [tile.name for tile in projected.tiles if tile.tab_id == _WORK_ID] == [
+        "Work X",
+        "Work Y",
+    ]  # nosec B101
+    assert cfg.tiles[-1].placement_id is not None  # nosec B101
+    assert cfg.tiles[-1].resource_id is not None  # nosec B101
+    assert cfg.tiles[-1].launch_binding_id is not None  # nosec B101
     assert harness.current_tab() == "Work"  # nosec B101
     assert harness.selected_tabs == ["Work"]  # nosec B101
     assert harness.rebuild_count == 1  # nosec B101
@@ -887,7 +998,7 @@ def test_add_tile_with_strict_v1_preserves_identity_and_extension_state(
 
 
 @pytest.mark.unit
-def test_add_tile_persistence_failure_restores_strict_v1_live_identity(
+def test_add_tile_persistence_failure_restores_strict_v2_live_identity(
     tmp_path,
     monkeypatch,
 ):
@@ -896,7 +1007,7 @@ def test_add_tile_persistence_failure_restores_strict_v1_live_identity(
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
     cfg.save()
     baseline_bytes = cfg_path.read_bytes()
-    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    baseline_mapping = copy.deepcopy(_config_v2_document(cfg))
     live_tiles = tuple(cfg.tiles)
     harness = _RuntimeHarness(cfg, current_tab="Work")
     sensitive_name = "Private work tile"
@@ -921,7 +1032,7 @@ def test_add_tile_persistence_failure_restores_strict_v1_live_identity(
 
     def capture_candidate(path, payload):
         document = json.loads(payload)
-        assert config_schema.validate_v1(document)  # nosec B101
+        assert config_schema_v2.validate_v2(document)  # nosec B101
         attempted_documents.append(document)
         real_atomic_write(path, payload)
 
@@ -944,14 +1055,18 @@ def test_add_tile_persistence_failure_restores_strict_v1_live_identity(
     Main.add_tile(harness)
 
     assert len(attempted_documents) == 1  # nosec B101
-    assert attempted_documents[0]["tiles"][-1]["tab_id"] == _WORK_ID  # nosec B101
+    attempted = _project_v2(attempted_documents[0])
+    attempted_tile = next(
+        tile for tile in attempted.tiles if tile.name == sensitive_name
+    )
+    assert attempted_tile.tab_id == _WORK_ID  # nosec B101
     assert harness.cfg is cfg  # nosec B101
     assert len(harness.cfg.tiles) == len(live_tiles)  # nosec B101
     assert all(  # nosec B101
         current is original
         for current, original in zip(harness.cfg.tiles, live_tiles, strict=True)
     )
-    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert _config_v2_document(harness.cfg) == baseline_mapping  # nosec B101
     assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
     assert harness.current_tab() == "Work"  # nosec B101
     assert harness.selected_tabs == ["Work"]  # nosec B101
@@ -997,7 +1112,7 @@ def test_close_geometry_save_failures_restore_state_and_leave_no_residue(
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
     cfg.save()
     baseline_bytes = cfg_path.read_bytes()
-    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    baseline_mapping = copy.deepcopy(_config_v2_document(cfg))
     live_tiles = tuple(cfg.tiles)
     breadcrumbs = []
     monkeypatch.setattr(
@@ -1008,9 +1123,9 @@ def test_close_geometry_save_failures_restore_state_and_leave_no_residue(
 
     with monkeypatch.context() as size_limit_patch:
         size_limit_patch.setattr(
-            tile_launcher,
-            "MAX_CONFIG_BYTES",
-            len(baseline_bytes),
+            LauncherConfig,
+            "_payload_for_update",
+            staticmethod(_fail_v2_size),
         )
         saved = tile_launcher._persist_close_geometry(
             cfg,
@@ -1021,7 +1136,7 @@ def test_close_geometry_save_failures_restore_state_and_leave_no_residue(
         )
 
     assert saved is False  # nosec B101
-    assert cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert _config_v2_document(cfg) == baseline_mapping  # nosec B101
     assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
     assert tuple(cfg.tiles) == live_tiles  # nosec B101
     assert all(  # nosec B101
@@ -1045,7 +1160,7 @@ def test_close_geometry_save_failures_restore_state_and_leave_no_residue(
         )
 
     assert saved is False  # nosec B101
-    assert cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert _config_v2_document(cfg) == baseline_mapping  # nosec B101
     assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
     assert all(  # nosec B101
         current is original
@@ -1085,7 +1200,7 @@ def test_runtime_size_and_validation_failures_roll_back_live_identity_graph(
     monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
     cfg.save()
     baseline_bytes = cfg_path.read_bytes()
-    baseline_mapping = copy.deepcopy(cfg.to_v1_mapping())
+    baseline_mapping = copy.deepcopy(_config_v2_document(cfg))
     harness = _RuntimeHarness(cfg)
     live_config = harness.cfg
     live_main_tile = harness.cfg.tiles[0]
@@ -1102,12 +1217,17 @@ def test_runtime_size_and_validation_failures_roll_back_live_identity_graph(
         lambda parent, title, text: messages.append((parent, title, text)),
     )
 
-    monkeypatch.setattr(tile_launcher, "MAX_CONFIG_BYTES", len(baseline_bytes))
-    Main.duplicate_tile(harness, harness.cfg.tiles[0])
+    with monkeypatch.context() as size_limit_patch:
+        size_limit_patch.setattr(
+            LauncherConfig,
+            "_payload_for_update",
+            staticmethod(_fail_v2_size),
+        )
+        Main.duplicate_tile(harness, harness.cfg.tiles[0])
 
     assert harness.cfg is live_config  # nosec B101
     assert harness.cfg.tiles[0] is live_main_tile  # nosec B101
-    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert _config_v2_document(harness.cfg) == baseline_mapping  # nosec B101
     assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
     assert breadcrumbs[-1] == (  # nosec B101
         "config_change_save_failed",
@@ -1129,7 +1249,7 @@ def test_runtime_size_and_validation_failures_roll_back_live_identity_graph(
     )
 
     def reject_save(_config):
-        raise ValueError("invalid_schema_v1_runtime_state")
+        raise ValueError("invalid_schema_v2_runtime_state")
 
     monkeypatch.setattr(LauncherConfig, "save", reject_save)
     Main.rename_tab(harness)
@@ -1138,7 +1258,7 @@ def test_runtime_size_and_validation_failures_roll_back_live_identity_graph(
     assert any(tile is live_work_tile for tile in harness.cfg.tiles)  # nosec B101
     assert live_work_tile.tab == "Work"  # nosec B101
     assert live_work_tile.tab_id == _WORK_ID  # nosec B101
-    assert harness.cfg.to_v1_mapping() == baseline_mapping  # nosec B101
+    assert _config_v2_document(harness.cfg) == baseline_mapping  # nosec B101
     assert cfg_path.read_bytes() == baseline_bytes  # nosec B101
     assert breadcrumbs[-1] == (  # nosec B101
         "config_change_save_failed",
@@ -1157,11 +1277,11 @@ def test_runtime_utf8_encoding_failure_is_fixed_and_context_free(
     monkeypatch,
 ) -> None:
     cfg = _runtime_config()
-    monkeypatch.setattr(LauncherConfig, "serialize", lambda _config: "\ud800")
+    cfg.title = "\ud800"
 
     with pytest.raises(ValueError) as exc_info:
         cfg._serialized_payload()
 
-    assert exc_info.value.args == ("invalid_schema_v1_runtime_state",)  # nosec B101
+    assert exc_info.value.args == ("invalid_schema_v2_runtime_state",)  # nosec B101
     assert exc_info.value.__cause__ is None  # nosec B101
     assert exc_info.value.__context__ is None  # nosec B101

--- a/tests/unit/test_tab_order.py
+++ b/tests/unit/test_tab_order.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 import pytest
 
 from tab_order import (
+    TabIdentityAllocationError,
     TabOrderState,
     add_tab,
     delete_tab,
@@ -22,6 +23,7 @@ D_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 H_ID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
 OBSOLETE_ID = "11111111-1111-4111-8111-111111111111"
 UNKNOWN_ID = "22222222-2222-4222-8222-222222222222"
+V5_ID = "ffffffff-ffff-5fff-8fff-ffffffffffff"
 
 
 def _id_factory(values: list[str]) -> Callable[[], str]:
@@ -143,6 +145,41 @@ def test_add_appends_unique_identifier_after_factory_collision() -> None:
     assert added.tabs == ["A", "B"]
     assert added.tab_ids == {"A": A_ID, "B": B_ID}
     assert added.tab_order == [A_ID, B_ID]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("candidate", ["not-a-uuid", A_ID, V5_ID])
+def test_add_bounds_invalid_colliding_or_non_uuid4_allocation(candidate: str) -> None:
+    state = TabOrderState(["A"], {"A": A_ID}, [A_ID])
+    calls = 0
+
+    def allocate() -> str:
+        nonlocal calls
+        calls += 1
+        return candidate
+
+    with pytest.raises(TabIdentityAllocationError) as exc_info:
+        add_tab(state, "B", allocate)
+
+    assert calls == 32  # nosec B101
+    assert exc_info.value.args == ("identity_allocation_failure",)  # nosec B101
+    assert exc_info.value.__cause__ is None  # nosec B101
+    assert exc_info.value.__context__ is None  # nosec B101
+
+
+@pytest.mark.unit
+def test_add_rejects_factory_exception_without_leaking_context() -> None:
+    state = TabOrderState(["A"], {"A": A_ID}, [A_ID])
+
+    def fail() -> str:
+        raise RuntimeError("sensitive allocator detail")
+
+    with pytest.raises(TabIdentityAllocationError) as exc_info:
+        add_tab(state, "B", fail)
+
+    assert exc_info.value.args == ("identity_allocation_failure",)  # nosec B101
+    assert exc_info.value.__cause__ is None  # nosec B101
+    assert exc_info.value.__context__ is None  # nosec B101
 
 
 @pytest.mark.unit

--- a/tests/unit/test_unit_collection_boundary.py
+++ b/tests/unit/test_unit_collection_boundary.py
@@ -230,6 +230,12 @@ def test_nested_parameter_mark_does_not_mark_the_whole_test(tmp_path: Path) -> N
 
 def test_unit_target_collects_only_the_guarded_tests_tree() -> None:
     makefile_lines = MAKEFILE_PATH.read_text(encoding="utf-8").splitlines()
+    target_declaration = next(
+        line
+        for line in makefile_lines
+        if not line.startswith((" ", "\t")) and line.partition(":")[0] == "test_unit"
+    )
+    prerequisites = target_declaration.partition(":")[2].partition("##")[0].split()
     phony_targets = {
         target
         for line in makefile_lines
@@ -246,9 +252,19 @@ def test_unit_target_collects_only_the_guarded_tests_tree() -> None:
     )
 
     assert "test_unit" in phony_targets  # nosec B101
+    assert not prerequisites  # nosec B101
     assert pytest_invocations == (  # nosec B101
         "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PY) -m pytest -q tests \\",
     )
+
+
+def test_make_online_probe_is_lazy() -> None:
+    makefile_lines = MAKEFILE_PATH.read_text(encoding="utf-8").splitlines()
+    online_assignment = next(
+        line for line in makefile_lines if line.startswith("ONLINE ")
+    )
+
+    assert online_assignment.startswith("ONLINE = ")  # nosec B101
 
 
 def test_unit_collection_ignores_external_test_modules() -> None:

--- a/tests/unit/test_url_import_integration.py
+++ b/tests/unit/test_url_import_integration.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 import copy
+import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
+
+import config_schema_v2
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 pytest.importorskip("PySide6.QtWidgets")
@@ -206,6 +210,62 @@ def test_import_saves_detached_candidate_once_then_commits_in_source_order(
         assert tile.open_target == "tab"
 
 
+def test_import_persists_real_v2_candidate_and_commits_new_identities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg_path = tmp_path / "config.json"
+    original = _config()
+    monkeypatch.setattr(tile_launcher, "CFG_PATH", cfg_path)
+    original.save()
+    assert original._v2_document is not None  # nosec B101
+    baseline = copy.deepcopy(original._v2_document)
+    harness = _MainHarness(original, current_tab="Work")
+    dialog = _Dialog(
+        destination="Work",
+        selections=(
+            _Selection(8, "Second", "https://second.example.test/"),
+            _Selection(3, "First", "https://first.example.test/"),
+        ),
+    )
+    _install_dialog(monkeypatch, dialog)
+
+    Main.import_urls(harness)
+
+    candidate = harness.cfg
+    document = candidate._v2_document
+    assert candidate is not original  # nosec B101
+    assert original._v2_document == baseline  # nosec B101
+    assert document is not None  # nosec B101
+    assert config_schema_v2.validate_v2(document)  # nosec B101
+    persisted = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert persisted == document  # nosec B101
+    assert document["extensions"] == baseline["extensions"]  # nosec B101
+    assert (
+        document["application"]["extensions"]
+        == (  # nosec B101
+            baseline["application"]["extensions"]
+        )
+    )
+    imported = candidate.tiles[-2:]
+    assert [tile.name for tile in imported] == ["First", "Second"]  # nosec B101
+    assert all(  # nosec B101
+        tile.placement_id is not None
+        and tile.resource_id is not None
+        and tile.launch_binding_id is not None
+        for tile in imported
+    )
+    destination_id = candidate.tab_ids["Work"]
+    destination = next(tab for tab in document["tabs"] if tab["id"] == destination_id)
+    imported_placement_ids = [tile.placement_id for tile in imported]
+    assert destination["display_order"][-2:] == imported_placement_ids  # nosec B101
+    assert destination["kanban_order"]["in_use"][-2:] == (  # nosec B101
+        imported_placement_ids
+    )
+    assert harness.rebuild_count == 1  # nosec B101
+    assert harness.selected_tabs == ["Work"]  # nosec B101
+
+
 def test_import_into_hidden_tab_never_unhides_or_selects_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -262,8 +322,8 @@ def test_refresh_detached_candidate_preserves_identity_and_extension_state() -> 
     ("failure", "expected_category"),
     (
         (OSError(_SENSITIVE_PATH), "persistence_failure"),
-        (ValueError("invalid_schema_v1_runtime_state"), "validation_failure"),
-        (ValueError("schema_v1_size_limit_exceeded"), "size_limit_exceeded"),
+        (ValueError("invalid_schema_v2_runtime_state"), "validation_failure"),
+        (ValueError("schema_v2_size_limit_exceeded"), "size_limit_exceeded"),
     ),
 )
 def test_save_failure_keeps_live_config_and_review_state_without_rebuild(
@@ -326,7 +386,7 @@ def test_save_failure_keeps_live_config_and_review_state_without_rebuild(
     ]
 
 
-def test_actual_over_limit_import_keeps_live_review_and_file_exact(
+def test_v2_size_limit_import_keeps_live_review_and_file_exact(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -353,7 +413,15 @@ def test_actual_over_limit_import_keeps_live_review_and_file_exact(
         "critical",
         lambda parent, title, text: errors.append((parent, title, text)),
     )
-    monkeypatch.setattr(tile_launcher, "MAX_CONFIG_BYTES", len(baseline_bytes))
+
+    def reject_oversized_v2(_update: object) -> bytes:
+        raise ValueError("schema_v2_size_limit_exceeded")
+
+    monkeypatch.setattr(
+        LauncherConfig,
+        "_payload_for_update",
+        staticmethod(reject_oversized_v2),
+    )
 
     Main.import_urls(harness)
 

--- a/tests/unit_collection_guard.py
+++ b/tests/unit_collection_guard.py
@@ -36,6 +36,7 @@ QT_FREE_UNIT_TEST_PATHS = frozenset(
         "tests/unit/test_config_migration_v2.py",
         "tests/unit/test_config_persistence.py",
         "tests/unit/test_config_recovery.py",
+        "tests/unit/test_config_runtime_state_v2.py",
         "tests/unit/test_config_runtime_v2.py",
         "tests/unit/test_config_schema.py",
         "tests/unit/test_config_schema_v2.py",

--- a/tile_launcher.py
+++ b/tile_launcher.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import math
 import os
@@ -91,9 +90,22 @@ from config_migration import (
     startup_failure_route,
     startup_notice_message,
 )
-from config_persistence import atomic_write_bytes
+from config_persistence import atomic_create_bytes, atomic_write_bytes
+from config_runtime_state_v2 import (
+    FlatStateRejected,
+    FlatTabState,
+    FlatTileIdentity,
+    FlatTileState,
+    FlatWorkspaceState,
+    FlatWorkspaceUpdate,
+    NativeV2ConstructionError,
+    build_native_v2,
+    project_flat_workspace,
+    reserved_entity_ids,
+    synchronize_flat_workspace,
+)
+from config_runtime_v2 import clone_document
 from config_recovery import (
-    MAX_CONFIG_BYTES,
     ConfigLoadFailureCategory,
     ConfigMissing,
     ConfigRecoveryRequired,
@@ -111,11 +123,12 @@ from config_schema import (
     DEFAULT_WORKSPACE_NAME,
     JsonObject,
     JsonValue,
-    NativeV1ConstructionError,
     Uuid4Allocator,
-    build_native_v1,
     validate_v1,
 )
+from config_migration_v2 import migrate_v1_to_v2
+from config_schema_v2 import Root as V2Root
+from config_serialization_v2 import SerializedV2Document, serialize_v2
 from debug_scaffold import (
     record_breadcrumb,
     sanitize_launch_command,
@@ -139,6 +152,7 @@ from tile_metadata_refresh import (
 from tile_editor_dialog import TileEditorDialog
 from url_import_dialog import ImportDestination, UrlImportDialog
 from tab_order import (
+    TabIdentityAllocationError,
     TabOrderState,
     add_tab as add_tab_to_order,
     delete_tab as delete_tab_from_order,
@@ -322,6 +336,10 @@ class Tile:
     chrome_profile: Optional[str] = None  # e.g. "Default", "Profile 1"
     open_target: Literal["tab", "window"] = "tab"
     tab_id: str | None = None
+    placement_id: str | None = None
+    resource_id: str | None = None
+    launch_binding_id: str | None = None
+    duplicate_source_placement_id: str | None = None
 
 
 NativeConfigurationFailureCategory: TypeAlias = Literal[
@@ -372,9 +390,21 @@ def _runtime_save_failure_category(
 ) -> RuntimeSaveFailureCategory:
     if isinstance(error, OSError):
         return "persistence_failure"
-    if error.args == ("schema_v1_size_limit_exceeded",):
+    if error.args == ("schema_v2_size_limit_exceeded",):
         return "size_limit_exceeded"
     return "validation_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class _V2CommitPlan:
+    document: V2Root = field(repr=False)
+    tiles: tuple[Tile, ...] = field(repr=False)
+    tile_identities: tuple[FlatTileIdentity, ...] = field(repr=False)
+    editable: bool
+    application_extensions: JsonObject = field(repr=False)
+    workspace_extensions: JsonObject = field(repr=False)
+    tab_extensions: dict[str, JsonObject] = field(repr=False)
+    extensions: JsonObject = field(repr=False)
 
 
 @dataclass
@@ -397,6 +427,8 @@ class LauncherConfig:
     workspace_extensions: JsonObject = field(default_factory=dict)
     tab_extensions: dict[str, JsonObject] = field(default_factory=dict)
     extensions: JsonObject = field(default_factory=dict)
+    _v2_document: V2Root | None = field(default=None, repr=False, compare=False)
+    _v2_editable: bool = field(default=False, repr=False, compare=False)
     _identity_ready: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -405,7 +437,7 @@ class LauncherConfig:
 
     @classmethod
     def from_legacy_mapping(cls, data: dict[str, object]) -> "LauncherConfig":
-        """Construct the current unversioned model with its existing behavior."""
+        """Construct the legacy unversioned model with compatibility behavior."""
         legacy = cast(dict[str, Any], data)
         tiles = [Tile(**tile) for tile in legacy.get("tiles", [])]
         raw_tabs = legacy.get("tabs") or []
@@ -501,13 +533,76 @@ class LauncherConfig:
         )
 
     @classmethod
+    def from_v2_mapping(cls, data: Mapping[str, object]) -> "LauncherConfig":
+        """Project one complete v2 graph while retaining it as authority."""
+
+        cloned = clone_document(data)
+        if not isinstance(cloned, dict):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        projected = project_flat_workspace(cloned)
+        if isinstance(projected, FlatStateRejected):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        title_by_id = {tab.id: tab.name for tab in projected.tabs}
+        tabs = [title_by_id[tab_id] for tab_id in projected.tab_order]
+        tab_ids = {title_by_id[tab_id]: tab_id for tab_id in projected.tab_order}
+        hidden_tabs = [tab.name for tab in projected.tabs if tab.hidden]
+        tiles = [
+            Tile(
+                name=tile.name,
+                url=tile.url,
+                tab=title_by_id[tile.tab_id],
+                icon=tile.icon,
+                bg=tile.background_color,
+                browser=tile.browser,
+                chrome_profile=tile.chrome_profile,
+                open_target=tile.open_target,
+                tab_id=tile.tab_id,
+                placement_id=tile.placement_id,
+                resource_id=tile.resource_id,
+                launch_binding_id=tile.launch_binding_id,
+            )
+            for tile in projected.tiles
+        ]
+        root = cast(V2Root, cloned)
+        workspace = next(
+            item for item in root["workspaces"] if item["id"] == projected.workspace_id
+        )
+        tab_definitions = {item["id"]: item for item in root["tabs"]}
+        return cls(
+            title=projected.title,
+            columns=projected.columns,
+            tiles=tiles,
+            tabs=tabs,
+            hidden_tabs=hidden_tabs,
+            tab_ids=tab_ids,
+            tab_order=list(projected.tab_order),
+            auto_fit=projected.auto_fit,
+            window_x=projected.window_x,
+            window_y=projected.window_y,
+            window_w=projected.window_w,
+            window_h=projected.window_h,
+            workspace_id=projected.workspace_id,
+            workspace_name=projected.workspace_name,
+            application_extensions=cast(JsonObject, root["application"]["extensions"]),
+            workspace_extensions=cast(JsonObject, workspace["extensions"]),
+            tab_extensions={
+                tab_id: cast(JsonObject, tab_definitions[tab_id]["extensions"])
+                for tab_id in projected.tab_order
+            },
+            extensions=cast(JsonObject, root["extensions"]),
+            _v2_document=root,
+            _v2_editable=projected.editable,
+            _identity_ready=True,
+        )
+
+    @classmethod
     def first_run(
         cls,
         id_factory: Uuid4Allocator = uuid4,
     ) -> "LauncherConfig":
-        """Return one validated native-v1 friendly configuration."""
+        """Return one complete native-v2 configuration."""
 
-        return cls.from_v1_mapping(build_native_v1(id_factory))
+        return cls.from_v2_mapping(build_native_v2(id_factory))
 
     @staticmethod
     def load(
@@ -527,9 +622,9 @@ class LauncherConfig:
             failure_category: NativeConfigurationFailureCategory | None = None
             try:
                 cfg = LauncherConfig.first_run()
-                cfg.save()
-            except NativeV1ConstructionError:
-                failure_category = "identity_allocation_failure"
+                cfg._save_if_missing()
+            except NativeV2ConstructionError as error:
+                failure_category = error.category
             except ValueError:
                 failure_category = "validation_failure"
             except OSError:
@@ -549,29 +644,16 @@ class LauncherConfig:
                 on_existing_legacy(cfg, result.raw)
             return cfg
         if isinstance(result, (VersionedCurrent, MigrationCommitted)):
-            return LauncherConfig.from_v1_mapping(result.document)
+            return LauncherConfig.from_v2_mapping(result.document)
         if startup_failure_route(result) is StartupFailureRoute.EXIT_ONLY:
             raise ConfigurationMigrationError.from_outcome(result)
         raise ConfigurationMigrationError.unexpected_success()
 
     def serialize(self) -> str:
-        """Serialize one complete, strictly validated schema-version 1 document."""
+        """Serialize one complete, strictly validated schema-version 2 document."""
 
-        document = self.to_v1_mapping()
-        serialized: str | None = None
-        try:
-            serialized = json.dumps(
-                document,
-                ensure_ascii=False,
-                sort_keys=True,
-                indent=2,
-                allow_nan=False,
-            )
-        except (TypeError, ValueError, OverflowError, UnicodeError):
-            serialized = None
-        if serialized is None:
-            raise ValueError("invalid_schema_v1_runtime_state")
-        return serialized
+        update = self._prepare_v2_update()
+        return self._payload_for_update(update).decode("utf-8")
 
     def to_v1_mapping(self) -> JsonObject:
         """Return current state as v1 without repairing or regenerating identity."""
@@ -665,21 +747,173 @@ class LauncherConfig:
             raise ValueError("invalid_schema_v1_runtime_state")
         return document
 
+    def _flat_v2_state(self) -> FlatWorkspaceState:
+        title_by_id = {tab_id: title for title, tab_id in self.tab_ids.items()}
+        if set(title_by_id) != set(self.tab_order):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        return FlatWorkspaceState(
+            title=self.title,
+            workspace_id=self.workspace_id,
+            workspace_name=self.workspace_name,
+            tabs=tuple(
+                FlatTabState(
+                    tab_id,
+                    title_by_id[tab_id],
+                    title_by_id[tab_id] in self.hidden_tabs,
+                )
+                for tab_id in self.tab_order
+            ),
+            tab_order=tuple(self.tab_order),
+            tiles=tuple(
+                FlatTileState(
+                    placement_id=tile.placement_id,
+                    resource_id=tile.resource_id,
+                    launch_binding_id=tile.launch_binding_id,
+                    name=tile.name,
+                    url=tile.url,
+                    tab_id="" if tile.tab_id is None else tile.tab_id,
+                    icon=tile.icon,
+                    background_color=tile.bg,
+                    browser=tile.browser,
+                    chrome_profile=tile.chrome_profile,
+                    open_target=tile.open_target,
+                    duplicate_source_placement_id=(tile.duplicate_source_placement_id),
+                )
+                for tile in self.tiles
+            ),
+            columns=self.columns,
+            auto_fit=self.auto_fit,
+            window_x=self.window_x,
+            window_y=self.window_y,
+            window_w=self.window_w,
+            window_h=self.window_h,
+            editable=self._v2_editable,
+        )
+
+    def _initial_v2_update(self) -> FlatWorkspaceUpdate:
+        candidate = migrate_v1_to_v2(self.to_v1_mapping())
+        if candidate is None:
+            raise ValueError("invalid_schema_v2_runtime_state")
+        projected = project_flat_workspace(candidate)
+        if isinstance(projected, FlatStateRejected) or not projected.editable:
+            raise ValueError("invalid_schema_v2_runtime_state")
+        identities_by_tab: dict[str, list[FlatTileIdentity]] = {
+            tab_id: [] for tab_id in projected.tab_order
+        }
+        for tile in projected.tiles:
+            if (
+                tile.placement_id is None
+                or tile.resource_id is None
+                or tile.launch_binding_id is None
+            ):
+                raise ValueError("invalid_schema_v2_runtime_state")
+            identities_by_tab[tile.tab_id].append(
+                FlatTileIdentity(
+                    tile.placement_id,
+                    tile.resource_id,
+                    tile.launch_binding_id,
+                )
+            )
+        identities: list[FlatTileIdentity] = []
+        for tile in self.tiles:
+            if tile.tab_id is None or not identities_by_tab.get(tile.tab_id):
+                raise ValueError("invalid_schema_v2_runtime_state")
+            identities.append(identities_by_tab[tile.tab_id].pop(0))
+        if any(identities_by_tab.values()):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        return FlatWorkspaceUpdate(candidate, tuple(identities))
+
+    def _prepare_v2_update(self) -> FlatWorkspaceUpdate:
+        if self._v2_document is None:
+            return self._initial_v2_update()
+        result = synchronize_flat_workspace(
+            self._v2_document,
+            self._flat_v2_state(),
+        )
+        if isinstance(result, FlatStateRejected):
+            if result.category == "identity_allocation_failure":
+                raise ValueError("schema_v2_identity_allocation_failure")
+            if result.category == "unsupported_graph":
+                raise ValueError("unsupported_schema_v2_runtime_state")
+            raise ValueError("invalid_schema_v2_runtime_state")
+        return result
+
+    @staticmethod
+    def _payload_for_update(update: FlatWorkspaceUpdate) -> bytes:
+        result = serialize_v2(update.document)
+        if not isinstance(result, SerializedV2Document):
+            if result.category.value == "candidate_size_limit_exceeded":
+                raise ValueError("schema_v2_size_limit_exceeded")
+            raise ValueError("invalid_schema_v2_runtime_state")
+        return result.data
+
+    def _plan_v2_commit(self, update: FlatWorkspaceUpdate) -> _V2CommitPlan:
+        if len(update.tile_identities) != len(self.tiles):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        projected = project_flat_workspace(update.document)
+        if (
+            isinstance(projected, FlatStateRejected)
+            or projected.workspace_id != self.workspace_id
+            or projected.tab_order != tuple(self.tab_order)
+        ):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        workspace = next(
+            (
+                item
+                for item in update.document["workspaces"]
+                if item["id"] == self.workspace_id
+            ),
+            None,
+        )
+        tabs = {item["id"]: item for item in update.document["tabs"]}
+        if workspace is None or any(tab_id not in tabs for tab_id in self.tab_order):
+            raise ValueError("invalid_schema_v2_runtime_state")
+        return _V2CommitPlan(
+            document=update.document,
+            tiles=tuple(self.tiles),
+            tile_identities=update.tile_identities,
+            editable=projected.editable,
+            application_extensions=cast(
+                JsonObject,
+                update.document["application"]["extensions"],
+            ),
+            workspace_extensions=cast(JsonObject, workspace["extensions"]),
+            tab_extensions={
+                tab_id: cast(JsonObject, tabs[tab_id]["extensions"])
+                for tab_id in self.tab_order
+            },
+            extensions=cast(JsonObject, update.document["extensions"]),
+        )
+
+    def _commit_v2_update(self, plan: _V2CommitPlan) -> None:
+        for tile, identity in zip(plan.tiles, plan.tile_identities):
+            tile.placement_id = identity.placement_id
+            tile.resource_id = identity.resource_id
+            tile.launch_binding_id = identity.launch_binding_id
+            tile.duplicate_source_placement_id = None
+        self._v2_document = plan.document
+        self._v2_editable = plan.editable
+        self.application_extensions = plan.application_extensions
+        self.workspace_extensions = plan.workspace_extensions
+        self.tab_extensions = plan.tab_extensions
+        self.extensions = plan.extensions
+
     def save(self) -> None:
-        payload = self._serialized_payload()
+        update = self._prepare_v2_update()
+        plan = self._plan_v2_commit(update)
+        payload = self._payload_for_update(update)
         atomic_write_bytes(CFG_PATH, payload)
+        self._commit_v2_update(plan)
+
+    def _save_if_missing(self) -> None:
+        update = self._prepare_v2_update()
+        plan = self._plan_v2_commit(update)
+        payload = self._payload_for_update(update)
+        atomic_create_bytes(CFG_PATH, payload)
+        self._commit_v2_update(plan)
 
     def _serialized_payload(self) -> bytes:
-        payload: bytes | None = None
-        try:
-            payload = self.serialize().encode("utf-8")
-        except UnicodeError:
-            payload = None
-        if payload is None:
-            raise ValueError("invalid_schema_v1_runtime_state")
-        if len(payload) > MAX_CONFIG_BYTES:
-            raise ValueError("schema_v1_size_limit_exceeded")
-        return payload
+        return self._payload_for_update(self._prepare_v2_update())
 
 
 @dataclass(frozen=True, slots=True)
@@ -690,9 +924,38 @@ class _RuntimeChangeSnapshot:
 
 
 def _runtime_change_snapshot(config: LauncherConfig) -> _RuntimeChangeSnapshot:
+    saved_tiles = [replace(tile) for tile in config.tiles]
+    saved_document = _detached_v2_document(config._v2_document)
+    saved_state = replace(
+        config,
+        tiles=saved_tiles,
+        tabs=list(config.tabs),
+        hidden_tabs=list(config.hidden_tabs),
+        tab_ids=dict(config.tab_ids),
+        tab_order=list(config.tab_order),
+        tab_extensions=dict(config.tab_extensions),
+        _v2_document=saved_document,
+    )
+    if saved_document is not None:
+        workspace = next(
+            item
+            for item in saved_document["workspaces"]
+            if item["id"] == saved_state.workspace_id
+        )
+        tabs = {item["id"]: item for item in saved_document["tabs"]}
+        saved_state.application_extensions = cast(
+            JsonObject,
+            saved_document["application"]["extensions"],
+        )
+        saved_state.workspace_extensions = cast(JsonObject, workspace["extensions"])
+        saved_state.tab_extensions = {
+            tab_id: cast(JsonObject, tabs[tab_id]["extensions"])
+            for tab_id in saved_state.tab_order
+        }
+        saved_state.extensions = cast(JsonObject, saved_document["extensions"])
     return _RuntimeChangeSnapshot(
         live=config,
-        state=deepcopy(config),
+        state=saved_state,
         tiles=tuple(config.tiles),
     )
 
@@ -707,6 +970,10 @@ def _restore_tile(tile: Tile, saved: Tile) -> None:
     tile.chrome_profile = saved.chrome_profile
     tile.open_target = saved.open_target
     tile.tab_id = saved.tab_id
+    tile.placement_id = saved.placement_id
+    tile.resource_id = saved.resource_id
+    tile.launch_binding_id = saved.launch_binding_id
+    tile.duplicate_source_placement_id = saved.duplicate_source_placement_id
 
 
 def _restore_runtime_change(snapshot: _RuntimeChangeSnapshot) -> LauncherConfig:
@@ -736,6 +1003,8 @@ def _restore_runtime_change(snapshot: _RuntimeChangeSnapshot) -> LauncherConfig:
     live.workspace_extensions = state.workspace_extensions
     live.tab_extensions = state.tab_extensions
     live.extensions = state.extensions
+    live._v2_document = state._v2_document
+    live._v2_editable = state._v2_editable
     live._identity_ready = state._identity_ready
     return live
 
@@ -748,6 +1017,8 @@ def _persist_close_geometry(
     width: int,
     height: int,
 ) -> bool:
+    if config._v2_document is not None and not config._v2_editable:
+        return True
     previous_geometry = (
         config.window_x,
         config.window_y,
@@ -793,13 +1064,25 @@ def _guarded_existing_legacy_save(
     config: LauncherConfig,
     loaded: RawConfigLoaded,
 ) -> None:
+    update = config._prepare_v2_update()
+    plan = config._plan_v2_commit(update)
     result = guarded_legacy_normalization_save(
         CFG_PATH,
         loaded,
-        config.serialize(),
+        config._payload_for_update(update).decode("utf-8"),
     )
     if isinstance(result, LegacyNormalizationSaveFailed):
         raise ConfigurationMigrationError.from_outcome(result)
+    config._commit_v2_update(plan)
+
+
+def _detached_v2_document(document: V2Root | None) -> V2Root | None:
+    if document is None:
+        return None
+    cloned = clone_document(document)
+    if not isinstance(cloned, dict):
+        raise ValueError("invalid_schema_v2_runtime_state")
+    return cast(V2Root, cloned)
 
 
 def _tab_order_state(cfg: LauncherConfig) -> TabOrderState:
@@ -936,10 +1219,11 @@ def _config_with_imported_tiles(
         hidden_tabs=list(cfg.hidden_tabs),
         tab_ids=dict(cfg.tab_ids),
         tab_order=list(cfg.tab_order),
-        application_extensions=deepcopy(cfg.application_extensions),
-        workspace_extensions=deepcopy(cfg.workspace_extensions),
-        tab_extensions=deepcopy(cfg.tab_extensions),
-        extensions=deepcopy(cfg.extensions),
+        application_extensions=dict(cfg.application_extensions),
+        workspace_extensions=dict(cfg.workspace_extensions),
+        tab_extensions=dict(cfg.tab_extensions),
+        extensions=dict(cfg.extensions),
+        _v2_document=_detached_v2_document(cfg._v2_document),
     )
 
 
@@ -1790,6 +2074,9 @@ class Main(QMainWindow):
     def _selection_active(self) -> bool:
         return self._selection_tab_id is not None
 
+    def _mutations_enabled(self) -> bool:
+        return self.cfg._v2_document is None or self.cfg._v2_editable
+
     def _tab_id_at(self, index: int) -> str | None:
         if index < 0:
             return None
@@ -1811,7 +2098,11 @@ class Main(QMainWindow):
         )
 
     def enter_selection_mode(self) -> None:
-        if self._selection_active() or self._active_refresh is not None:
+        if (
+            not Main._mutations_enabled(self)
+            or self._selection_active()
+            or self._active_refresh is not None
+        ):
             return
         tab_name = self.current_tab()
         tab_id = self._tab_id_at(self.tabs_widget.currentIndex())
@@ -1929,6 +2220,7 @@ class Main(QMainWindow):
     def refresh_selected_metadata(self) -> None:
         if (
             self._closing
+            or not Main._mutations_enabled(self)
             or not self._selection_active()
             or self._active_refresh is not None
             or self._metadata_refresh_pool.activeThreadCount() > 0
@@ -2085,10 +2377,11 @@ class Main(QMainWindow):
                 hidden_tabs=list(self.cfg.hidden_tabs),
                 tab_ids=dict(self.cfg.tab_ids),
                 tab_order=list(self.cfg.tab_order),
-                application_extensions=deepcopy(self.cfg.application_extensions),
-                workspace_extensions=deepcopy(self.cfg.workspace_extensions),
-                tab_extensions=deepcopy(self.cfg.tab_extensions),
-                extensions=deepcopy(self.cfg.extensions),
+                application_extensions=dict(self.cfg.application_extensions),
+                workspace_extensions=dict(self.cfg.workspace_extensions),
+                tab_extensions=dict(self.cfg.tab_extensions),
+                extensions=dict(self.cfg.extensions),
+                _v2_document=_detached_v2_document(self.cfg._v2_document),
             ),
             tiles_by_identity,
         )
@@ -2309,6 +2602,7 @@ class Main(QMainWindow):
     def _update_selection_controls(self) -> None:
         selecting = self._selection_active()
         busy = self._active_refresh is not None
+        mutable = Main._mutations_enabled(self)
         selected_count = len(self._selected_tokens)
         total_count = len(self._selection_tiles)
 
@@ -2317,13 +2611,15 @@ class Main(QMainWindow):
         for action in self._selection_toolbar_actions:
             action.setVisible(selecting)
 
-        self.add_action.setEnabled(not selecting and not busy)
-        self.import_action.setEnabled(not selecting and not busy)
+        self.add_action.setEnabled(mutable and not selecting and not busy)
+        self.import_action.setEnabled(mutable and not selecting and not busy)
         active_tab_id = self.cfg.tab_ids[self.current_tab()]
         active_tab_has_tiles = any(
             tile.tab_id == active_tab_id for tile in self.cfg.tiles
         )
-        self.select_tiles_action.setEnabled(not busy and active_tab_has_tiles)
+        self.select_tiles_action.setEnabled(
+            mutable and not busy and active_tab_has_tiles
+        )
         self.selection_count_label.setText(
             f"Refreshing {selected_count}…" if busy else f"{selected_count} selected"
         )
@@ -2339,10 +2635,10 @@ class Main(QMainWindow):
         self.done_selection_action.setEnabled(selecting and not busy)
 
         for action in self._tab_mutation_actions:
-            action.setEnabled(not selecting and not busy)
+            action.setEnabled(mutable and not selecting and not busy)
         self._update_toggle_tab_action()
-        self.auto_fit_action.setEnabled(not selecting and not busy)
-        self.tabs_widget.tabBar().setMovable(not selecting and not busy)
+        self.auto_fit_action.setEnabled(mutable and not selecting and not busy)
+        self.tabs_widget.tabBar().setMovable(mutable and not selecting and not busy)
         self.tabs_widget.setEnabled(not busy)
 
     def _save_runtime_change(
@@ -2381,7 +2677,11 @@ class Main(QMainWindow):
         return False
 
     def _on_tab_moved(self, from_index: int, to_index: int) -> None:
-        if self._selection_active() or self._active_refresh is not None:
+        if (
+            not Main._mutations_enabled(self)
+            or self._selection_active()
+            or self._active_refresh is not None
+        ):
             return
         tab_bar = self.tabs_widget.tabBar()
         visible_ids_after = [tab_bar.tabData(index) for index in range(tab_bar.count())]
@@ -2431,11 +2731,15 @@ class Main(QMainWindow):
         )
         visible = self._visible_tabs()
         allow_hide = not hidden and len(visible) > 1
-        self.toggle_tab_action.setEnabled(hidden or allow_hide)
+        self.toggle_tab_action.setEnabled(
+            Main._mutations_enabled(self) and (hidden or allow_hide)
+        )
         if self._selection_active() or self._active_refresh is not None:
             self.toggle_tab_action.setEnabled(False)
 
     def _toggle_auto_fit(self, checked: bool) -> None:
+        if not Main._mutations_enabled(self):
+            return
         previous = _runtime_change_snapshot(self.cfg)
         restore_tab = self.current_tab()
         previous_auto_fit = self.cfg.auto_fit
@@ -3002,7 +3306,11 @@ class Main(QMainWindow):
             )
 
     def move_tile(self, tab: str, from_idx: int, to_idx: int) -> None:
-        if self._selection_active() or self._active_refresh is not None:
+        if (
+            not Main._mutations_enabled(self)
+            or self._selection_active()
+            or self._active_refresh is not None
+        ):
             return
         if from_idx == to_idx:
             return
@@ -3023,6 +3331,8 @@ class Main(QMainWindow):
         self._populate_tab(tab)
 
     def add_tile(self, default_tab: str | None = None) -> None:
+        if not Main._mutations_enabled(self):
+            return
         dlg = TileEditorDialog(
             tabs=self.cfg.tabs,
             browsers=available_browsers(),
@@ -3066,6 +3376,8 @@ class Main(QMainWindow):
             record_breadcrumb("tile_add")
 
     def import_urls(self, default_tab: str | None = None) -> None:
+        if not Main._mutations_enabled(self):
+            return
         previous_visible_tab = self.current_tab()
         destinations = tuple(
             ImportDestination(
@@ -3141,6 +3453,8 @@ class Main(QMainWindow):
             return
 
     def edit_tile(self, tile: Tile) -> None:
+        if not Main._mutations_enabled(self):
+            return
         dlg = TileEditorDialog(
             tabs=self.cfg.tabs,
             browsers=available_browsers(),
@@ -3172,9 +3486,17 @@ class Main(QMainWindow):
             self._set_current_tab_by_name(tile.tab)
 
     def duplicate_tile(self, tile: Tile) -> None:
+        if not Main._mutations_enabled(self):
+            return
         previous = _runtime_change_snapshot(self.cfg)
         restore_tab = self.current_tab()
-        new_tile = replace(tile)
+        new_tile = replace(
+            tile,
+            placement_id=None,
+            resource_id=None,
+            launch_binding_id=None,
+            duplicate_source_placement_id=tile.placement_id,
+        )
         idx = self.cfg.tiles.index(tile)
         self.cfg.tiles.insert(idx + 1, new_tile)
         if not Main._save_runtime_change(
@@ -3188,6 +3510,8 @@ class Main(QMainWindow):
         self._set_current_tab_by_name(tile.tab)
 
     def remove_tile(self, tile: Tile) -> None:
+        if not Main._mutations_enabled(self):
+            return
         ok = QMessageBox.warning(
             self,
             "Remove tile?",
@@ -3209,6 +3533,8 @@ class Main(QMainWindow):
             self.rebuild()
 
     def change_tile_tab(self, tile: Tile, new_tab: str) -> None:
+        if not Main._mutations_enabled(self):
+            return
         previous = _runtime_change_snapshot(self.cfg)
         restore_tab = self.current_tab()
         tile.tab = new_tab
@@ -3224,6 +3550,8 @@ class Main(QMainWindow):
         self._set_current_tab_by_name(new_tab)
 
     def add_tab(self) -> None:
+        if not Main._mutations_enabled(self):
+            return
         name, ok = QInputDialog.getText(self, "Add Tab", "Tab name:")
         if not ok or not name.strip():
             return
@@ -3235,11 +3563,30 @@ class Main(QMainWindow):
             return
         previous = _runtime_change_snapshot(self.cfg)
         restore_tab = self.current_tab()
-        state = add_tab_to_order(
-            _tab_order_state(self.cfg),
-            name,
-            blocked_ids=(self.cfg.workspace_id,),
-        )
+        try:
+            state = add_tab_to_order(
+                _tab_order_state(self.cfg),
+                name,
+                blocked_ids=(
+                    reserved_entity_ids(self.cfg._v2_document)
+                    if self.cfg._v2_document is not None
+                    else (self.cfg.workspace_id,)
+                ),
+            )
+        except TabIdentityAllocationError:
+            record_breadcrumb(
+                "config_change_save_failed",
+                failure_count=1,
+                failure_category="validation_failure",
+                operation="tab_add",
+            )
+            parent = self if isinstance(self, QWidget) else None
+            QMessageBox.critical(
+                parent,
+                "DesktopTileLauncher",
+                "The change could not be saved. No changes were applied.",
+            )
+            return
         _apply_tab_order_state(self.cfg, state)
         if not Main._save_runtime_change(
             self,
@@ -3252,6 +3599,8 @@ class Main(QMainWindow):
         self._set_current_tab_by_name(name)
 
     def rename_tab(self) -> None:
+        if not Main._mutations_enabled(self):
+            return
         current = self.current_tab()
         name, ok = QInputDialog.getText(self, "Rename Tab", "Tab name:", text=current)
         if not ok or not name.strip():
@@ -3284,6 +3633,8 @@ class Main(QMainWindow):
         self._set_current_tab_by_name(name)
 
     def delete_tab(self) -> None:
+        if not Main._mutations_enabled(self):
+            return
         current = self.current_tab()
         if len(self.cfg.tabs) == 1:
             QMessageBox.warning(self, "Not allowed", "At least one tab must exist.")
@@ -3315,6 +3666,8 @@ class Main(QMainWindow):
         self.rebuild()
 
     def toggle_current_tab_visibility(self) -> None:
+        if not Main._mutations_enabled(self):
+            return
         name = self.current_tab()
         hidden = name in self.cfg.hidden_tabs
         if not hidden and len(self._visible_tabs()) == 1:
@@ -3348,6 +3701,8 @@ class Main(QMainWindow):
         )
 
     def manage_tab_visibility(self) -> None:
+        if not Main._mutations_enabled(self):
+            return
         dlg = TabVisibilityDialog(self.cfg.tabs, self.cfg.hidden_tabs, self)
         while True:
             if dlg.exec() != QDialog.DialogCode.Accepted:


### PR DESCRIPTION
## Summary

- activate schema version 2 as the current production configuration format and register the transactional v1-to-v2 migration
- add a lossless flat-UI projection and synchronization layer that preserves the complete Resource, Placement, DeviceBinding, Workspace, and extension graph
- keep unsupported advanced graph states read-only instead of flattening or discarding them
- harden startup with duplicate-member JSON rejection and exclusive first-run publication
- update recovery, ordering, documentation, and regression coverage for the production cutover

## Why

The schema-v2 validator, transformer, serializer, and runtime adapters were already present but deliberately dormant. This final integration slice connects those accepted pieces to startup and persistence while preserving existing launcher behavior and the complete authoritative graph.

## User and developer impact

Existing legacy and schema-v1 configurations migrate transactionally to schema v2 with the established recovery safeguards. Current flat operations retain their familiar behavior, while advanced state that cannot be represented losslessly is shown read-only. New saves remain detached until persistence succeeds.

## Review hardening

The pre-publish review also:

- rejects malformed runtime state before hashing or identity lookup
- validates runtime `open_target` values without relying on narrowed static literal types
- enforces append placement for Add/Import and source-adjacent placement for Duplicate
- repairs the v2 size-limit Qt test seam
- adds a real-v2 URL-import transaction test for Qt-capable CI
- makes the required unit gate hermetic and locks its fail-closed boundary
- reconciles historical and active ADR language

## Validation

- `ruff format --check .`
- `ruff check .`
- `ruff check tests`
- `mypy .`
- `make test_unit` — 756 passed, 0 failed, 0 skipped, 0 errors; 20 non-allowlisted modules excluded before import

Automated Qt/GUI tests were not run by the constrained agent. A human Windows acceptance pass was completed against the current source with isolated profile directories.

## Manual Windows acceptance

Completed 2026-08-03 against the current source on Windows with isolated APPDATA and LOCALAPPDATA directories; the real user configuration was not touched.

- native schema-v2 first run produced the expected default Workspace, Tab, Tiles, and bindings
- valid v0 migrated transactionally through v1 to v2, preserving ordering, visibility, settings, extensions, deterministic identities, and one byte-identical recovery copy
- strict v1 migrated to v2 with all expected deterministic identities and one byte-identical recovery copy
- restarting current v2 caused no startup rewrite: hash, length, timestamp, and identities remained unchanged while the window was open
- Tab and Tile add, rename, reorder, hide/show, delete, edit, duplicate, move, remove, URL import, launch, auto-fit, geometry save, and restart persistence behaved as expected
- deleting a Tab removed only its owned Tab, Placement, and binding identities while retaining the copied Resource as a valid orphan
- metadata refresh completed safely with “Nothing found. No changes made.”
- malformed JSON default Exit left the source untouched; Preserve and Reset created one exact recovery copy, installed valid native v2, and left no temporary residue
- unsupported schema v3 was Exit-only, returned exit code 1, left the source untouched, and created no recovery artifact or temporary residue
- failure dialogs exposed no source JSON, private marker, filename, or raw exception details

Result: **PASS**.

Closes #129